### PR TITLE
feat: delete confirmation dialogs [BD-38] [TNL-9351]

### DIFF
--- a/src/discussions/comments/CommentsView.jsx
+++ b/src/discussions/comments/CommentsView.jsx
@@ -117,7 +117,7 @@ function CommentsView({ intl }) {
   const thread = usePost(postId);
   if (!thread) {
     return (
-      <Spinner animation="border" variant="primary" />
+      <Spinner animation="border" variant="primary" data-testid="loading-indicator" />
     );
   }
   return (

--- a/src/discussions/comments/comment/Reply.jsx
+++ b/src/discussions/comments/comment/Reply.jsx
@@ -8,10 +8,9 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Avatar, useToggle } from '@edx/paragon';
 
 import { ContentActions } from '../../../data/constants';
-import { DeleteConfirmation } from '../../common';
-import ActionsDropdown from '../../common/ActionsDropdown';
-import AlertBanner from '../../common/AlertBanner';
-import AuthorLabel from '../../common/AuthorLabel';
+import {
+  ActionsDropdown, AlertBanner, AuthorLabel, DeleteConfirmation,
+} from '../../common';
 import { selectAuthorAvatars } from '../../posts/data/selectors';
 import { editComment, removeComment } from '../data/thunks';
 import messages from '../messages';

--- a/src/discussions/comments/data/__factories__/comments.factory.js
+++ b/src/discussions/comments/data/__factories__/comments.factory.js
@@ -15,6 +15,7 @@ Factory.define('comment')
   .attrs({
     author: 'edx',
     author_label: 'Staff',
+    can_delete: true,
     created_at: () => (new Date()).toISOString(),
     updated_at: () => (new Date()).toISOString(),
     abuse_flagged: false,

--- a/src/discussions/comments/messages.js
+++ b/src/discussions/comments/messages.js
@@ -115,6 +115,22 @@ const messages = defineMessages({
     id: 'discussions.editor.error.empty',
     defaultMessage: 'Post content cannot be empty.',
   },
+  deleteResponseTitle: {
+    id: 'discussions.editor.delete.response.title',
+    defaultMessage: 'Delete response',
+  },
+  deleteResponseDescription: {
+    id: 'discussions.editor.delete.response.description',
+    defaultMessage: 'Are you sure you want to permanently delete this response?',
+  },
+  deleteCommentTitle: {
+    id: 'discussions.editor.delete.comment.title',
+    defaultMessage: 'Delete comment',
+  },
+  deleteCommentDescription: {
+    id: 'discussions.editor.delete.comment.description',
+    defaultMessage: 'Are you sure you want to permanently delete this comment?',
+  },
 });
 
 export default messages;

--- a/src/discussions/common/DeleteConfirmation.jsx
+++ b/src/discussions/common/DeleteConfirmation.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { ActionRow, Button, ModalDialog } from '@edx/paragon';
+
+import messages from '../messages';
+
+function DeleteConfirmation({
+  intl,
+  isOpen,
+  title,
+  description,
+  onClose,
+  onDelete,
+}) {
+  return (
+    <ModalDialog title={title} isOpen={isOpen} hasCloseButton={false} onClose={onClose}>
+      <ModalDialog.Header>
+        <ModalDialog.Title>
+          {title}
+        </ModalDialog.Title>
+      </ModalDialog.Header>
+      <ModalDialog.Body>
+        {description}
+      </ModalDialog.Body>
+      <ModalDialog.Footer>
+        <ActionRow>
+          <ModalDialog.CloseButton variant="tertiary">
+            {intl.formatMessage(messages.deleteConfirmationCancel)}
+          </ModalDialog.CloseButton>
+          <Button variant="primary" onClick={onDelete}>
+            {intl.formatMessage(messages.deleteConfirmationDelete)}
+          </Button>
+        </ActionRow>
+      </ModalDialog.Footer>
+    </ModalDialog>
+  );
+}
+
+DeleteConfirmation.propTypes = {
+  intl: intlShape.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+};
+
+export default injectIntl(DeleteConfirmation);

--- a/src/discussions/common/index.js
+++ b/src/discussions/common/index.js
@@ -1,3 +1,4 @@
 export { default as ActionsDropdown } from './ActionsDropdown';
 export { default as AlertBanner } from './AlertBanner';
 export { default as AuthorLabel } from './AuthorLabel';
+export { default as DeleteConfirmation } from './DeleteConfirmation';

--- a/src/discussions/messages.js
+++ b/src/discussions/messages.js
@@ -66,6 +66,16 @@ const messages = defineMessages({
     defaultMessage: 'Unmark as answered',
     description: 'Action to unmark a comment as answering a post',
   },
+  deleteConfirmationCancel: {
+    id: 'discussions.delete.confirmation.button.cancel',
+    defaultMessage: 'Cancel',
+    description: 'Cancel button shown on delete confirmation dialog',
+  },
+  deleteConfirmationDelete: {
+    id: 'discussions.delete.confirmation.button.delete',
+    defaultMessage: 'Delete',
+    description: 'Delete button shown on delete confirmation dialog',
+  },
 });
 
 export default messages;

--- a/src/discussions/posts/data/__factories__/threads.factory.js
+++ b/src/discussions/posts/data/__factories__/threads.factory.js
@@ -24,6 +24,7 @@ Factory.define('thread')
     author: 'test_user',
     author_label: 'Staff',
     abuse_flagged: false,
+    can_delete: true,
     voted: false,
     vote_count: 1,
     course_id: 'course-v1:Test+TestX+Test_Course',

--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -5,11 +5,11 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { Hyperlink } from '@edx/paragon';
+import { Hyperlink, useToggle } from '@edx/paragon';
 
 import { ContentActions } from '../../../data/constants';
 import { selectTopicContext } from '../../../data/selectors';
-import { AlertBanner } from '../../common';
+import { AlertBanner, DeleteConfirmation } from '../../common';
 import { selectTopic } from '../../topics/data/selectors';
 import { removeThread, updateExistingThread } from '../data/thunks';
 import messages from './messages';
@@ -27,16 +27,30 @@ function Post({
   const dispatch = useDispatch();
   const topic = useSelector(selectTopic(post.topicId));
   const topicContext = useSelector(selectTopicContext(post.topicId));
+  const [isDeleting, showDeleteConfirmation, hideDeleteConfirmation] = useToggle(false);
   const actionHandlers = {
-    [ContentActions.EDIT_CONTENT]: () => history.push({ ...location, pathname: `${location.pathname}/edit` }),
-    // TODO: Add flow to confirm before deleting
-    [ContentActions.DELETE]: () => dispatch(removeThread(post.id)),
+    [ContentActions.EDIT_CONTENT]: () => history.push({
+      ...location,
+      pathname: `${location.pathname}/edit`,
+    }),
+    [ContentActions.DELETE]: showDeleteConfirmation,
     [ContentActions.CLOSE]: () => dispatch(updateExistingThread(post.id, { closed: !post.closed })),
     [ContentActions.PIN]: () => dispatch(updateExistingThread(post.id, { pinned: !post.pinned })),
     [ContentActions.REPORT]: () => dispatch(updateExistingThread(post.id, { flagged: !post.abuseFlagged })),
   };
   return (
-    <div className="d-flex flex-column p-2.5 w-100 mw-100">
+    <div className="d-flex flex-column p-2.5 w-100 mw-100" data-testid={`post-${post.id}`}>
+      <DeleteConfirmation
+        isOpen={isDeleting}
+        title={intl.formatMessage(messages.deletePostTitle)}
+        description={intl.formatMessage(messages.deletePostDescription)}
+        onClose={hideDeleteConfirmation}
+        onDelete={() => {
+          dispatch(removeThread(post.id));
+          history.goBack();
+          hideDeleteConfirmation();
+        }}
+      />
       <div className="mb-4">
         <AlertBanner postType={post.type} content={post} />
       </div>

--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -47,7 +47,7 @@ function Post({
         onClose={hideDeleteConfirmation}
         onDelete={() => {
           dispatch(removeThread(post.id));
-          history.goBack();
+          history.push('.');
           hideDeleteConfirmation();
         }}
       />

--- a/src/discussions/posts/post/messages.js
+++ b/src/discussions/posts/post/messages.js
@@ -62,6 +62,14 @@ const messages = defineMessages({
     defaultMessage: 'Everyone',
     description: 'Cohort visibility indicator for all people',
   },
+  deletePostTitle: {
+    id: 'discussions.editor.delete.post.title',
+    defaultMessage: 'Delete post',
+  },
+  deletePostDescription: {
+    id: 'discussions.editor.delete.post.description',
+    defaultMessage: 'Are you sure you want to permanently delete this post?',
+  },
 });
 
 export default messages;

--- a/src/discussions/utils.js
+++ b/src/discussions/utils.js
@@ -9,18 +9,6 @@ import {
 import { ContentActions, Routes, ThreadType } from '../data/constants';
 import messages from './messages';
 
-export function buildIntlSelectionList(options, intl, messagesData) {
-  return Object.values(options)
-    .map(
-      option => (
-        {
-          label: intl.formatMessage(messagesData[option]),
-          value: option,
-        }
-      ),
-    );
-}
-
 /**
  * Get HTTP Error status from generic error.
  * @param error Generic caught error.


### PR DESCRIPTION
Adds delete confirmation dialogs for posts, comments and replies.


![Screenshot_20220118_181702](https://user-images.githubusercontent.com/118837/149940081-09b523ab-dc22-4a23-9cb9-7d0b96844c86.png)

