### PR TITLE
build: Mark repo to be included in automated releases

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -8,5 +8,4 @@ openedx-release:
   # The openedx-release key is described in OEP-10:
   #   https://open-edx-proposals.readthedocs.io/en/latest/oep-0010-proc-openedx-releases.html
   # The FAQ might also be helpful: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1331268879/Open+edX+Release+FAQ
-  maybe: true   # Delete this "maybe" line when you have decided about Open edX inclusion.
   ref: master


### PR DESCRIPTION
 Just removing the line that prevents it from being included in the automated releases, following OEP-10.
 Ref https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0010-proc-openedx-releases.html 