### PR TITLE
fix: filtering by post type wasn't working [BD-38] [TNL-9609]

### DIFF
--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -8,6 +8,7 @@ export const API_BASE_URL = getConfig().LMS_BASE_URL;
  * @enum {string}
  */
 export const ThreadType = {
+  ALL: 'all',
   QUESTION: 'question',
   DISCUSSION: 'discussion',
 };
@@ -89,17 +90,6 @@ export const ThreadViewStatus = {
 };
 
 /**
- * Enum for filtering user posts.
- * @readonly
- * @enum {string}
- */
-export const MyPostsFilter = {
-  MY_POSTS: 'myPosts',
-  MY_DISCUSSIONS: 'myDiscussions',
-  MY_QUESTIONS: 'myQuestions',
-};
-
-/**
  * Enum for filtering posts by status.
  * @readonly
  * @enum {string}
@@ -110,17 +100,6 @@ export const PostsStatusFilter = {
   FOLLOWING: 'statusFollowing',
   REPORTED: 'statusReported',
   UNANSWERED: 'statusUnanswered',
-};
-
-/**
- * Enum for filtering all posts.
- * @readonly
- * @enum {string}
- */
-export const AllPostsFilter = {
-  ALL_POSTS: 'allPosts',
-  ALL_DISCUSSIONS: 'allDiscussions',
-  ALL_QUESTIONS: 'allQuestions',
 };
 
 /**

--- a/src/discussions/data/selectors.js
+++ b/src/discussions/data/selectors.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/prefer-default-export */
-import { AllPostsFilter, PostsStatusFilter } from '../../data/constants';
+import { PostsStatusFilter, ThreadType } from '../../data/constants';
 
 export const selectAnonymousPostingConfig = state => ({
   allowAnonymous: state.config.allowAnonymous,
@@ -21,7 +21,7 @@ export function selectAreThreadsFiltered(state) {
 
   return !(
     filters.status === PostsStatusFilter.ALL
-    && filters.allPosts === AllPostsFilter.ALL_POSTS
+    && filters.postType === ThreadType.ALL
   );
 }
 

--- a/src/discussions/posts/PostsView.test.jsx
+++ b/src/discussions/posts/PostsView.test.jsx
@@ -1,0 +1,253 @@
+import React from 'react';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import MockAdapter from 'axios-mock-adapter';
+import { act } from 'react-dom/test-utils';
+import { IntlProvider } from 'react-intl';
+import {
+  generatePath, MemoryRouter, Route, Switch,
+} from 'react-router';
+import { Factory } from 'rosie';
+
+import { initializeMockApp } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { AppProvider } from '@edx/frontend-platform/react';
+
+import { Routes, ThreadType } from '../../data/constants';
+import { initializeStore } from '../../store';
+import { DiscussionContext } from '../common/context';
+import { threadsApiUrl } from './data/api';
+import { PostsView } from './index';
+
+import './data/__factories__';
+
+const courseId = 'course-v1:edX+TestX+Test_Course';
+let store;
+let axiosMock;
+
+async function renderComponent({
+  postId, topicId, category, myPosts,
+} = { myPosts: false }) {
+  let path = generatePath(Routes.POSTS.ALL_POSTS, { courseId });
+  let showOwnPosts = false;
+  if (postId) {
+    path = generatePath(Routes.POSTS.ALL_POSTS, { courseId, postId });
+  } else if (topicId) {
+    path = generatePath(Routes.POSTS.PATH, { courseId, topicId });
+  } else if (category) {
+    path = generatePath(Routes.TOPICS.CATEGORY, { courseId, category });
+  } else if (myPosts) {
+    path = generatePath(Routes.POSTS.MY_POSTS, { courseId });
+    showOwnPosts = myPosts;
+  }
+  await render(
+    <IntlProvider locale="en">
+      <AppProvider store={store}>
+        <MemoryRouter initialEntries={[path]}>
+          <DiscussionContext.Provider value={{
+            courseId,
+            postId,
+            topicId,
+            category,
+          }}
+          >
+            <Switch>
+              <Route path={Routes.POSTS.MY_POSTS}>
+                <PostsView showOwnPosts={showOwnPosts} />
+              </Route>
+              <Route
+                path={[Routes.POSTS.PATH, Routes.POSTS.ALL_POSTS, Routes.TOPICS.CATEGORY]}
+                component={PostsView}
+              />
+            </Switch>
+          </DiscussionContext.Provider>
+        </MemoryRouter>
+      </AppProvider>
+    </IntlProvider>,
+  );
+}
+
+describe('PostsView', () => {
+  const threadCount = 6;
+  beforeEach(async () => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 3,
+        username: 'abc123',
+        administrator: true,
+        roles: [],
+      },
+    });
+
+    store = initializeStore({
+      blocks: { blocks: { 'test-usage-key': { topics: ['some-topic-2', 'some-topic-0'] } } },
+    });
+    Factory.resetAll();
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    axiosMock.onGet(threadsApiUrl)
+      .reply((args) => {
+        const threadAttrs = {};
+        if (args.params.author) {
+          threadAttrs.author = args.params.author;
+        }
+        return [200, Factory.build('threadsResult', {}, {
+          topicId: undefined,
+          count: threadCount,
+          threadAttrs,
+          pageSize: 6,
+        })];
+      });
+  });
+
+  describe('Basic', () => {
+    test('displays a list of all posts', async () => {
+      await act(async () => {
+        await renderComponent();
+      });
+      expect(screen.getAllByText(/this is thread-\d+/i)).toHaveLength(threadCount);
+    });
+    test('displays a list of user posts', async () => {
+      await act(async () => {
+        await renderComponent({ myPosts: true });
+      });
+      expect(screen.getAllByText('abc123')).toHaveLength(threadCount);
+    });
+    test('displays a list of posts in a topic', async () => {
+      await act(async () => {
+        await renderComponent({ topicId: 'some-topic-1' });
+      });
+      expect(screen.getAllByText(/this is thread-\d+ in topic some-topic-1/i)).toHaveLength(Math.ceil(threadCount / 3));
+    });
+    test('displays a list of posts in a category', async () => {
+      await act(async () => {
+        await renderComponent({ category: 'test-usage-key' });
+      });
+      expect(screen.queryAllByText(/this is thread-\d+ in topic some-topic-1}/i)).toHaveLength(0);
+      expect(screen.queryAllByText(/this is thread-\d+ in topic some-topic-2/i)).toHaveLength(Math.ceil(threadCount / 3));
+      expect(screen.queryAllByText(/this is thread-\d+ in topic some-topic-0/i)).toHaveLength(Math.ceil(threadCount / 3));
+    });
+  });
+
+  describe('Filtering', () => {
+    let dropDownButton;
+
+    function lastQueryParams() {
+      const { params } = axiosMock.history.get[axiosMock.history.get.length - 1];
+      return params;
+    }
+
+    beforeEach(async () => {
+      await act(async () => {
+        await renderComponent();
+      });
+      dropDownButton = screen.getByRole('button', {
+        name: /all posts by recent activity/i,
+      });
+      await act(async () => {
+        fireEvent.click(dropDownButton);
+      });
+    });
+    test('test that the filter bar works', async () => {
+      // 3 type filters: all, discussion, question
+      // 5 status filters: any, unread, following, reported, unanswered
+      // 3 sort: activity, comments, votes
+      expect(screen.queryAllByRole('radio')).toHaveLength(11);
+    });
+
+    describe.each([
+      {
+        label: 'Discussions',
+        queryParam: { thread_type: ThreadType.DISCUSSION },
+      },
+      {
+        label: 'Questions',
+        queryParam: { thread_type: ThreadType.QUESTION },
+      },
+      {
+        label: 'Unread',
+        queryParam: { view: 'unread' },
+      },
+      {
+        label: 'Unanswered',
+        queryParam: { view: 'unanswered' },
+      },
+      {
+        label: 'Following',
+        queryParam: { following: true },
+      },
+      {
+        label: 'Reported',
+        queryParam: { flagged: true },
+      },
+      {
+        label: 'Most activity',
+        queryParam: { order_by: 'comment_count' },
+      },
+      {
+        label: 'Most votes',
+        queryParam: { order_by: 'vote_count' },
+      },
+    ])(
+      'one at a time',
+      ({
+        label,
+        queryParam,
+      }) => {
+        test(`select "${label}"`, async () => {
+          await act(async () => {
+            fireEvent.click(screen.getByLabelText(label));
+          });
+          // Assert that changing the filters results in the correct query
+          expect(lastQueryParams()).toMatchObject(queryParam);
+        });
+      },
+    );
+
+    describe.each([
+      {
+        firstClick: 'Discussions',
+        secondClick: 'Unanswered',
+        selected: ['Questions', 'Unanswered'],
+      },
+      {
+        firstClick: 'Unanswered',
+        secondClick: 'Discussions',
+        selected: ['Discussions', 'Any'],
+      },
+      {
+        firstClick: 'Questions',
+        secondClick: 'Unread',
+        selected: ['Discussions', 'Unread'],
+      },
+      {
+        firstClick: 'Unread',
+        secondClick: 'Questions',
+        selected: ['Questions', 'Any'],
+      },
+    ])(
+      'incompatible combinations',
+      ({
+        firstClick,
+        secondClick,
+        selected,
+      }) => {
+        test(`select "${firstClick}" then "${secondClick}"`, async () => {
+          await act(async () => {
+            fireEvent.click(screen.getByLabelText(firstClick));
+          });
+          await act(async () => {
+            fireEvent.click(dropDownButton);
+          });
+          await act(async () => {
+            fireEvent.click(screen.getByLabelText(secondClick));
+          });
+          await act(async () => {
+            fireEvent.click(dropDownButton);
+          });
+          expect(screen.getAllByTestId('selected')[0]).toHaveTextContent(selected[0]);
+          expect(screen.getAllByTestId('selected')[1]).toHaveTextContent(selected[1]);
+        });
+      },
+    );
+  });
+});

--- a/src/discussions/posts/data/api.js
+++ b/src/discussions/posts/data/api.js
@@ -24,6 +24,7 @@ export const coursesApiUrl = `${apiBaseUrl}/api/discussion/v1/courses/`;
  * @param {ThreadOrdering} orderBy The results wil be sorted on this basis.
  * @param {boolean} following If true, only threads followed by the current user will be returned.
  * @param {boolean} flagged If true, only threads that have been reported will be returned.
+ * @param {string} threadType Can be 'discussion' or 'question'.
  * @param {ThreadViewStatus} view Set to "unread" on "unanswered" to filter to only those statuses.
  * @returns {Promise<{}>}
  */
@@ -38,6 +39,7 @@ export async function getThreads(
     view,
     author,
     flagged,
+    threadType,
   } = {},
 ) {
   const params = snakeCaseObject({
@@ -46,6 +48,7 @@ export async function getThreads(
     pageSize,
     topicId: topicIds && topicIds.join(','),
     textSearch,
+    threadType,
     orderBy: snakeCase(orderBy),
     following,
     view,

--- a/src/discussions/posts/data/redux.test.js
+++ b/src/discussions/posts/data/redux.test.js
@@ -101,7 +101,7 @@ describe('Threads/Posts data layer tests', () => {
     expect(store.getState().threads.threadsById['thread-1'])
       .toHaveProperty('topicId');
     expect(store.getState().threads.threadsById['thread-1'].topicId)
-      .toEqual('some-topic');
+      .toEqual('some-topic-1');
   });
 
   test('successfully handles thread creation', async () => {

--- a/src/discussions/posts/data/slices.js
+++ b/src/discussions/posts/data/slices.js
@@ -2,11 +2,10 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 import {
-  AllPostsFilter,
-  MyPostsFilter,
   PostsStatusFilter,
   RequestStatus,
   ThreadOrdering,
+  ThreadType,
 } from '../../../data/constants';
 
 const threadsSlice = createSlice({
@@ -31,8 +30,7 @@ const threadsSlice = createSlice({
     postStatus: RequestStatus.SUCCESSFUL,
     filters: {
       status: PostsStatusFilter.ALL,
-      allPosts: AllPostsFilter.ALL_POSTS,
-      myPosts: MyPostsFilter.MY_POSTS,
+      postType: ThreadType.ALL,
       search: '',
     },
     postEditorVisible: false,
@@ -141,12 +139,8 @@ const threadsSlice = createSlice({
       state.filters.status = payload;
       state.pages = [];
     },
-    setAllPostsTypeFilter: (state, { payload }) => {
-      state.filters.allPosts = payload;
-      state.pages = [];
-    },
-    setMyPostsTypeFilter: (state, { payload }) => {
-      state.filters.myPosts = payload;
+    setPostsTypeFilter: (state, { payload }) => {
+      state.filters.postType = payload;
       state.pages = [];
     },
     setSearchQuery: (state, { payload }) => {
@@ -191,8 +185,7 @@ export const {
   updateThreadFailed,
   updateThreadRequest,
   updateThreadSuccess,
-  setAllPostsTypeFilter,
-  setMyPostsTypeFilter,
+  setPostsTypeFilter,
   setSortedBy,
   setStatusFilter,
   setSearchQuery,

--- a/src/discussions/posts/data/thunks.js
+++ b/src/discussions/posts/data/thunks.js
@@ -2,7 +2,9 @@
 import { camelCaseObject } from '@edx/frontend-platform';
 import { logError } from '@edx/frontend-platform/logging';
 
-import { PostsStatusFilter } from '../../../data/constants';
+import {
+  PostsStatusFilter, ThreadType,
+} from '../../../data/constants';
 import { getHttpErrorStatus } from '../../utils';
 import {
   deleteThread, getThread, getThreads, postThread, updateThread,
@@ -34,7 +36,7 @@ import {
  * Filters to apply to a thread/posts query.
  * @typedef {Object} ThreadFilter
  * @property {PostsStatusFilter} status
- * @property {AllPostsFilter} allPosts
+ * @property {ThreadType} postType
  */
 
 /**
@@ -109,6 +111,9 @@ export function fetchThreads(courseId, {
   }
   if (filters.status === PostsStatusFilter.REPORTED) {
     options.flagged = true;
+  }
+  if (filters.postType !== ThreadType.ALL) {
+    options.threadType = filters.postType;
   }
   if (filters.search) {
     options.textSearch = filters.search;

--- a/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
+++ b/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
@@ -22,12 +22,14 @@ const ActionItem = ({
   value,
   selected,
 }) => (
-  <label htmlFor={id} className="focus border-bottom-0 d-flex p-1 m-2 align-items-center">
+  <label htmlFor={id} className="focus border-bottom-0 d-flex p-1 m-2 align-items-center" data-testid={value === selected ? 'selected' : null}>
     <Icon src={Check} className={classNames('text-success mr-2', { invisible: value !== selected })} />
     <Form.Radio id={id} className="sr-only sr-only-focusable" value={value} tabIndex={0}>
       {label}
     </Form.Radio>
-    {label}
+    <span aria-hidden>
+      {label}
+    </span>
   </label>
 );
 

--- a/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
+++ b/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
@@ -9,8 +9,10 @@ import { AppContext } from '@edx/frontend-platform/react';
 import { Collapsible, Form, Icon } from '@edx/paragon';
 import { Check, Sort } from '@edx/paragon/icons';
 
-import { AllPostsFilter, PostsStatusFilter, ThreadOrdering } from '../../../data/constants';
-import { setAllPostsTypeFilter, setSortedBy, setStatusFilter } from '../data';
+import {
+  PostsStatusFilter, ThreadOrdering, ThreadType,
+} from '../../../data/constants';
+import { setPostsTypeFilter, setSortedBy, setStatusFilter } from '../data';
 import { selectThreadFilters, selectThreadSorting } from '../data/selectors';
 import messages from './messages';
 
@@ -47,17 +49,17 @@ function PostFilterBar({
   const [isOpen, setOpen] = useState(false);
 
   const handleSortFilterChange = (event) => {
-    const currentType = currentFilters.allPosts;
+    const currentType = currentFilters.postType;
     const currentStatus = currentFilters.status;
     const {
       name,
       value,
     } = event.currentTarget;
     if (name === 'type') {
-      dispatch(setAllPostsTypeFilter(value));
+      dispatch(setPostsTypeFilter(value));
       if (
-        (value === AllPostsFilter.ALL_DISCUSSIONS && currentStatus === PostsStatusFilter.UNANSWERED)
-        || (value === AllPostsFilter.ALL_QUESTIONS && currentStatus === PostsStatusFilter.UNREAD)
+        (value === ThreadType.DISCUSSION && currentStatus === PostsStatusFilter.UNANSWERED)
+        || (value === ThreadType.QUESTION && currentStatus === PostsStatusFilter.UNREAD)
       ) {
         // You can't filter discussions by unanswered or questions by unread
         dispatch(setStatusFilter(PostsStatusFilter.ALL));
@@ -65,13 +67,13 @@ function PostFilterBar({
     }
     if (name === 'status') {
       dispatch(setStatusFilter(value));
-      if (value === PostsStatusFilter.UNANSWERED && currentType !== AllPostsFilter.ALL_QUESTIONS) {
+      if (value === PostsStatusFilter.UNANSWERED && currentType !== ThreadType.QUESTION) {
         // You can't filter discussions by unanswered so switch type to questions
-        dispatch(setAllPostsTypeFilter(AllPostsFilter.ALL_QUESTIONS));
+        dispatch(setPostsTypeFilter(ThreadType.QUESTION));
       }
-      if (value === PostsStatusFilter.UNREAD && currentType !== AllPostsFilter.ALL_DISCUSSIONS) {
+      if (value === PostsStatusFilter.UNREAD && currentType !== ThreadType.DISCUSSION) {
         // You can't filter questions by unread so switch type to discussion
-        dispatch(setAllPostsTypeFilter(AllPostsFilter.ALL_DISCUSSIONS));
+        dispatch(setPostsTypeFilter(ThreadType.DISCUSSION));
       }
     }
     if (name === 'sort') {
@@ -86,7 +88,7 @@ function PostFilterBar({
       iconWhenClosed={<Icon src={Sort} />}
       title={intl.formatMessage(messages.sortFilterStatus, {
         own: filterSelfPosts,
-        type: currentFilters.allPosts,
+        type: currentFilters.postType,
         sort: currentSorting,
         status: currentFilters.status,
       })}
@@ -97,26 +99,26 @@ function PostFilterBar({
         <Form.RadioSet
           name="type"
           className="d-flex flex-column list-group list-group-flush"
-          value={currentFilters.allPosts}
+          value={currentFilters.postType}
           onChange={handleSortFilterChange}
         >
           <ActionItem
             id="type-all"
             label={intl.formatMessage(messages.allPosts)}
-            value={AllPostsFilter.ALL_POSTS}
-            selected={currentFilters.allPosts}
+            value={ThreadType.ALL}
+            selected={currentFilters.postType}
           />
           <ActionItem
             id="type-discussions"
             label={intl.formatMessage(messages.filterDiscussions)}
-            value={AllPostsFilter.ALL_DISCUSSIONS}
-            selected={currentFilters.allPosts}
+            value={ThreadType.DISCUSSION}
+            selected={currentFilters.postType}
           />
           <ActionItem
             id="type-questions"
             label={intl.formatMessage(messages.filterQuestions)}
-            value={AllPostsFilter.ALL_QUESTIONS}
-            selected={currentFilters.allPosts}
+            value={ThreadType.QUESTION}
+            selected={currentFilters.postType}
           />
         </Form.RadioSet>
         <Form.RadioSet

--- a/src/discussions/posts/post-filter-bar/messages.js
+++ b/src/discussions/posts/post-filter-bar/messages.js
@@ -92,10 +92,10 @@ const messages = defineMessages({
       statusFollowing {followed}
       statusReported {reported}
       statusUnanswered {unanswered}
-    } {type, select, 
-      allPosts {posts} 
-      allDiscussions {discussions} 
-      allQuestions {questions}
+    } {type, select,  
+      discussion {discussions} 
+      question {questions}
+      all {posts}
      } by {sort, select,
         lastActivityAt {recent activity}
         commentCount {most activity}


### PR DESCRIPTION
Fixes an issue where filtering by post type wasn't working, and simplifies that code a bit.

The code was simply not passing along the post type filter. 

The issue with the `following` filter not working has to do with a bug in the backend, and it is fixed here: https://github.com/openedx/cs_comments_service/pull/375

**Test instructions**
Just test that filtering by discussions and questions works in all posts and my posts. 
