### PR TITLE
fix: post summary box size is large

### DIFF
--- a/src/discussions/posts/post/PostFooter.jsx
+++ b/src/discussions/posts/post/PostFooter.jsx
@@ -24,7 +24,7 @@ function PostFooter({
 }) {
   const dispatch = useDispatch();
   return (
-    <div className="d-flex align-items-center mt-3">
+    <div className="d-flex align-items-center mt-2">
       <LikeButton
         count={post.voteCount}
         onClick={() => dispatch(updateExistingThread(post.id, { voted: !post.voted }))}

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -44,7 +44,7 @@ function PostLink({
         </div>
       )}
       <div
-        className={classNames('d-flex flex-row flex-fill mw-100 p-3.5 border-primary-500', { 'bg-light-300': post.read })}
+        className={classNames('d-flex flex-row flex-fill mw-100 p-3 border-primary-500', { 'bg-light-300': post.read })}
         style={post.id === postId ? {
           borderRightWidth: '4px',
           borderRightStyle: 'solid',


### PR DESCRIPTION
## Ticket: [TNL-9751](https://openedx.atlassian.net/browse/TNL-9751)

The post summary box is smaller now.

<img width="488" alt="Screenshot 2022-04-01 at 1 05 45 PM" src="https://user-images.githubusercontent.com/51022010/161222036-e6d055f8-9fa8-47e8-bf4e-3004c69ae76f.png">

