### PR TITLE
fix: UI adjustments to post summary and post details

### DIFF
--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -69,6 +69,16 @@ export const RequestStatus = {
 };
 
 /**
+ * Enum for author label and avatar border color classes.
+ * @readonly
+ * @enum {string}
+ */
+export const ColorClasses = {
+  Staff: 'warning-700',
+  'Community TA': 'success-700',
+};
+
+/**
  * Enum for thread ordering.
  * @readonly
  * @enum {string}

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -73,7 +73,7 @@ export const RequestStatus = {
  * @readonly
  * @enum {string}
  */
-export const ColorClasses = {
+export const AvatarBorderAndLabelTextColors = {
   Staff: 'warning-700',
   'Community TA': 'success-700',
 };

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -73,7 +73,7 @@ export const RequestStatus = {
  * @readonly
  * @enum {string}
  */
-export const AvatarBorderAndLabelTextColors = {
+export const AvatarBorderAndLabelColors = {
   Staff: 'warning-700',
   'Community TA': 'success-700',
 };

--- a/src/discussions/comments/comment/CommentHeader.jsx
+++ b/src/discussions/comments/comment/CommentHeader.jsx
@@ -19,7 +19,7 @@ function CommentHeader({
   actionHandlers,
 }) {
   const authorAvatars = useSelector(selectAuthorAvatars(comment.author));
-  const colorClass = ColorClasses[comment.authorLabel] || '';
+  const colorClass = ColorClasses[comment.authorLabel];
   return (
     <div className="d-flex flex-row justify-content-between">
       <div className="align-items-center d-flex flex-row">

--- a/src/discussions/comments/comment/CommentHeader.jsx
+++ b/src/discussions/comments/comment/CommentHeader.jsx
@@ -7,7 +7,7 @@ import { injectIntl } from '@edx/frontend-platform/i18n';
 import { Avatar, Icon } from '@edx/paragon';
 import { CheckCircle, Verified } from '@edx/paragon/icons';
 
-import { AvatarBorderAndLabelTextColors, ThreadType } from '../../../data/constants';
+import { AvatarBorderAndLabelColors, ThreadType } from '../../../data/constants';
 import { AuthorLabel } from '../../common';
 import ActionsDropdown from '../../common/ActionsDropdown';
 import { selectAuthorAvatars } from '../../posts/data/selectors';
@@ -19,7 +19,7 @@ function CommentHeader({
   actionHandlers,
 }) {
   const authorAvatars = useSelector(selectAuthorAvatars(comment.author));
-  const colorClass = AvatarBorderAndLabelTextColors[comment.authorLabel];
+  const colorClass = AvatarBorderAndLabelColors[comment.authorLabel];
   return (
     <div className="d-flex flex-row justify-content-between">
       <div className="align-items-center d-flex flex-row">

--- a/src/discussions/comments/comment/CommentHeader.jsx
+++ b/src/discussions/comments/comment/CommentHeader.jsx
@@ -7,7 +7,7 @@ import { injectIntl } from '@edx/frontend-platform/i18n';
 import { Avatar, Icon } from '@edx/paragon';
 import { CheckCircle, Verified } from '@edx/paragon/icons';
 
-import { ThreadType } from '../../../data/constants';
+import { ColorClasses, ThreadType } from '../../../data/constants';
 import { AuthorLabel } from '../../common';
 import ActionsDropdown from '../../common/ActionsDropdown';
 import { selectAuthorAvatars } from '../../posts/data/selectors';
@@ -19,18 +19,17 @@ function CommentHeader({
   actionHandlers,
 }) {
   const authorAvatars = useSelector(selectAuthorAvatars(comment.author));
-  const borderClasses = { Staff: 'border-warning-700', 'Community TA': 'border-success-700' };
-  const borderClass = borderClasses[comment.authorLabel] || '';
+  const colorClass = ColorClasses[comment.authorLabel] || '';
   return (
     <div className="d-flex flex-row justify-content-between">
       <div className="align-items-center d-flex flex-row">
         <Avatar
-          className={`m-2 ${borderClass}`}
+          className={`m-2 ${colorClass && `border-${colorClass}`}`}
           style={{ borderWidth: '2px' }}
           alt={comment.author}
           src={authorAvatars?.imageUrlSmall}
         />
-        <AuthorLabel author={comment.author} authorLabel={comment.authorLabel} />
+        <AuthorLabel author={comment.author} authorLabel={comment.authorLabel} labelColor={colorClass && `text-${colorClass}`} />
       </div>
       <div className="d-flex align-items-center">
         {comment.endorsed && (postType === 'question'

--- a/src/discussions/comments/comment/CommentHeader.jsx
+++ b/src/discussions/comments/comment/CommentHeader.jsx
@@ -7,7 +7,7 @@ import { injectIntl } from '@edx/frontend-platform/i18n';
 import { Avatar, Icon } from '@edx/paragon';
 import { CheckCircle, Verified } from '@edx/paragon/icons';
 
-import { ColorClasses, ThreadType } from '../../../data/constants';
+import { AvatarBorderAndLabelTextColors, ThreadType } from '../../../data/constants';
 import { AuthorLabel } from '../../common';
 import ActionsDropdown from '../../common/ActionsDropdown';
 import { selectAuthorAvatars } from '../../posts/data/selectors';
@@ -19,7 +19,7 @@ function CommentHeader({
   actionHandlers,
 }) {
   const authorAvatars = useSelector(selectAuthorAvatars(comment.author));
-  const colorClass = ColorClasses[comment.authorLabel];
+  const colorClass = AvatarBorderAndLabelTextColors[comment.authorLabel];
   return (
     <div className="d-flex flex-row justify-content-between">
       <div className="align-items-center d-flex flex-row">

--- a/src/discussions/comments/comment/CommentHeader.jsx
+++ b/src/discussions/comments/comment/CommentHeader.jsx
@@ -19,10 +19,17 @@ function CommentHeader({
   actionHandlers,
 }) {
   const authorAvatars = useSelector(selectAuthorAvatars(comment.author));
+  const borderClasses = { Staff: 'border-warning-700', 'Community TA': 'border-success-700' };
+  const borderClass = borderClasses[comment.authorLabel] || '';
   return (
     <div className="d-flex flex-row justify-content-between">
       <div className="align-items-center d-flex flex-row">
-        <Avatar className="m-2" alt={comment.author} src={authorAvatars?.imageUrlSmall} />
+        <Avatar
+          className={`m-2 ${borderClass}`}
+          style={{ borderWidth: '2px' }}
+          alt={comment.author}
+          src={authorAvatars?.imageUrlSmall}
+        />
         <AuthorLabel author={comment.author} authorLabel={comment.authorLabel} />
       </div>
       <div className="d-flex align-items-center">

--- a/src/discussions/comments/comment/Reply.jsx
+++ b/src/discussions/comments/comment/Reply.jsx
@@ -7,7 +7,7 @@ import * as timeago from 'timeago.js';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Avatar, useToggle } from '@edx/paragon';
 
-import { AvatarBorderAndLabelTextColors, ContentActions } from '../../../data/constants';
+import { AvatarBorderAndLabelColors, ContentActions } from '../../../data/constants';
 import {
   ActionsDropdown, AlertBanner, AuthorLabel, DeleteConfirmation,
 } from '../../common';
@@ -32,7 +32,7 @@ function Reply({
     [ContentActions.REPORT]: () => dispatch(editComment(reply.id, { flagged: !reply.abuseFlagged })),
   };
   const authorAvatars = useSelector(selectAuthorAvatars(reply.author));
-  const colorClass = AvatarBorderAndLabelTextColors[reply.authorLabel];
+  const colorClass = AvatarBorderAndLabelColors[reply.authorLabel];
   return (
     <div className="d-flex my-2 flex-column" data-testid={`reply-${reply.id}`}>
       <DeleteConfirmation

--- a/src/discussions/comments/comment/Reply.jsx
+++ b/src/discussions/comments/comment/Reply.jsx
@@ -7,7 +7,7 @@ import * as timeago from 'timeago.js';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Avatar, useToggle } from '@edx/paragon';
 
-import { ContentActions } from '../../../data/constants';
+import { ColorClasses, ContentActions } from '../../../data/constants';
 import {
   ActionsDropdown, AlertBanner, AuthorLabel, DeleteConfirmation,
 } from '../../common';
@@ -32,6 +32,7 @@ function Reply({
     [ContentActions.REPORT]: () => dispatch(editComment(reply.id, { flagged: !reply.abuseFlagged })),
   };
   const authorAvatars = useSelector(selectAuthorAvatars(reply.author));
+  const colorClass = ColorClasses[reply.authorLabel] || '';
   return (
     <div className="d-flex my-2 flex-column" data-testid={`reply-${reply.id}`}>
       <DeleteConfirmation
@@ -50,11 +51,16 @@ function Reply({
       <div className="d-flex">
 
         <div className="d-flex m-3">
-          <Avatar alt={reply.author} src={authorAvatars?.imageUrlSmall} />
+          <Avatar
+            className={`m-2 ${colorClass && `border-${colorClass}`}`}
+            style={{ borderWidth: '2px' }}
+            alt={reply.author}
+            src={authorAvatars?.imageUrlSmall}
+          />
         </div>
         <div className="rounded bg-light-300 px-4 py-2 flex-fill">
           <div className="d-flex flex-row justify-content-between align-items-center">
-            <AuthorLabel author={reply.author} authorLabel={reply.authorLabel} />
+            <AuthorLabel author={reply.author} authorLabel={reply.authorLabel} labelColor={colorClass && `text-${colorClass}`} />
             <ActionsDropdown
               commentOrPost={{
                 ...reply,

--- a/src/discussions/comments/comment/Reply.jsx
+++ b/src/discussions/comments/comment/Reply.jsx
@@ -7,7 +7,7 @@ import * as timeago from 'timeago.js';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Avatar, useToggle } from '@edx/paragon';
 
-import { ColorClasses, ContentActions } from '../../../data/constants';
+import { AvatarBorderAndLabelTextColors, ContentActions } from '../../../data/constants';
 import {
   ActionsDropdown, AlertBanner, AuthorLabel, DeleteConfirmation,
 } from '../../common';
@@ -32,7 +32,7 @@ function Reply({
     [ContentActions.REPORT]: () => dispatch(editComment(reply.id, { flagged: !reply.abuseFlagged })),
   };
   const authorAvatars = useSelector(selectAuthorAvatars(reply.author));
-  const colorClass = ColorClasses[reply.authorLabel];
+  const colorClass = AvatarBorderAndLabelTextColors[reply.authorLabel];
   return (
     <div className="d-flex my-2 flex-column" data-testid={`reply-${reply.id}`}>
       <DeleteConfirmation

--- a/src/discussions/comments/comment/Reply.jsx
+++ b/src/discussions/comments/comment/Reply.jsx
@@ -32,7 +32,7 @@ function Reply({
     [ContentActions.REPORT]: () => dispatch(editComment(reply.id, { flagged: !reply.abuseFlagged })),
   };
   const authorAvatars = useSelector(selectAuthorAvatars(reply.author));
-  const colorClass = ColorClasses[reply.authorLabel] || '';
+  const colorClass = ColorClasses[reply.authorLabel];
   return (
     <div className="d-flex my-2 flex-column" data-testid={`reply-${reply.id}`}>
       <DeleteConfirmation

--- a/src/discussions/common/AuthorLabel.jsx
+++ b/src/discussions/common/AuthorLabel.jsx
@@ -14,19 +14,17 @@ function AuthorLabel({
   author,
   authorLabel,
   linkToProfile,
+  labelColor,
 }) {
   let icon = null;
   let authorLabelMessage = null;
-  let authorLabelClass = '';
   if (authorLabel === 'Staff') {
     icon = Institution;
     authorLabelMessage = intl.formatMessage(messages.authorLabelStaff);
-    authorLabelClass = 'text-warning-700';
   }
   if (authorLabel === 'Community TA') {
     icon = School;
     authorLabelMessage = intl.formatMessage(messages.authorLabelTA);
-    authorLabelClass = 'text-success-700';
   }
   const labelContents = (
     <>
@@ -47,7 +45,7 @@ function AuthorLabel({
       )}
     </>
   );
-  const className = classNames('d-flex align-items-center', authorLabelClass);
+  const className = classNames('d-flex align-items-center', labelColor);
   return linkToProfile
     ? React.createElement('a', { href: '#nowhere', className }, labelContents)
     : React.createElement('div', { className }, labelContents);
@@ -58,11 +56,13 @@ AuthorLabel.propTypes = {
   author: PropTypes.string.isRequired,
   authorLabel: PropTypes.string,
   linkToProfile: PropTypes.bool,
+  labelColor: PropTypes.string,
 };
 
 AuthorLabel.defaultProps = {
   linkToProfile: false,
   authorLabel: null,
+  labelColor: '',
 };
 
 export default injectIntl(AuthorLabel);

--- a/src/discussions/common/AuthorLabel.jsx
+++ b/src/discussions/common/AuthorLabel.jsx
@@ -17,13 +17,16 @@ function AuthorLabel({
 }) {
   let icon = null;
   let authorLabelMessage = null;
+  let authorLabelClass = '';
   if (authorLabel === 'Staff') {
     icon = Institution;
     authorLabelMessage = intl.formatMessage(messages.authorLabelStaff);
+    authorLabelClass = 'text-warning-700';
   }
   if (authorLabel === 'Community TA') {
     icon = School;
     authorLabelMessage = intl.formatMessage(messages.authorLabelTA);
+    authorLabelClass = 'text-success-700';
   }
   const labelContents = (
     <>
@@ -44,7 +47,7 @@ function AuthorLabel({
       )}
     </>
   );
-  const className = classNames('d-flex align-items-center');
+  const className = classNames('d-flex align-items-center', authorLabelClass);
   return linkToProfile
     ? React.createElement('a', { href: '#nowhere', className }, labelContents)
     : React.createElement('div', { className }, labelContents);

--- a/src/discussions/posts/post/LikeButton.jsx
+++ b/src/discussions/posts/post/LikeButton.jsx
@@ -36,7 +36,7 @@ function LikeButton(
       >
         <IconButton
           onClick={handleClick}
-          className="p-0 mr-2"
+          className="p-3 mr-2"
           alt="Like"
           iconAs={Icon}
           size="inline"

--- a/src/discussions/posts/post/PostFooter.jsx
+++ b/src/discussions/posts/post/PostFooter.jsx
@@ -24,7 +24,7 @@ function PostFooter({
 }) {
   const dispatch = useDispatch();
   return (
-    <div className="d-flex align-items-center">
+    <div className="d-flex align-items-center mt-3">
       <LikeButton
         count={post.voteCount}
         onClick={() => dispatch(updateExistingThread(post.id, { voted: !post.voted }))}

--- a/src/discussions/posts/post/PostHeader.jsx
+++ b/src/discussions/posts/post/PostHeader.jsx
@@ -7,7 +7,7 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Avatar, Badge, Icon } from '@edx/paragon';
 import { Help } from '@edx/paragon/icons';
 
-import { AvatarBorderAndLabelTextColors, ThreadType } from '../../../data/constants';
+import { AvatarBorderAndLabelColors, ThreadType } from '../../../data/constants';
 import { ActionsDropdown, AuthorLabel } from '../../common';
 import { selectAuthorAvatars } from '../data/selectors';
 import messages from './messages';
@@ -15,7 +15,7 @@ import { postShape } from './proptypes';
 
 export function PostAvatar({ post, authorLabel, fromPostLink }) {
   const authorAvatars = useSelector(selectAuthorAvatars(post.author));
-  const borderColor = AvatarBorderAndLabelTextColors[authorLabel];
+  const borderColor = AvatarBorderAndLabelColors[authorLabel];
   return (
     <div className="mr-3">
       {post.type === ThreadType.QUESTION && (
@@ -57,7 +57,7 @@ function PostHeader({
   actionHandlers,
 }) {
   const showAnsweredBadge = preview && post.hasEndorsed && post.type === ThreadType.QUESTION;
-  const authorLabelColor = AvatarBorderAndLabelTextColors[post.authorLabel];
+  const authorLabelColor = AvatarBorderAndLabelColors[post.authorLabel];
   return (
     <div className="d-flex flex-fill mw-100">
       <PostAvatar post={post} authorLabel={post.authorLabel} />

--- a/src/discussions/posts/post/PostHeader.jsx
+++ b/src/discussions/posts/post/PostHeader.jsx
@@ -15,7 +15,7 @@ import { postShape } from './proptypes';
 
 export function PostAvatar({ post, authorLabel, fromPostLink }) {
   const authorAvatars = useSelector(selectAuthorAvatars(post.author));
-  const borderClass = ColorClasses[authorLabel] || '';
+  const borderColor = ColorClasses[authorLabel];
   return (
     <div className="mr-3">
       {post.type === ThreadType.QUESTION && (
@@ -30,7 +30,7 @@ export function PostAvatar({ post, authorLabel, fromPostLink }) {
       )}
       <Avatar
         size={fromPostLink ? 'sm' : 'md'}
-        className={`${borderClass && `border-${borderClass}`} ${post.type === ThreadType.QUESTION ? 'mt-2.5 ml-2.5' : ''}`}
+        className={`${borderColor && `border-${borderColor}`} ${post.type === ThreadType.QUESTION ? 'mt-2.5 ml-2.5' : ''}`}
         style={{ borderWidth: '2px' }}
         alt={post.author}
         src={authorAvatars?.imageUrlSmall}
@@ -57,7 +57,7 @@ function PostHeader({
   actionHandlers,
 }) {
   const showAnsweredBadge = preview && post.hasEndorsed && post.type === ThreadType.QUESTION;
-  const authorLabelColor = ColorClasses[post.authorLabel] || '';
+  const authorLabelColor = ColorClasses[post.authorLabel];
   return (
     <div className="d-flex flex-fill mw-100">
       <PostAvatar post={post} authorLabel={post.authorLabel} />

--- a/src/discussions/posts/post/PostHeader.jsx
+++ b/src/discussions/posts/post/PostHeader.jsx
@@ -7,7 +7,7 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Avatar, Badge, Icon } from '@edx/paragon';
 import { Help } from '@edx/paragon/icons';
 
-import { ColorClasses, ThreadType } from '../../../data/constants';
+import { AvatarBorderAndLabelTextColors, ThreadType } from '../../../data/constants';
 import { ActionsDropdown, AuthorLabel } from '../../common';
 import { selectAuthorAvatars } from '../data/selectors';
 import messages from './messages';
@@ -15,7 +15,7 @@ import { postShape } from './proptypes';
 
 export function PostAvatar({ post, authorLabel, fromPostLink }) {
   const authorAvatars = useSelector(selectAuthorAvatars(post.author));
-  const borderColor = ColorClasses[authorLabel];
+  const borderColor = AvatarBorderAndLabelTextColors[authorLabel];
   return (
     <div className="mr-3">
       {post.type === ThreadType.QUESTION && (
@@ -57,7 +57,7 @@ function PostHeader({
   actionHandlers,
 }) {
   const showAnsweredBadge = preview && post.hasEndorsed && post.type === ThreadType.QUESTION;
-  const authorLabelColor = ColorClasses[post.authorLabel];
+  const authorLabelColor = AvatarBorderAndLabelTextColors[post.authorLabel];
   return (
     <div className="d-flex flex-fill mw-100">
       <PostAvatar post={post} authorLabel={post.authorLabel} />

--- a/src/discussions/posts/post/PostHeader.jsx
+++ b/src/discussions/posts/post/PostHeader.jsx
@@ -13,10 +13,12 @@ import { selectAuthorAvatars } from '../data/selectors';
 import messages from './messages';
 import { postShape } from './proptypes';
 
-export function PostAvatar({ post }) {
+export function PostAvatar({ post, authorLabel }) {
   const authorAvatars = useSelector(selectAuthorAvatars(post.author));
+  const borderClasses = { Staff: 'border-warning-700', 'Community TA': 'border-success-700' };
+  const borderClass = borderClasses[authorLabel] || '';
   return (
-    <div className="mr-2">
+    <div className="mr-3">
       {post.type === ThreadType.QUESTION && (
       <Icon
         src={Help}
@@ -29,7 +31,8 @@ export function PostAvatar({ post }) {
       )}
       <Avatar
         size={post.type === ThreadType.QUESTION ? 'sm' : 'md'}
-        className={post.type === ThreadType.QUESTION ? 'mt-2.5 ml-2.5' : ''}
+        className={`${borderClass} ${post.type === ThreadType.QUESTION ? 'mt-2.5 ml-2.5' : ''}`}
+        style={{ borderWidth: '2px' }}
         alt={post.author}
         src={authorAvatars?.imageUrlSmall}
       />
@@ -39,6 +42,11 @@ export function PostAvatar({ post }) {
 
 PostAvatar.propTypes = {
   post: postShape.isRequired,
+  authorLabel: PropTypes.string,
+};
+
+PostAvatar.defaultProps = {
+  authorLabel: null,
 };
 
 function PostHeader({
@@ -51,7 +59,7 @@ function PostHeader({
 
   return (
     <div className="d-flex flex-fill mw-100">
-      <PostAvatar post={post} />
+      <PostAvatar post={post} authorLabel={post.authorLabel} />
       <div className="align-items-center d-flex flex-row" style={{ width: 'calc(100% - 8rem)' }}>
         <div className="d-flex flex-column justify-content-start mw-100">
           {preview

--- a/src/discussions/posts/post/PostHeader.jsx
+++ b/src/discussions/posts/post/PostHeader.jsx
@@ -7,16 +7,15 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Avatar, Badge, Icon } from '@edx/paragon';
 import { Help } from '@edx/paragon/icons';
 
-import { ThreadType } from '../../../data/constants';
+import { ColorClasses, ThreadType } from '../../../data/constants';
 import { ActionsDropdown, AuthorLabel } from '../../common';
 import { selectAuthorAvatars } from '../data/selectors';
 import messages from './messages';
 import { postShape } from './proptypes';
 
-export function PostAvatar({ post, authorLabel }) {
+export function PostAvatar({ post, authorLabel, fromPostLink }) {
   const authorAvatars = useSelector(selectAuthorAvatars(post.author));
-  const borderClasses = { Staff: 'border-warning-700', 'Community TA': 'border-success-700' };
-  const borderClass = borderClasses[authorLabel] || '';
+  const borderClass = ColorClasses[authorLabel] || '';
   return (
     <div className="mr-3">
       {post.type === ThreadType.QUESTION && (
@@ -30,8 +29,8 @@ export function PostAvatar({ post, authorLabel }) {
       />
       )}
       <Avatar
-        size={post.type === ThreadType.QUESTION ? 'sm' : 'md'}
-        className={`${borderClass} ${post.type === ThreadType.QUESTION ? 'mt-2.5 ml-2.5' : ''}`}
+        size={fromPostLink ? 'sm' : 'md'}
+        className={`${borderClass && `border-${borderClass}`} ${post.type === ThreadType.QUESTION ? 'mt-2.5 ml-2.5' : ''}`}
         style={{ borderWidth: '2px' }}
         alt={post.author}
         src={authorAvatars?.imageUrlSmall}
@@ -43,10 +42,12 @@ export function PostAvatar({ post, authorLabel }) {
 PostAvatar.propTypes = {
   post: postShape.isRequired,
   authorLabel: PropTypes.string,
+  fromPostLink: PropTypes.bool,
 };
 
 PostAvatar.defaultProps = {
   authorLabel: null,
+  fromPostLink: false,
 };
 
 function PostHeader({
@@ -56,7 +57,7 @@ function PostHeader({
   actionHandlers,
 }) {
   const showAnsweredBadge = preview && post.hasEndorsed && post.type === ThreadType.QUESTION;
-
+  const authorLabelColor = ColorClasses[post.authorLabel] || '';
   return (
     <div className="d-flex flex-fill mw-100">
       <PostAvatar post={post} authorLabel={post.authorLabel} />
@@ -73,7 +74,11 @@ function PostHeader({
               </div>
             )
             : <h3 className="mb-0">{post.title}</h3>}
-          <AuthorLabel author={post.author || intl.formatMessage(messages.anonymous)} authorLabel={post.authorLabel} />
+          <AuthorLabel
+            author={post.author || intl.formatMessage(messages.anonymous)}
+            authorLabel={post.authorLabel}
+            labelColor={authorLabelColor && `text-${authorLabelColor}`}
+          />
         </div>
       </div>
       {!preview

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -32,7 +32,7 @@ function PostLink({
     postId: post.id,
   });
   const showAnsweredBadge = post.hasEndorsed && post.type === ThreadType.QUESTION;
-  const authorLabelColor = ColorClasses[post.authorLabel] || '';
+  const authorLabelColor = ColorClasses[post.authorLabel];
   return (
     <Link
       className="discussion-post list-group-item list-group-item-action p-0 text-decoration-none text-gray-900 mw-100"

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -49,11 +49,11 @@ function PostLink({
           borderRightStyle: 'solid',
         } : null}
       >
-        <PostAvatar post={post} />
+        <PostAvatar post={post} authorLabel={post.authorLabel} />
         <div className="d-flex flex-column" style={{ width: 'calc(100% - 4rem)' }}>
           <div className="align-items-center d-flex flex-row flex-fill">
             <div className="d-flex flex-column justify-content-start mw-100 flex-fill">
-              <div className="h4 d-flex align-items-center pb-0 mb-0 flex-fill">
+              <div className="d-flex align-items-center pb-0 mb-0 flex-fill" style={{ fontWeight: 500 }}>
                 <div className="flex-fill text-truncate">
                   {post.title}
                 </div>

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -7,7 +7,7 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Badge, Icon } from '@edx/paragon';
 import { Bookmark } from '@edx/paragon/icons';
 
-import { Routes, ThreadType } from '../../../data/constants';
+import { ColorClasses, Routes, ThreadType } from '../../../data/constants';
 import AuthorLabel from '../../common/AuthorLabel';
 import { DiscussionContext } from '../../common/context';
 import { discussionsPath } from '../../utils';
@@ -32,6 +32,7 @@ function PostLink({
     postId: post.id,
   });
   const showAnsweredBadge = post.hasEndorsed && post.type === ThreadType.QUESTION;
+  const authorLabelColor = ColorClasses[post.authorLabel] || '';
   return (
     <Link
       className="discussion-post list-group-item list-group-item-action p-0 text-decoration-none text-gray-900 mw-100"
@@ -49,7 +50,7 @@ function PostLink({
           borderRightStyle: 'solid',
         } : null}
       >
-        <PostAvatar post={post} authorLabel={post.authorLabel} />
+        <PostAvatar post={post} authorLabel={post.authorLabel} fromPostLink />
         <div className="d-flex flex-column" style={{ width: 'calc(100% - 4rem)' }}>
           <div className="align-items-center d-flex flex-row flex-fill">
             <div className="d-flex flex-column justify-content-start mw-100 flex-fill">
@@ -73,6 +74,7 @@ function PostLink({
               <AuthorLabel
                 author={post.author || intl.formatMessage(messages.anonymous)}
                 authorLabel={post.authorLabel}
+                labelColor={authorLabelColor && `text-${authorLabelColor}`}
               />
             </div>
           </div>

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -7,7 +7,7 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Badge, Icon } from '@edx/paragon';
 import { Bookmark } from '@edx/paragon/icons';
 
-import { ColorClasses, Routes, ThreadType } from '../../../data/constants';
+import { AvatarBorderAndLabelTextColors, Routes, ThreadType } from '../../../data/constants';
 import AuthorLabel from '../../common/AuthorLabel';
 import { DiscussionContext } from '../../common/context';
 import { discussionsPath } from '../../utils';
@@ -32,7 +32,7 @@ function PostLink({
     postId: post.id,
   });
   const showAnsweredBadge = post.hasEndorsed && post.type === ThreadType.QUESTION;
-  const authorLabelColor = ColorClasses[post.authorLabel];
+  const authorLabelColor = AvatarBorderAndLabelTextColors[post.authorLabel];
   return (
     <Link
       className="discussion-post list-group-item list-group-item-action p-0 text-decoration-none text-gray-900 mw-100"

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -7,7 +7,7 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Badge, Icon } from '@edx/paragon';
 import { Bookmark } from '@edx/paragon/icons';
 
-import { AvatarBorderAndLabelTextColors, Routes, ThreadType } from '../../../data/constants';
+import { AvatarBorderAndLabelColors, Routes, ThreadType } from '../../../data/constants';
 import AuthorLabel from '../../common/AuthorLabel';
 import { DiscussionContext } from '../../common/context';
 import { discussionsPath } from '../../utils';
@@ -32,7 +32,7 @@ function PostLink({
     postId: post.id,
   });
   const showAnsweredBadge = post.hasEndorsed && post.type === ThreadType.QUESTION;
-  const authorLabelColor = AvatarBorderAndLabelTextColors[post.authorLabel];
+  const authorLabelColor = AvatarBorderAndLabelColors[post.authorLabel];
   return (
     <Link
       className="discussion-post list-group-item list-group-item-action p-0 text-decoration-none text-gray-900 mw-100"


### PR DESCRIPTION
## Ticket: [TNL-9751](https://openedx.atlassian.net/browse/TNL-9751)

Updated UI of post summary and post details:
Font-weight of summary title
Author label color (in both summary and post details)
Border around avatar/profile image (in both summary and post details)
Spacing between avatar and other details
Spacing between the summary footer and content
Enlarge background of like button

<img width="1677" alt="Screenshot 2022-03-31 at 5 56 49 PM" src="https://user-images.githubusercontent.com/51022010/161060159-94ed7fac-daf9-4e59-9fd3-569436be1993.png">