### PR TITLE
[BD-38] [TNL-9572] [BB-5555] Remove the legacy unread indicator from post-link avatar

### DIFF
--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Badge, Icon } from '@edx/paragon';
-import { Flag, Pin, Unread } from '@edx/paragon/icons';
+import { Flag, Pin } from '@edx/paragon/icons';
 
 import { Routes, ThreadType } from '../../../data/constants';
 import AuthorLabel from '../../common/AuthorLabel';
@@ -55,7 +55,6 @@ function PostLink({
           borderRightStyle: 'solid',
         } : null}
       >
-        <Icon className={classNames('p-0 mr-n3 text-brand-500', { invisible: post.read })} src={Unread} />
         <PostAvatar post={post} />
         <div className="d-flex flex-column" style={{ width: 'calc(100% - 4rem)' }}>
           <div className="align-items-center d-flex flex-row flex-fill">


### PR DESCRIPTION
### Description

Removes the circular badge icon from showing up on top of the Avatar in the PostLink component for "unread" conditions

### Relevant Information

https://openedx.atlassian.net/browse/TNL-9572

### Testing instructions

1. Checkout to the PR branch
2. Get the app running at https://localhost:2002/<course_id>/
2. Add a new post in a topic from LMS discussion
3. Go the topic in the app  - the new post will appear with white background and the avatar will not have any badge.