### PR TITLE
fix: answered and endorsed indicator modification

### DIFF
--- a/src/discussions/common/AlertBanner.jsx
+++ b/src/discussions/common/AlertBanner.jsx
@@ -65,7 +65,7 @@ function AlertBanner({
                 />
               )}
 
-              <span className="mr-3">
+              <span className="mr-3" data-testid="endorsed-by-label">
                 {endorsedByLabels[content.endorsedByLabel]}
               </span>
               {timeago.format(content.endorsedAt, intl.locale)}

--- a/src/discussions/common/AlertBanner.jsx
+++ b/src/discussions/common/AlertBanner.jsx
@@ -26,7 +26,12 @@ function AlertBanner({
   return (
     <>
       {content.endorsed && (
-        <Alert variant="plain" className={`p-3 m-0 rounded-0 shadow-none ${classes}`} icon={iconClass}>
+        <Alert
+          variant="plain"
+          className={`p-3 m-0 shadow-none ${classes}`}
+          style={{ borderRadius: '0.375rem 0.375rem 0 0' }}
+          icon={iconClass}
+        >
           <div className="d-flex justify-content-between">
             <strong className="lead">{intl.formatMessage(
               isQuestion

--- a/src/discussions/common/AlertBanner.jsx
+++ b/src/discussions/common/AlertBanner.jsx
@@ -4,8 +4,10 @@ import PropTypes from 'prop-types';
 import * as timeago from 'timeago.js';
 
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { Alert, Hyperlink } from '@edx/paragon';
-import { CheckCircle, Error, Verified } from '@edx/paragon/icons';
+import { Alert, Icon } from '@edx/paragon';
+import {
+  CheckCircle, Error, Institution, School, Verified,
+} from '@edx/paragon/icons';
 
 import { ThreadType } from '../../data/constants';
 import { commentShape } from '../comments/comment/proptypes';
@@ -20,24 +22,47 @@ function AlertBanner({
   const isQuestion = postType === ThreadType.QUESTION;
   const classes = isQuestion ? 'bg-success-500 text-white' : 'bg-dark-500 text-white';
   const iconClass = isQuestion ? CheckCircle : Verified;
+  const endorsedByLabels = { Staff: 'Staff', 'Community TA': 'TA' };
   return (
     <>
       {content.endorsed && (
         <Alert variant="plain" className={`p-3 m-0 rounded-0 shadow-none ${classes}`} icon={iconClass}>
           <div className="d-flex justify-content-between">
-            <strong>{intl.formatMessage(
+            <strong className="lead">{intl.formatMessage(
               isQuestion
                 ? messages.answer
                 : messages.endorsed,
             )}
             </strong>
-            <span>
+            <span className="d-flex align-items-center">
               {intl.formatMessage(
                 isQuestion
                   ? messages.answeredLabel
                   : messages.endorsedLabel,
-              )}&nbsp;
-              <Hyperlink>{content.endorsedBy}</Hyperlink>&nbsp;
+              )}
+              <span className="mx-2">{content.endorsedBy}</span>
+
+              {content.endorsedByLabel === 'Staff' ? (
+                <Icon
+                  style={{
+                    width: '1rem',
+                    height: '1rem',
+                  }}
+                  src={Institution}
+                />
+              ) : (
+                <Icon
+                  style={{
+                    width: '1rem',
+                    height: '1rem',
+                  }}
+                  src={School}
+                />
+              )}
+
+              <span className="mr-3">
+                {endorsedByLabels[content.endorsedByLabel]}
+              </span>
               {timeago.format(content.endorsedAt, intl.locale)}
             </span>
           </div>

--- a/src/discussions/common/AlertBanner.test.jsx
+++ b/src/discussions/common/AlertBanner.test.jsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { Factory } from 'rosie';
+
+import { camelCaseObject, initializeMockApp, snakeCaseObject } from '@edx/frontend-platform';
+import { AppProvider } from '@edx/frontend-platform/react';
+
+import { ThreadType } from '../../data/constants';
+import AlertBanner from './AlertBanner';
+
+import '../comments/data/__factories__';
+
+let store;
+
+function buildTestContent(buildParams) {
+  const buildParamsSnakeCase = snakeCaseObject(buildParams);
+  return [
+    Factory.build('comment', { ...buildParamsSnakeCase }, null),
+  ].map(content => camelCaseObject(content));
+}
+
+function renderComponent(
+  content,
+) {
+  render(
+    <IntlProvider locale="en">
+      <AppProvider store={store}>
+        <AlertBanner
+          content={content}
+          postType={ThreadType.QUESTION}
+        />
+      </AppProvider>
+    </IntlProvider>,
+  );
+}
+
+describe('AlertBanner', () => {
+  beforeEach(async () => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 3,
+        username: 'abc123',
+        administrator: false,
+        roles: [],
+      },
+    });
+  });
+
+  it.each(buildTestContent({ endorsed: true, endorsedByLabel: 'Staff' }))(
+    'endorsed by label is Staff when endorsed by staff user',
+    async (content) => {
+      renderComponent(content);
+
+      await waitFor(() => expect(screen.getByText('Staff')).toBeInTheDocument());
+    },
+  );
+
+  it.each(buildTestContent({ endorsed: true, endorsedByLabel: 'Community TA' }))(
+    'endorsed by label is TA when not endorsed by staff user',
+    async (content) => {
+      renderComponent(content);
+
+      await waitFor(() => expect(screen.getByText('TA')).toBeInTheDocument());
+    },
+  );
+});

--- a/src/discussions/common/AlertBanner.test.jsx
+++ b/src/discussions/common/AlertBanner.test.jsx
@@ -1,4 +1,6 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import {
+  render, screen, waitFor, within,
+} from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { Factory } from 'rosie';
 
@@ -51,7 +53,9 @@ describe('AlertBanner', () => {
     async (content) => {
       renderComponent(content);
 
-      await waitFor(() => expect(screen.getByText('Staff')).toBeInTheDocument());
+      await waitFor(() => expect(
+        within(screen.getByTestId('endorsed-by-label')).getByText('Staff'),
+      ).toBeInTheDocument());
     },
   );
 
@@ -60,7 +64,9 @@ describe('AlertBanner', () => {
     async (content) => {
       renderComponent(content);
 
-      await waitFor(() => expect(screen.getByText('TA')).toBeInTheDocument());
+      await waitFor(() => expect(
+        within(screen.getByTestId('endorsed-by-label')).getByText('TA'),
+      ).toBeInTheDocument());
     },
   );
 });


### PR DESCRIPTION
Ticket: [TNL-9610](https://openedx.atlassian.net/browse/TNL-9610)

- Font of “Answer” and “Endorsed” string is bigger now.
- Color of username is same as rest of the text.
- Added user role (“Staff”, “TA” etc.) and icon.
- Added more space between timestamp and username.
- Top-right and top-left corner of the header box are rounded.

<img width="1162" alt="Screenshot 2022-03-01 at 1 39 48 PM" src="https://user-images.githubusercontent.com/51022010/156134699-0c2e1d46-96d0-455f-be46-665795259d49.png">
<img width="1162" alt="Screenshot 2022-03-01 at 1 39 22 PM" src="https://user-images.githubusercontent.com/51022010/156134741-4e0304af-17af-457f-95c6-ebec071a9b8c.png">

