### PR TITLE
fix: spacing between answered and reported markers

### DIFF
--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -59,7 +59,7 @@ function PostLink({
                 </div>
                 {showAnsweredBadge
                   && (
-                    <div className="ml-auto">
+                    <div className="ml-auto mr-2">
                       <Badge variant="success">{intl.formatMessage(messages.answered)}</Badge>
                     </div>
                   )}


### PR DESCRIPTION
## Ticket: [TNL-9745](https://openedx.atlassian.net/browse/TNL-9745)

Added space between 'Answered' and 'Reported' markers.
<img width="476" alt="Screenshot 2022-03-22 at 7 13 05 PM" src="https://user-images.githubusercontent.com/51022010/159501614-0ffe0b78-ec90-44eb-a09d-4ba84d946d1d.png">

