### PR TITLE
feat: allow anonymous post support is removed from add post section

### DIFF
--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -374,19 +374,6 @@ function PostEditor({
                     {intl.formatMessage(messages.followPost)}
                   </Form.Checkbox>
                 </Form.Group>
-                {allowAnonymous && (
-                  <Form.Group>
-                    <Form.Checkbox
-                      name="anonymous"
-                      checked={values.anonymous}
-                      onChange={handleChange}
-                      onBlur={handleBlur}
-                      className="mr-4"
-                    >
-                      {intl.formatMessage(messages.anonymousPost)}
-                    </Form.Checkbox>
-                  </Form.Group>
-                )}
                 {allowAnonymousToPeers
                   && (
                     <Form.Group>

--- a/src/discussions/posts/post-editor/PostEditor.test.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.test.jsx
@@ -117,15 +117,13 @@ describe('PostEditor', () => {
           .toHaveLength(3);
 
         expect(screen.queryByText('cohort', { exact: false }))
-          .not
-          .toBeInTheDocument();
+          .not.toBeInTheDocument();
         if (allowAnonymous) {
           expect(screen.queryByText('Post anonymously'))
-            .toBeInTheDocument();
+            .not.toBeInTheDocument();
         } else {
           expect(screen.queryByText('Post anonymously'))
-            .not
-            .toBeInTheDocument();
+            .not.toBeInTheDocument();
         }
         if (allowAnonymousToPeers) {
           expect(screen.queryByText('Post anonymously to peers'))


### PR DESCRIPTION
TNL TIcket : [9469](https://openedx.atlassian.net/browse/TNL-9469)

Related Course authoring PR: https://github.com/openedx/frontend-app-course-authoring/pull/284
https://github.com/openedx/edx-platform/pull/30189
This PR is a part of the change mentioned in the above ticket, more related PRs are mentioned

Updated screen after removing allow anonymous post for all.
<img width="1000" alt="Screenshot 2022-04-06 at 1 20 12 AM" src="https://user-images.githubusercontent.com/67791278/161842206-a8bda20c-b218-4f83-a94b-2d3a9e8d0fe3.png">

## Testing instructions

checkout in all the three mentioned branches in different repos

- configure discussion provider will no longer show toggle-switch to post anonymously
- add post both using new MFE and legacy experience post anonymously options is removed
- for courses already configured to allow post anonymous feature still won't show the option to post anonymously
