### PR TITLE
fix: align empty state in the center and auto-grow container [BD-38] [TNL-9684] [TNL-9627]

### DIFF
--- a/src/discussions/discussions-home/DiscussionsHome.jsx
+++ b/src/discussions/discussions-home/DiscussionsHome.jsx
@@ -77,7 +77,7 @@ export default function DiscussionsHome() {
           path={[Routes.POSTS.PATH, Routes.TOPICS.CATEGORY]}
           component={provider === DiscussionProvider.LEGACY ? LegacyBreadcrumbMenu : BreadcrumbMenu}
         />
-        <div className="d-flex flex-row overflow-hidden">
+        <div className="d-flex flex-row overflow-hidden flex-grow-1">
           <DiscussionSidebar displaySidebar={displaySidebar} />
           {displayContentArea && <DiscussionContent />}
           {!displayContentArea && (

--- a/src/discussions/empty-posts/EmptyPage.jsx
+++ b/src/discussions/empty-posts/EmptyPage.jsx
@@ -15,20 +15,22 @@ function EmptyPage({
   fullWidth = false,
 }) {
   const containerClasses = classNames(
-    'align-content-start align-items-center d-flex w-100 flex-column pt-5',
+    'justify-content-center align-items-center d-flex w-100 flex-column pt-5',
     { 'bg-light-300': !fullWidth },
   );
 
   return (
     <div className={containerClasses}>
-      <EmptyIcon />
-      <h3 className="pt-3">{title}</h3>
-      {subTitle && <p className="pb-2">{subTitle}</p>}
-      {action && actionText && (
-        <Button onClick={action} variant="outline-dark">
-          {actionText}
-        </Button>
-      )}
+      <div className="d-flex flex-column align-items-center">
+        <EmptyIcon />
+        <h3 className="pt-3">{title}</h3>
+        {subTitle && <p className="pb-2">{subTitle}</p>}
+        {action && actionText && (
+          <Button onClick={action} variant="outline-dark">
+            {actionText}
+          </Button>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Makes the empty page illustration be centrally aligned on the page.

Makes the content container expand to take the full vertical space.

**Tickets:**
- https://openedx.atlassian.net/browse/TNL-9627
- https://openedx.atlassian.net/browse/TNL-9684

![Screenshot 2022-03-25 at 03-55-55 Discussions localhost](https://user-images.githubusercontent.com/118837/160051379-ecf5023d-8695-40fb-8594-e291ceb5a470.png)


