### PR TITLE
fix: selecting different post does not clear comments list [BD-38] [TNL-9423] [BB-5183] 

### DIFF
--- a/src/discussions/comments/data/redux.test.js
+++ b/src/discussions/comments/data/redux.test.js
@@ -328,7 +328,7 @@ describe('Comments/Responses data layer tests', () => {
         results: allComments.slice(3, 6),
         pagination: { count: 6, numPages: 2 },
       });
-    await executeThunk(fetchThreadComments(threadId, { endorsed }), store.dispatch, store.getState);
+    await executeThunk(fetchThreadComments(threadId, { page: 2, endorsed }), store.dispatch, store.getState);
 
     expect(store.getState().comments.commentsInThreads[threadId][endorsed])
       .toEqual([

--- a/src/discussions/comments/data/slices.js
+++ b/src/discussions/comments/data/slices.js
@@ -28,20 +28,28 @@ const commentsSlice = createSlice({
       state.status = RequestStatus.IN_PROGRESS;
     },
     fetchCommentsSuccess: (state, { payload }) => {
-      const { threadId, endorsed } = payload;
+      const { threadId, page, endorsed } = payload;
       // force endorsed to be null, true or false
       state.status = RequestStatus.SUCCESSFUL;
       state.commentsInThreads[threadId] = state.commentsInThreads[threadId] || {};
       state.pagination[threadId] = state.pagination[threadId] || {};
-      state.commentsInThreads[threadId][endorsed] = [
-        // Newly posted comments will appear twice when fetching more pages.
-        // We use a Set here to remove duplicate entries, then spread it
-        // back into an array.
-        ...new Set([
-          ...(state.commentsInThreads[threadId][endorsed] || []),
-          ...(payload.commentsInThreads[threadId] || []),
-        ]),
-      ];
+
+      // Append to existing list of comments list
+      // only if the new fetch is due to pagination
+      if (page === 1) {
+        state.commentsInThreads[threadId][endorsed] = (payload.commentsInThreads[threadId] || []);
+      } else {
+        state.commentsInThreads[threadId][endorsed] = [
+          // Newly posted comments will appear twice when fetching more pages.
+          // We use a Set here to remove duplicate entries, then spread it
+          // back into an array.
+          ...new Set([
+            ...(state.commentsInThreads[threadId][endorsed] || []),
+            ...(payload.commentsInThreads[threadId] || []),
+          ]),
+        ];
+      }
+
       state.pagination[threadId][endorsed] = {
         currentPage: payload.page,
         totalPages: payload.pagination.numPages,


### PR DESCRIPTION
## Description

This pull request fixes an issue where selecting different posts in the MFE, would not clear the comments list of the prior posts.
Rather comments of the newly selected posts would get appended to the comments list and would be shown along with the comments of the earlier posts.


## Testing instructions

1. Select a post with atleast one comment.
2. Select a different post with atleast one comment.
3. Only the comments of the currently selected post should be displayed below the post

