### PR TITLE
fix: answered marker not right aligned correctly

### DIFF
--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -59,7 +59,7 @@ function PostLink({
                 </div>
                 {showAnsweredBadge
                   && (
-                    <div className="ml-auto">
+                    <div className="ml-auto mr-2">
                       <Badge variant="success">{intl.formatMessage(messages.answered)}</Badge>
                     </div>
                   )}

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -59,13 +59,13 @@ function PostLink({
                 </div>
                 {showAnsweredBadge
                   && (
-                    <div className="ml-auto mr-2">
+                    <div className="ml-auto">
                       <Badge variant="success">{intl.formatMessage(messages.answered)}</Badge>
                     </div>
                   )}
                 {post.abuseFlagged
                   && (
-                    <div className="ml-auto">
+                    <div className={showAnsweredBadge ? 'ml-2' : 'ml-auto'}>
                       <Badge variant="danger" data-testid="reported-post">{intl.formatMessage(messages.contentReported)}</Badge>
                     </div>
                   )}


### PR DESCRIPTION
## Ticket: [TNL-9745](https://openedx.atlassian.net/browse/TNL-9745)

Answered marker is right aligned.
<img width="484" alt="Screenshot 2022-03-24 at 5 28 18 PM" src="https://user-images.githubusercontent.com/51022010/159916232-9d35a7ae-84f8-4847-bc32-f5c36369cc7d.png">

