### PR TITLE
fix: remove discussions from the base path [BD-38] [TNL-9347]

### DIFF
--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -140,7 +140,7 @@ export const TopicOrdering = {
   BY_COMMENT_COUNT: 'sortByCommentCount',
 };
 
-const BASE_PATH = '/discussions/:courseId';
+const BASE_PATH = '/:courseId';
 
 export const Routes = {
   DISCUSSIONS: {

--- a/src/discussions/discussions-home/DiscussionsHome.test.jsx
+++ b/src/discussions/discussions-home/DiscussionsHome.test.jsx
@@ -13,7 +13,7 @@ import DiscussionsHome from './DiscussionsHome';
 let store;
 const courseId = 'course-v1:edX+DemoX+Demo_Course';
 
-function renderComponent(location = `/discussions/${courseId}/`) {
+function renderComponent(location = `/${courseId}/`) {
   render(
     <IntlProvider locale="en">
       <ResponsiveContext.Provider value={{ width: 1280 }}>
@@ -51,7 +51,7 @@ describe('DiscussionsHome', () => {
   });
 
   test('full view should show header and footer and hide close button', async () => {
-    renderComponent(`/discussions/${courseId}/topics`);
+    renderComponent(`/${courseId}/topics`);
     expect(screen.queryByText(navigationBarMessages.allTopics.defaultMessage))
       .toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Close' }))
@@ -68,7 +68,7 @@ describe('DiscussionsHome', () => {
   });
 
   test('in-context view should hide header and footer and show close button', async () => {
-    renderComponent(`/discussions/${courseId}/topics?inContext`);
+    renderComponent(`/${courseId}/topics?inContext`);
 
     expect(screen.queryByText(navigationBarMessages.allTopics.defaultMessage))
       .not

--- a/src/discussions/navigation/breadcrumb-menu/LegacyBreadcrumbMenu.test.jsx
+++ b/src/discussions/navigation/breadcrumb-menu/LegacyBreadcrumbMenu.test.jsx
@@ -72,7 +72,7 @@ describe('LegacyBreadcrumbMenu', () => {
   });
 
   it('shows the category dropdown with a category selected', async () => {
-    renderComponent(`/discussions/${courseId}/category/category-1`);
+    renderComponent(`/${courseId}/category/category-1`);
 
     // The current category should be visible on the page
     const categoryDropdown = await screen.findByText('category-1');
@@ -101,7 +101,7 @@ describe('LegacyBreadcrumbMenu', () => {
   });
 
   it('shows the category correct dropdown labels with a topic selected', async () => {
-    renderComponent(`/discussions/${courseId}/topics/category-2-topic-1`);
+    renderComponent(`/${courseId}/topics/category-2-topic-1`);
 
     // Since a topic is selected, we have both a category and topic, so "show all shouldn't be visible"
     expect(screen.queryByText('Show all')).not.toBeInTheDocument();

--- a/src/discussions/posts/post-editor/PostEditor.test.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.test.jsx
@@ -29,7 +29,7 @@ const topicsApiUrl = `${API_BASE_URL}/api/discussion/v1/course_topics/${courseId
 let store;
 let axiosMock;
 
-async function renderComponent(editExisting = false, location = `/discussions/${courseId}/posts/`) {
+async function renderComponent(editExisting = false, location = `/${courseId}/posts/`) {
   const path = editExisting ? Routes.POSTS.EDIT_POST : Routes.POSTS.NEW_POSTS;
   await render(
     <IntlProvider locale="en">
@@ -258,7 +258,7 @@ describe('PostEditor', () => {
       axiosMock.onGet(`${threadsApiUrl}${threadId}/`)
         .reply(200, Factory.build('thread'));
       await executeThunk(fetchThread(threadId), store.dispatch, store.getState);
-      await renderComponent(true, `/discussions/${courseId}/posts/${threadId}/edit`);
+      await renderComponent(true, `/${courseId}/posts/${threadId}/edit`);
 
       ['ncw-topic 1', 'ncw-topic 2', 'category-1-topic 1', 'category-2-topic 1'].forEach((topicName) => {
         userEvent.selectOptions(

--- a/src/discussions/topics/TopicsView.test.jsx
+++ b/src/discussions/topics/TopicsView.test.jsx
@@ -28,11 +28,11 @@ function renderComponent() {
   render(
     <IntlProvider locale="en">
       <AppProvider store={store}>
-        <MemoryRouter initialEntries={[`/discussions/${courseId}/topics/`]}>
-          <Route path="/discussions/:courseId/topics/">
+        <MemoryRouter initialEntries={[`/${courseId}/topics/`]}>
+          <Route path="/:courseId/topics/">
             <TopicsView />
           </Route>
-          <Route path="/discussions/:courseId/category/:category">
+          <Route path="/:courseId/category/:category">
             <TopicsView />
           </Route>
           <Route


### PR DESCRIPTION
Remove the discussions prefix from the base path to avoid potential repeat of that
word the path when deployed.

Ticket: https://openedx.atlassian.net/browse/TNL-9347