### PR TITLE
fix: update post when comment is marked as answer; reload topics on open [BD-38] [TNL-9646] [TNL-9703]

### DIFF
--- a/src/discussions/comments/comment/Comment.jsx
+++ b/src/discussions/comments/comment/Comment.jsx
@@ -8,6 +8,7 @@ import { Button, useToggle } from '@edx/paragon';
 
 import { ContentActions } from '../../../data/constants';
 import { AlertBanner, DeleteConfirmation } from '../../common';
+import { fetchThread } from '../../posts/data/thunks';
 import CommentIcons from '../comment-icons/CommentIcons';
 import { selectCommentCurrentPage, selectCommentHasMorePages, selectCommentResponses } from '../data/selectors';
 import { editComment, fetchCommentResponses, removeComment } from '../data/thunks';
@@ -39,7 +40,10 @@ function Comment({
   }, [comment.id]);
   const actionHandlers = {
     [ContentActions.EDIT_CONTENT]: () => setEditing(true),
-    [ContentActions.ENDORSE]: () => dispatch(editComment(comment.id, { endorsed: !comment.endorsed })),
+    [ContentActions.ENDORSE]: async () => {
+      await dispatch(editComment(comment.id, { endorsed: !comment.endorsed }));
+      await dispatch(fetchThread(comment.threadId));
+    },
     [ContentActions.DELETE]: showDeleteConfirmation,
     [ContentActions.REPORT]: () => dispatch(editComment(comment.id, { flagged: !comment.abuseFlagged })),
   };

--- a/src/discussions/topics/TopicsView.jsx
+++ b/src/discussions/topics/TopicsView.jsx
@@ -1,12 +1,14 @@
-import React from 'react';
+import React, { useContext, useEffect } from 'react';
 
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router';
 
 import { DiscussionProvider } from '../../data/constants';
 import { selectSequences } from '../../data/selectors';
+import { DiscussionContext } from '../common/context';
 import { selectDiscussionProvider } from '../data/selectors';
 import { selectCategories, selectNonCoursewareTopics, selectTopicFilter } from './data/selectors';
+import { fetchCourseTopics } from './data/thunks';
 import LegacyTopicGroup from './topic-group/LegacyTopicGroup';
 import Topic from './topic-group/topic/Topic';
 import TopicGroup from './topic-group/TopicGroup';
@@ -57,6 +59,14 @@ function LegacyCoursewareTopics() {
 
 function TopicsView() {
   const provider = useSelector(selectDiscussionProvider);
+  const { courseId } = useContext(DiscussionContext);
+  const dispatch = useDispatch();
+  useEffect(() => {
+    // Don't load till the provider information is available
+    if (provider) {
+      dispatch(fetchCourseTopics(courseId));
+    }
+  }, [provider]);
 
   return (
     <div


### PR DESCRIPTION
When a comment is marked as an answer, refresh the post it's in so the answered tag appears.
When navigating to the post tab, refresh the topic list.

https://user-images.githubusercontent.com/118837/160101466-5e47cc4c-80e0-4110-b7e1-15366cca125e.mp4


