### PR TITLE
build: use shared browserslist config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,5 @@ jobs:
       run: npm run build
     - name: i18n_extract
       run: npm run i18n_extract
-    - name: is-es5
-      run: npm run is-es5
     - name: Coverage
       uses: codecov/codecov-action@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "yup": "0.31.1"
       },
       "devDependencies": {
+        "@edx/browserslist-config": "1.0.2",
         "@edx/frontend-build": "9.1.4",
         "@testing-library/jest-dom": "5.16.2",
         "@testing-library/react": "12.1.4",
@@ -1976,6 +1977,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
       "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ=="
+    },
+    "node_modules/@edx/browserslist-config": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.0.2.tgz",
+      "integrity": "sha512-IJhyDEdxStxWyBQiQCz3CgnI/u2yjwGY9QKG/tAfrDUVvJB5yRiZsenDIa6I6zHjTmFOrm8SLYukC6qiyHaBWQ==",
+      "dev": true
     },
     "node_modules/@edx/eslint-config": {
       "version": "2.0.0",
@@ -28251,6 +28258,12 @@
       "version": "npm:@edx/brand-openedx@1.1.0",
       "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
       "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ=="
+    },
+    "@edx/browserslist-config": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.0.2.tgz",
+      "integrity": "sha512-IJhyDEdxStxWyBQiQCz3CgnI/u2yjwGY9QKG/tAfrDUVvJB5yRiZsenDIa6I6zHjTmFOrm8SLYukC6qiyHaBWQ==",
+      "dev": true
     },
     "@edx/eslint-config": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "yup": "0.31.1"
   },
   "devDependencies": {
+    "@edx/browserslist-config": "1.0.2",
     "@edx/frontend-build": "9.1.4",
     "@testing-library/jest-dom": "5.16.2",
     "@testing-library/react": "12.1.4",

--- a/package.json
+++ b/package.json
@@ -6,14 +6,10 @@
     "type": "git",
     "url": "git+https://github.com/edx/frontend-app-discussions.git"
   },
-  "browserslist": [
-    "last 2 versions",
-    "ie 11"
-  ],
+  "browserslist": ["extends @edx/browserslist-config"],
   "scripts": {
     "build": "fedx-scripts webpack",
     "i18n_extract": "BABEL_ENV=i18n fedx-scripts babel src --quiet > /dev/null",
-    "is-es5": "es-check es5 ./dist/*.js",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .",
     "lint:fix": "fedx-scripts eslint --ext .js --ext .jsx . --fix",
     "snapshot": "fedx-scripts jest --updateSnapshot",


### PR DESCRIPTION
* Removes custom `browserslist` configuration in favor of using a [shared configuration](https://github.com/edx/browserslist-config).
* Removes `is-es5` check in CI since ES5 was only needed for IE 11 support which is dropped. The supported browsers defined by the shared configuration all [natively support ES6](https://caniuse.com/?search=es6).

This change reduces the resultant asset bundle size.