### PR TITLE
fix: removed edit reason code

### DIFF
--- a/src/discussions/posts/data/api.js
+++ b/src/discussions/posts/data/api.js
@@ -143,7 +143,6 @@ export async function updateThread(threadId, {
   following,
   closed,
   pinned,
-  editReasonCode,
 } = {}) {
   const url = `${threadsApiUrl}${threadId}/`;
   const patchData = snakeCaseObject({
@@ -157,7 +156,6 @@ export async function updateThread(threadId, {
     following,
     closed,
     pinned,
-    editReasonCode,
   });
   const { data } = await getAuthenticatedHttpClient()
     .patch(url, patchData, { headers: { 'Content-Type': 'application/merge-patch+json' } });


### PR DESCRIPTION
- TNL TICKET: https://openedx.atlassian.net/browse/TNL-9742

The user was unable to edit the already added post. due to reason code field going in the payload. that has been removed for getting fix.