### PR TITLE
fix: UI style update of answered and endorsed banners

### DIFF
--- a/src/discussions/common/AlertBanner.jsx
+++ b/src/discussions/common/AlertBanner.jsx
@@ -33,7 +33,7 @@ function AlertBanner({
       {content.endorsed && (
         <Alert
           variant="plain"
-          className={`p-3 m-0 shadow-none ${classes}`}
+          className={`p-3 m-0 align-items-center shadow-none ${classes}`}
           style={{ borderRadius: '0.375rem 0.375rem 0 0' }}
           icon={iconClass}
         >


### PR DESCRIPTION
## Ticket: [TNL-9704](https://openedx.atlassian.net/browse/TNL-9704)

Fixed UI style of answered and endorsed banners on top of response
<img width="1114" alt="Screenshot 2022-03-22 at 6 04 10 PM" src="https://user-images.githubusercontent.com/51022010/159489190-f1182f7a-2ae7-4795-bb97-a4a80a6b4893.png">

