### PR TITLE
[TNL-9569] Like count should not display is zero

### DIFF
--- a/src/discussions/posts/post/LikeButton.jsx
+++ b/src/discussions/posts/post/LikeButton.jsx
@@ -43,7 +43,7 @@ function LikeButton(
           src={voted ? ThumbUpFilled : ThumbUpOutline}
         />
       </OverlayTrigger>
-      {count}
+      {(count && count > 0) ? count : null}
     </div>
   );
 }


### PR DESCRIPTION
## Description

As per TNL-9569, made the UI follow the Figma designs more
closely. When there are no likes just show the empty like icon.

## Supporting information

- https://tasks.opencraft.com/browse/SE-5348
- https://openedx.atlassian.net/browse/TNL-9569

## Testing instructions

- Install the package
- Go to the discussions tab for any course
- Click the **View the new experience** button
- Add a post
- Like/unlike the post

The counter should appear when adding a like and disappear if the number of likes == 0.

## Deadline

8 March 2022