### PR TITLE
fix : [BB-5597][TNL-9618] [BD-38] text leaking out from post summary

### DIFF
--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -60,7 +60,7 @@ function Post({
         <AlertBanner postType={post.type} content={post} />
       </div>
       <PostHeader post={post} actionHandlers={actionHandlers} />
-      <div className="d-flex my-2">
+      <div className="d-flex my-2 text-break">
         {/* eslint-disable-next-line react/no-danger */}
         <div dangerouslySetInnerHTML={{ __html: post.renderedBody }} />
       </div>

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -77,7 +77,7 @@ function PostLink({
             </div>
           </div>
           {/* eslint-disable-next-line react/no-danger */}
-          <div dangerouslySetInnerHTML={{ __html: post.previewBody }} />
+          <div className="text-truncate" dangerouslySetInnerHTML={{ __html: post.previewBody }} />
           <PostFooter post={post} preview intl={intl} />
         </div>
       </div>


### PR DESCRIPTION
Fix text leaking out from post summary in case of very long word such , it should fit inside the element.
`verylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongword`
Like 
![image](https://user-images.githubusercontent.com/3465029/157721274-20926ad2-c3c4-43b3-bc82-4a67b6df4d95.png)


**Test instruction**
- Create a new post with very long word.
- Save it 
- Make sure his summary (or preview) fit inside the post element.