### PR TITLE
fix: clear saved post or comment on submit [BD-38] [TNL-9630] 

### DIFF
--- a/src/discussions/comments/messages.js
+++ b/src/discussions/comments/messages.js
@@ -99,6 +99,10 @@ const messages = defineMessages({
     id: 'discussions.editor.submit',
     defaultMessage: 'Submit',
   },
+  submitting: {
+    id: 'discussions.editor.submitting',
+    defaultMessage: 'Submitting',
+  },
   cancel: {
     id: 'discussions.editor.cancel',
     defaultMessage: 'Cancel',

--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
 import { Formik } from 'formik';
@@ -62,6 +62,7 @@ function PostEditor({
   editExisting,
 }) {
   const dispatch = useDispatch();
+  const editorRef = useRef(null);
   const [submitting, dispatchSubmit] = useDispatchWithState();
   const history = useHistory();
   const location = useLocation();
@@ -131,6 +132,10 @@ function PostEditor({
         anonymousToPeers: allowAnonymousToPeers ? values.anonymousToPeers : undefined,
         cohort,
       }));
+    }
+    /* istanbul ignore if: TinyMCE is mocked so this cannot be easily tested */
+    if (editorRef.current) {
+      editorRef.current.plugins.autosave.removeDraft();
     }
     hideEditor();
   };
@@ -304,6 +309,12 @@ function PostEditor({
           </Form.Group>
           <div className="py-2">
             <TinyMCEEditor
+              onInit={
+                /* istanbul ignore next: TinyMCE is mocked so this cannot be easily tested */
+                (_, editor) => {
+                  editorRef.current = editor;
+                }
+              }
               id={postEditorId}
               value={values.comment}
               onEditorChange={formikCompatibleHandler(handleChange, 'comment')}


### PR DESCRIPTION
If a post or comment has been submitted, clear it from autosaved drafts so that it doesn't show up anymore.

**Test instructions**
- Without checking out this PR do the following:
  - Create a new post, and type some text. 
  - Cancel the post, and add a new one again, you should see the saved post text.
  - Refresh the page, you should see the saved text.
  - Submit the post, and try adding a new post, you will still see the saved post. 
  - Repeat the above with comments and replies
- After checking out this PR try the above again, and now the text should be retained until the post or comment is saved. Once it's saved the text should no longer be saved. 