### PR TITLE
fix: when making a comment on a response that doesn't have responses [BD-38] [TNL-9563] 

### DIFF
--- a/src/discussions/comments/data/slices.js
+++ b/src/discussions/comments/data/slices.js
@@ -115,6 +115,9 @@ const commentsSlice = createSlice({
     postCommentSuccess: (state, { payload }) => {
       state.postStatus = RequestStatus.SUCCESSFUL;
       if (payload.parentId) {
+        if (!(payload.parentId in state.commentsInComments)) {
+          state.commentsInComments[payload.parentId] = [];
+        }
         state.commentsInComments[payload.parentId].push(payload.id);
       } else {
         // The comment should be added to either the discussion or unendorsed


### PR DESCRIPTION
Fixes a bug that wouldn't update the UI when making a comment on a response that doesn't have responses.

https://user-images.githubusercontent.com/118837/155137125-8f98968a-c73d-4e80-96d8-e441f28317be.mp4


