### PR TITLE
[BD-38] [TNL-8844] [BB-5014] Learners page to browse posts and comments

### DIFF
--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -135,6 +135,17 @@ export const LearnersOrdering = {
 };
 
 /**
+ * Enum for Learner content tabs
+ * @readonly
+ * @enum {string}
+ */
+export const LearnerTabs = {
+  POSTS: 'posts',
+  COMMENTS: 'comments',
+  RESPONSES: 'responses',
+};
+
+/**
  * Enum for discussion provider types supported by the MFE.
  * @type {{OPEN_EDX: string, LEGACY: string}}
  */
@@ -152,6 +163,11 @@ export const Routes = {
   LEARNERS: {
     PATH: `${BASE_PATH}/learners`,
     LEARNER: `${BASE_PATH}/learners/:learnerUsername`,
+    TABS: {
+      posts: `${BASE_PATH}/learners/:learnerUsername/${LearnerTabs.POSTS}`,
+      responses: `${BASE_PATH}/learners/:learnerUsername/${LearnerTabs.RESPONSES}`,
+      comments: `${BASE_PATH}/learners/:learnerUsername/${LearnerTabs.COMMENTS}`,
+    },
   },
   POSTS: {
     PATH: `${BASE_PATH}/topics/:topicId`,

--- a/src/discussions/comments/comment/Comment.jsx
+++ b/src/discussions/comments/comment/Comment.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
+import classNames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
@@ -21,6 +22,7 @@ import Reply from './Reply';
 function Comment({
   postType,
   comment,
+  showFullThread = true,
   intl,
 }) {
   const dispatch = useDispatch();
@@ -34,7 +36,7 @@ function Comment({
   const currentPage = useSelector(selectCommentCurrentPage(comment.id));
   useEffect(() => {
     // If the comment has a parent comment, it won't have any children, so don't fetch them.
-    if (hasChildren && !currentPage) {
+    if (hasChildren && !currentPage && showFullThread) {
       dispatch(fetchCommentResponses(comment.id, { page: 1 }));
     }
   }, [comment.id]);
@@ -50,9 +52,10 @@ function Comment({
   const handleLoadMoreComments = () => (
     dispatch(fetchCommentResponses(comment.id, { page: currentPage + 1 }))
   );
+  const commentClasses = classNames('d-flex flex-column card', { 'my-3': showFullThread });
 
   return (
-    <div className="discussion-comment d-flex flex-column card my-3" data-testid={`comment-${comment.id}`}>
+    <div className={commentClasses} data-testid={`comment-${comment.id}`}>
       <DeleteConfirmation
         isOpen={isDeleting}
         title={intl.formatMessage(messages.deleteResponseTitle)}
@@ -100,7 +103,7 @@ function Comment({
             {intl.formatMessage(messages.loadMoreResponses)}
           </Button>
         )}
-        {!isNested
+        {!isNested && showFullThread
           && (
             isReplying
               ? (
@@ -126,7 +129,12 @@ function Comment({
 Comment.propTypes = {
   postType: PropTypes.oneOf(['discussion', 'question']).isRequired,
   comment: commentShape.isRequired,
+  showFullThread: PropTypes.bool,
   intl: intlShape.isRequired,
+};
+
+Comment.defaultProps = {
+  showFullThread: true,
 };
 
 export default injectIntl(Comment);

--- a/src/discussions/comments/data/api.js
+++ b/src/discussions/comments/data/api.js
@@ -117,3 +117,28 @@ export async function deleteComment(commentId) {
   await getAuthenticatedHttpClient()
     .delete(url);
 }
+
+/**
+ * Get the comments by a specific user in a course's discussions
+ *
+ * comments = responses + comments in the UI
+ *
+ * @param {string} courseId Course ID for the course
+ * @param {string} username Username of the user
+ * @returns API response in the format
+ *  {
+ *    results: [array of comments],
+ *    pagination: {count, num_pages, next, previous}
+ *  }
+
+ */
+export async function getUserComments(courseId, username) {
+  const { data } = await getAuthenticatedHttpClient()
+    .get(commentsApiUrl, {
+      params: {
+        course_id: courseId,
+        username,
+      },
+    });
+  return data;
+}

--- a/src/discussions/discussions-home/DiscussionContent.jsx
+++ b/src/discussions/discussions-home/DiscussionContent.jsx
@@ -6,6 +6,7 @@ import { Route, Switch } from 'react-router';
 import { Routes } from '../../data/constants';
 import { CommentsView } from '../comments';
 import { useContainerSizeForParent } from '../data/hooks';
+import { LearnersContentView } from '../learners';
 import { PostEditor } from '../posts';
 
 export default function DiscussionContent() {
@@ -27,6 +28,9 @@ export default function DiscussionContent() {
             </Route>
             <Route path={Routes.COMMENTS.PATH}>
               <CommentsView />
+            </Route>
+            <Route path={Routes.LEARNERS.LEARNER}>
+              <LearnersContentView />
             </Route>
           </Switch>
         )}

--- a/src/discussions/learners/LearnersContentView.jsx
+++ b/src/discussions/learners/LearnersContentView.jsx
@@ -1,0 +1,110 @@
+import React, { useContext } from 'react';
+
+import classNames from 'classnames';
+import { useSelector } from 'react-redux';
+import {
+  generatePath, NavLink, Redirect, Route, Switch,
+} from 'react-router-dom';
+
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import {
+  Avatar, ButtonGroup, Card, Icon, IconButton, Spinner,
+} from '@edx/paragon';
+import { MoreHoriz, Report } from '@edx/paragon/icons';
+
+import { LearnerTabs, RequestStatus, Routes } from '../../data/constants';
+import { DiscussionContext } from '../common/context';
+import {
+  learnersLoadingStatus, selectLearner, selectLearnerAvatar, selectLearnerProfile,
+} from './data/selectors';
+import CommentsTabContent from './learner/CommentsTabContent';
+import PostsTabContent from './learner/PostsTabContent';
+import messages from './messages';
+
+function LearnersContentView({ intl }) {
+  const { courseId, learnerUsername } = useContext(DiscussionContext);
+  const params = { courseId, learnerUsername };
+  const apiStatus = useSelector(learnersLoadingStatus());
+  const learner = useSelector(selectLearner(learnerUsername));
+  const profile = useSelector(selectLearnerProfile(learnerUsername));
+  const avatar = useSelector(selectLearnerAvatar(learnerUsername));
+
+  const activeTabClass = (active) => classNames('btn', { 'btn-primary': active, 'btn-outline-primary': !active });
+
+  return (
+    <div className="learner-content d-flex flex-column">
+      <Card>
+        <Card.Body>
+          <div className="d-flex flex-row align-items-center m-3">
+            <Avatar src={avatar} alt={learnerUsername} />
+            <span className="font-weight-bold mx-3">
+              {profile.username}
+            </span>
+            <div className="ml-auto">
+              <IconButton iconAs={Icon} src={MoreHoriz} alt="Options" />
+            </div>
+          </div>
+        </Card.Body>
+        <Card.Footer className="pb-0 bg-light-200 justify-content-center">
+          <ButtonGroup className="my-2">
+            <NavLink
+              className={activeTabClass}
+              to={generatePath(Routes.LEARNERS.TABS.posts, params)}
+            >
+              {intl.formatMessage(messages.postsTab)} <span className="ml-3">{learner.threads}</span>
+              {
+                learner.activeFlags ? (
+                  <span className="ml-3">
+                    <Icon src={Report} />
+                  </span>
+                ) : null
+              }
+            </NavLink>
+            <NavLink
+              className={activeTabClass}
+              to={generatePath(Routes.LEARNERS.TABS.responses, params)}
+            >
+              {intl.formatMessage(messages.responsesTab)} <span className="ml-3">{learner.responses}</span>
+            </NavLink>
+            <NavLink
+              className={activeTabClass}
+              to={generatePath(Routes.LEARNERS.TABS.comments, params)}
+            >
+              {intl.formatMessage(messages.commentsTab)} <span className="ml-3">{learner.replies}</span>
+            </NavLink>
+          </ButtonGroup>
+        </Card.Footer>
+      </Card>
+
+      <Switch>
+        <Route path={Routes.LEARNERS.LEARNER} exact>
+          <Redirect to={generatePath(Routes.LEARNERS.TABS.posts, params)} />
+        </Route>
+        <Route
+          path={Routes.LEARNERS.TABS.posts}
+          component={PostsTabContent}
+        />
+        <Route path={Routes.LEARNERS.TABS.responses}>
+          <CommentsTabContent tab={LearnerTabs.RESPONSES} />
+        </Route>
+        <Route path={Routes.LEARNERS.TABS.comments}>
+          <CommentsTabContent tab={LearnerTabs.COMMENTS} />
+        </Route>
+      </Switch>
+
+      {
+        apiStatus === RequestStatus.IN_PROGRESS && (
+          <div className="my-3 text-center">
+            <Spinner animation="border" className="mie-3" />
+          </div>
+        )
+      }
+    </div>
+  );
+}
+
+LearnersContentView.propTypes = {
+  intl: intlShape.isRequired,
+};
+
+export default injectIntl(LearnersContentView);

--- a/src/discussions/learners/data/api.js
+++ b/src/discussions/learners/data/api.js
@@ -10,6 +10,8 @@ const apiBaseUrl = getConfig().LMS_BASE_URL;
 
 export const coursesApiUrl = `${apiBaseUrl}/api/discussion/v1/courses/`;
 export const userProfileApiUrl = `${apiBaseUrl}/api/user/v1/accounts`;
+export const postsApiUrl = `${apiBaseUrl}/api/discussion/v1/threads/`;
+export const commentsApiUrl = `${apiBaseUrl}/api/discussion/v1/comments/`;
 
 /**
  * Fetches all the learners in the given course.

--- a/src/discussions/learners/data/selectors.js
+++ b/src/discussions/learners/data/selectors.js
@@ -2,6 +2,8 @@
 
 import { createSelector } from '@reduxjs/toolkit';
 
+import { LearnerTabs } from '../../../data/constants';
+
 export const selectAllLearners = createSelector(
   state => state.learners,
   learners => learners.learners,
@@ -22,3 +24,26 @@ export const selectLearnerAvatar = author => state => (
 export const selectLearnerLastLogin = author => state => (
   state.learners.learnerProfiles[author]?.lastLogin
 );
+
+export const selectLearner = (username) => createSelector(
+  [selectAllLearners],
+  learners => learners.find(l => l.username === username) || {},
+);
+
+export const selectLearnerProfile = (username) => state => state.learners.learnerProfiles[username] || {};
+
+export const selectUserPosts = username => state => state.learners.postsByUser[username] || [];
+
+/**
+ * Get the comments of a post.
+ * @param {string} username Username of the learner to get the comments of
+ * @param {LearnerTabs} commentType Type of comments to get
+ * @returns {Array} Array of comments
+ */
+export const selectUserComments = (username, commentType) => state => (
+  commentType === LearnerTabs.COMMENTS
+    ? (state.learners.commentsByUser[username] || []).filter(c => c.parentId)
+    : (state.learners.commentsByUser[username] || []).filter(c => !c.parentId)
+);
+
+export const flaggedCommentCount = (username) => state => state.learners.flaggedCommentsByUser[username] || 0;

--- a/src/discussions/learners/data/slices.js
+++ b/src/discussions/learners/data/slices.js
@@ -18,6 +18,18 @@ const learnersSlice = createSlice({
     totalPages: null,
     totalLearners: null,
     sortedBy: LearnersOrdering.BY_LAST_ACTIVITY,
+    commentsByUser: {
+      // Map username to comments
+    },
+    postsByUser: {
+      // Map username to posts
+    },
+    commentCountByUser: {
+      // Map of username and comment count
+    },
+    postCountByUser: {
+      // Map of username and post count
+    },
   },
   reducers: {
     fetchLearnersSuccess: (state, { payload }) => {
@@ -44,6 +56,29 @@ const learnersSlice = createSlice({
       state.sortedBy = payload;
       state.pages = [];
     },
+    fetchUserCommentsRequest: (state) => {
+      state.status = RequestStatus.IN_PROGRESS;
+    },
+    fetchUserCommentsSuccess: (state, { payload }) => {
+      state.commentsByUser[payload.username] = payload.comments;
+      state.commentCountByUser[payload.username] = payload.pagination.count;
+      state.status = RequestStatus.SUCCESS;
+    },
+    fetchUserCommentsDenied: (state) => {
+      state.status = RequestStatus.DENIED;
+    },
+    fetchUserPostsRequest: (state) => {
+      state.status = RequestStatus.IN_PROGRESS;
+    },
+    fetchUserPostsSuccess: (state, { payload }) => {
+      state.postsByUser[payload.username] = payload.posts;
+      state.postCountByUser[payload.username] = payload.pagination.count;
+      state.status = RequestStatus.SUCCESS;
+    },
+    fetchUserPostsDenied: (state) => {
+      state.status = RequestStatus.DENIED;
+    },
+
   },
 });
 
@@ -53,6 +88,13 @@ export const {
   fetchLearnersSuccess,
   fetchLearnersDenied,
   setSortedBy,
+  fetchUserCommentsRequest,
+  fetchUserCommentsDenied,
+  fetchUserCommentsSuccess,
+  fetchUserPostsRequest,
+  fetchUserPostsDenied,
+  fetchUserPostsSuccess,
+
 } = learnersSlice.actions;
 
 export const learnersReducer = learnersSlice.reducer;

--- a/src/discussions/learners/data/thunks.js
+++ b/src/discussions/learners/data/thunks.js
@@ -2,6 +2,8 @@
 import { camelCaseObject } from '@edx/frontend-platform';
 import { logError } from '@edx/frontend-platform/logging';
 
+import { getUserComments } from '../../comments/data/api';
+import { getUserPosts } from '../../posts/data/api';
 import { getHttpErrorStatus } from '../../utils';
 import {
   getLearners, getUserProfiles,
@@ -11,6 +13,12 @@ import {
   fetchLearnersFailed,
   fetchLearnersRequest,
   fetchLearnersSuccess,
+  fetchUserCommentsDenied,
+  fetchUserCommentsRequest,
+  fetchUserCommentsSuccess,
+  fetchUserPostsDenied,
+  fetchUserPostsRequest,
+  fetchUserPostsSuccess,
 } from './slices';
 
 /**
@@ -45,6 +53,56 @@ export function fetchLearners(courseId, {
         dispatch(fetchLearnersFailed());
       }
       logError(error);
+    }
+  };
+}
+
+/**
+ * Fetch the comments of a user for the specified course and update the
+ * redux state
+ *
+ * @param {string} courseId Course ID of the course eg., course-v1:X+Y+Z
+ * @param {string} username Username of the learner
+ * @returns a promise that will update the state with the learner's comments
+ */
+export function fetchUserComments(courseId, username) {
+  return async (dispatch) => {
+    try {
+      dispatch(fetchUserCommentsRequest());
+      const data = await getUserComments(courseId, username);
+      dispatch(fetchUserCommentsSuccess(camelCaseObject({
+        username,
+        comments: data.results,
+        pagination: data.pagination,
+      })));
+    } catch (error) {
+      if (getHttpErrorStatus(error) === 403) {
+        dispatch(fetchUserCommentsDenied());
+      }
+    }
+  };
+}
+
+/**
+ * Fetch the posts of a user for the specified course and update the
+ * redux state
+ *
+ * @param {sting} courseId Course ID of the course eg., course-v1:X+Y+Z
+ * @param {string} username Username of the learner
+ * @returns a promise that will update the state with the learner's posts
+ */
+export function fetchUserPosts(courseId, username) {
+  return async (dispatch) => {
+    try {
+      dispatch(fetchUserPostsRequest());
+      const data = await getUserPosts(courseId, username, true);
+      dispatch(fetchUserPostsSuccess(camelCaseObject({
+        username, posts: data.results, pagination: data.pagination,
+      })));
+    } catch (error) {
+      if (getHttpErrorStatus(error) === 403) {
+        dispatch(fetchUserPostsDenied());
+      }
     }
   };
 }

--- a/src/discussions/learners/index.js
+++ b/src/discussions/learners/index.js
@@ -1,2 +1,3 @@
 /* eslint-disable import/prefer-default-export */
+export { default as LearnersContentView } from './LearnersContentView';
 export { default as LearnersView } from './LearnersView';

--- a/src/discussions/learners/learner/CommentsTabContent.jsx
+++ b/src/discussions/learners/learner/CommentsTabContent.jsx
@@ -1,0 +1,33 @@
+import React, { useContext, useEffect } from 'react';
+import PropType from 'prop-types';
+
+import { useDispatch, useSelector } from 'react-redux';
+
+import Comment from '../../comments/comment/Comment';
+import { DiscussionContext } from '../../common/context';
+import { selectUserComments } from '../data/selectors';
+import { fetchUserComments } from '../data/thunks';
+
+function CommentsTabContent({ tab }) {
+  const dispatch = useDispatch();
+  const { courseId, learnerUsername: username } = useContext(DiscussionContext);
+  const comments = useSelector(selectUserComments(username, tab));
+
+  useEffect(() => {
+    dispatch(fetchUserComments(courseId, username));
+  }, [courseId, username]);
+
+  return (
+    <div className="mx-3 my-3">
+      {comments.map(
+        (comment) => <Comment key={comment.id} comment={comment} showFullThread={false} postType="discussion" />,
+      )}
+    </div>
+  );
+}
+
+CommentsTabContent.propTypes = {
+  tab: PropType.string.isRequired,
+};
+
+export default CommentsTabContent;

--- a/src/discussions/learners/learner/LearnerFooter.jsx
+++ b/src/discussions/learners/learner/LearnerFooter.jsx
@@ -4,10 +4,7 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import {
   Icon, OverlayTrigger, Tooltip,
 } from '@edx/paragon';
-import {
-  Edit, Error,
-  QuestionAnswer,
-} from '@edx/paragon/icons';
+import { Edit, QuestionAnswer, Report } from '@edx/paragon/icons';
 
 import messages from './messages';
 import { learnerShape } from './proptypes';
@@ -48,7 +45,7 @@ function LearnerFooter({
             )}
           >
             <div className="d-flex">
-              <Icon src={Error} className="mx-2 my-0 text-danger" />
+              <Icon src={Report} className="mx-2 my-0 text-danger" />
               <span style={{ minWidth: '2rem' }}>
                 {activeFlags} {Boolean(inactiveFlags) && `/ ${inactiveFlags}`}
               </span>

--- a/src/discussions/learners/learner/PostsTabContent.jsx
+++ b/src/discussions/learners/learner/PostsTabContent.jsx
@@ -1,0 +1,36 @@
+import React, { useContext, useEffect } from 'react';
+
+import { useDispatch, useSelector } from 'react-redux';
+
+import { DiscussionContext } from '../../common/context';
+import { Post } from '../../posts';
+import { selectUserPosts } from '../data/selectors';
+import { fetchUserPosts } from '../data/thunks';
+
+function PostsTabContent() {
+  const dispatch = useDispatch();
+  const { courseId, learnerUsername: username } = useContext(DiscussionContext);
+  const posts = useSelector(selectUserPosts(username));
+
+  useEffect(() => {
+    dispatch(fetchUserPosts(courseId, username));
+  }, [courseId, username]);
+
+  return (
+    <div className="d-flex flex-column my-3 mx-3 bg-white rounded">
+      {posts.map((post) => (
+        <div
+          data-testid="post"
+          key={post.id}
+          className="px-3 pb-3 border-bottom border-light-500"
+        >
+          <Post post={post} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+PostsTabContent.propTypes = {};
+
+export default PostsTabContent;

--- a/src/discussions/learners/messages.js
+++ b/src/discussions/learners/messages.js
@@ -1,0 +1,21 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  postsTab: {
+    id: 'discussions.learner.tab.posts',
+    defaultMessage: 'Posts',
+    description: "Label for the learner's posts tab",
+  },
+  responsesTab: {
+    id: 'discussions.learner.tab.responses',
+    defaultMessage: 'Responses',
+    description: "Label for the learner's responses tab",
+  },
+  commentsTab: {
+    id: 'discussions.learner.tab.comments',
+    defaultMessage: 'Comments',
+    description: "Label for the learner's comments tab",
+  },
+});
+
+export default messages;

--- a/src/discussions/posts/data/api.js
+++ b/src/discussions/posts/data/api.js
@@ -196,3 +196,20 @@ export async function uploadFile(blob, filename, courseId, threadKey) {
   }
   return data;
 }
+
+/**
+ * Get the posts by a specific user in a course's discussions
+ *
+ * @param {string} courseId Course ID of the course
+ * @param {string} username Username of the user
+ * @returns API Response object in the format
+ *  {
+ *    results: [array of posts],
+ *    pagination: {count, num_pages, next, previous}
+ *  }
+ */
+export async function getUserPosts(courseId, username) {
+  const { data } = await getAuthenticatedHttpClient()
+    .get(threadsApiUrl, { params: { course_id: courseId, author: username } });
+  return data;
+}


### PR DESCRIPTION
### Description

This PR implements the content area for the Learners pages. It fetches the threads and comments of the selected user and renders them into 3 tabs
- Posts - `threads` API
- Responses - `comments` API items which are not a child of another comment
- Comments - `comments` API items which are children of other comments

### Testing Instructions

1. Enable learners tab by setting the Course Waffle Flag - `discussions.enable_learners_tab_in_discussions_mfe` for your test course
2. Open the Learners page by clicking on the "Learners" button on the top
3. Now select a specific learner in list to view their contributions
4. Switch between the Posts, Comments and Responses tab to see each kind of posts separately.

### Supporting information

1. JIRA Ticket - https://openedx.atlassian.net/browse/TNL-8844
2. Figma Design - https://www.figma.com/file/LVFnO9oRHYiamoicZuXDAC/Discussion-page?node-id=4066%3A374709n (scroll up for the new design)
