### PR TITLE
[BD-38] [TNL-9479] [BB-5419] Integrate retrieval of moderation reason codes from the LMS settings

### DIFF
--- a/src/discussions/data/api.js
+++ b/src/discussions/data/api.js
@@ -30,3 +30,12 @@ export async function getDiscussionsSettings(courseId) {
   const { data } = await getAuthenticatedHttpClient().get(url);
   return data;
 }
+
+/**
+ * Get the moderation settings
+ */
+export async function getModerationSettings() {
+  const url = `${apiBaseUrl}/api/discussion/v1/moderation_settings`;
+  const { data } = await getAuthenticatedHttpClient().get(url);
+  return data;
+}

--- a/src/discussions/data/selectors.js
+++ b/src/discussions/data/selectors.js
@@ -8,3 +8,5 @@ export const selectAnonymousPostingConfig = state => ({
 export const selectUserIsPrivileged = state => state.config.userIsPrivileged;
 
 export const selectDivisionSettings = state => state.config.settings;
+
+export const selectModerationSettings = state => state.config.moderationSettings;

--- a/src/discussions/data/slices.js
+++ b/src/discussions/data/slices.js
@@ -18,6 +18,10 @@ const configSlice = createSlice({
       dividedInlineDiscussions: [],
       dividedCourseWideDiscussions: [],
     },
+    moderationSettings: {
+      editReasonCodes: [],
+      closeReasonCodes: [],
+    },
   },
   reducers: {
     fetchConfigRequest: (state) => {

--- a/src/discussions/data/thunks.js
+++ b/src/discussions/data/thunks.js
@@ -3,7 +3,7 @@ import { camelCaseObject } from '@edx/frontend-platform';
 import { logError } from '@edx/frontend-platform/logging';
 
 import { getHttpErrorStatus } from '../utils';
-import { getDiscussionsConfig, getDiscussionsSettings } from './api';
+import { getDiscussionsConfig, getDiscussionsSettings, getModerationSettings } from './api';
 import {
   fetchConfigDenied, fetchConfigFailed, fetchConfigRequest, fetchConfigSuccess,
 } from './slices';
@@ -21,6 +21,7 @@ export function fetchCourseConfig(courseId) {
       if (config.user_is_privileged) {
         const settings = await getDiscussionsSettings(courseId);
         Object.assign(config, { settings });
+        config.moderationSettings = await getModerationSettings();
       }
       dispatch(fetchConfigSuccess(camelCaseObject(config)));
     } catch (error) {


### PR DESCRIPTION
### Description

This PR implements the retrieval of moderation settings from the API endpoint implemented by [this PR](https://github.com/openedx/edx-platform/pull/29831).