### PR TITLE
fix: post summaries disappear upon scroll to the bottom

### DIFF
--- a/src/discussions/posts/PostsView.jsx
+++ b/src/discussions/posts/PostsView.jsx
@@ -111,7 +111,7 @@ function PostsView({ showOwnPosts }) {
         filters,
         page: nextPage,
         author: showOwnPosts ? authenticatedUser.username : null,
-      }));
+      }, postsListComponent));
     }
   };
 

--- a/src/discussions/posts/data/thunks.js
+++ b/src/discussions/posts/data/thunks.js
@@ -91,7 +91,7 @@ export function fetchThreads(courseId, {
   author = null,
   filters = {},
   page = 1,
-} = {}) {
+} = {}, posts = []) {
   const options = {
     orderBy,
     topicIds,
@@ -117,6 +117,7 @@ export function fetchThreads(courseId, {
     try {
       dispatch(fetchThreadsRequest({ courseId }));
       const data = await getThreads(courseId, options);
+      data.results = [...posts, ...data.results];
       const normalisedData = normaliseThreads(camelCaseObject(data));
       dispatch(fetchThreadsSuccess({ ...normalisedData, page, author }));
     } catch (error) {


### PR DESCRIPTION
Previously loaded post were disappearing when next posts were loaded.

https://openedx.atlassian.net/browse/TNL-9628

Before:
![before](https://user-images.githubusercontent.com/77053848/156355676-a244979e-fef1-4cda-bf18-fd99dc74d600.gif)


After:
![after](https://user-images.githubusercontent.com/77053848/156355776-b6ec5b71-2f1b-473f-8d2b-0c71ae319c11.gif)

