### PR TITLE
style: content sections background colour changed

### DIFF
--- a/src/discussions/discussions-home/DiscussionContent.jsx
+++ b/src/discussions/discussions-home/DiscussionContent.jsx
@@ -15,7 +15,7 @@ export default function DiscussionContent() {
   useContainerSizeForParent(refContainer);
 
   return (
-    <div className="d-flex bg-light-300 flex-column w-75 w-xs-100 w-xl-75 align-items-center h-100 overflow-auto">
+    <div className="d-flex bg-light-400 flex-column w-75 w-xs-100 w-xl-75 align-items-center h-100 overflow-auto">
       <div className="d-flex flex-column w-100 mw-xl" ref={refContainer}>
         {postEditorVisible ? (
           <Route path={Routes.POSTS.NEW_POST}>

--- a/src/discussions/empty-posts/EmptyPage.jsx
+++ b/src/discussions/empty-posts/EmptyPage.jsx
@@ -16,7 +16,7 @@ function EmptyPage({
 }) {
   const containerClasses = classNames(
     'justify-content-center align-items-center d-flex w-100 flex-column pt-5',
-    { 'bg-light-300': !fullWidth },
+    { 'bg-light-400': !fullWidth },
   );
 
   return (


### PR DESCRIPTION
content sections background color changed from light-300 to light-400 to differentiate it from summary cards 

https://www.figma.com/file/LVFnO9oRHYiamoicZuXDAC/Discussion-page?node-id=2851%3A874102
Figma Mockups Attached.