### PR TITLE
fix: related link for posts should open in top frame [TNL-9647] [BD-38]

### DIFF
--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -67,7 +67,12 @@ function Post({
       {topicContext && topic && (
         <div className="border p-3 rounded mb-3 mt-2 align-self-start">
           {intl.formatMessage(messages.relatedTo)}{' '}
-          <Hyperlink destination={topicContext.unitLink}>{`${getTopicCategoryName(topic)} / ${topic.name}`}</Hyperlink>
+          <Hyperlink
+            destination={topicContext.unitLink}
+            target="_top"
+          >
+            {`${getTopicCategoryName(topic)} / ${topic.name}`}
+          </Hyperlink>
         </div>
       )}
       <PostFooter post={post} preview={preview} />


### PR DESCRIPTION
Opening the related link in the 'top' frame avoids an issue where the LMS
attempts to load the learning MFE in the discussions tab.
