### PR TITLE
fix: display non-breaking space entity properly in post summary

### DIFF
--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -77,7 +77,8 @@ function PostLink({
               />
             </div>
           </div>
-          <div>{post.previewBody}</div>
+          {/* eslint-disable-next-line react/no-danger */}
+          <div dangerouslySetInnerHTML={{ __html: post.previewBody }} />
           <PostFooter post={post} preview intl={intl} />
         </div>
       </div>


### PR DESCRIPTION
Ticket: [TNL-9568](https://openedx.atlassian.net/jira/software/c/projects/TNL/boards/713?modal=detail&selectedIssue=TNL-9568)
Non-breaking space Html entity(&nbsp) was showing up in post summery. Now it's rendered properly as a space.