### PR TITLE
fix: send request to fetch discussion settings only for admins

### DIFF
--- a/src/discussions/data/thunks.js
+++ b/src/discussions/data/thunks.js
@@ -18,7 +18,7 @@ export function fetchCourseConfig(courseId) {
     try {
       dispatch(fetchConfigRequest());
       const config = await getDiscussionsConfig(courseId);
-      if (config.user_is_privileged) {
+      if (config.is_user_admin) {
         const settings = await getDiscussionsSettings(courseId);
         Object.assign(config, { settings });
       }


### PR DESCRIPTION
## Ticket: [TNL-9731](https://openedx.atlassian.net/browse/TNL-9731)

Send a request to fetch discussion settings only for admins. UI was breaking if a request is sent for other roles.