### PR TITLE
fix: hide edit reason dropdown while adding a comment or response

### DIFF
--- a/src/discussions/comments/comment/Comment.jsx
+++ b/src/discussions/comments/comment/Comment.jsx
@@ -112,6 +112,7 @@ function Comment({
                     threadId: comment.threadId,
                     parentId: comment.id,
                   }}
+                  editing={false}
                   onCloseEditor={() => setReplying(false)}
                 />
               )

--- a/src/discussions/comments/comment/Comment.jsx
+++ b/src/discussions/comments/comment/Comment.jsx
@@ -112,7 +112,7 @@ function Comment({
                     threadId: comment.threadId,
                     parentId: comment.id,
                   }}
-                  editing={false}
+                  edit={false}
                   onCloseEditor={() => setReplying(false)}
                 />
               )

--- a/src/discussions/comments/comment/CommentEditor.jsx
+++ b/src/discussions/comments/comment/CommentEditor.jsx
@@ -20,6 +20,7 @@ function CommentEditor({
   intl,
   comment,
   onCloseEditor,
+  editing,
 }) {
   const { authenticatedUser } = useContext(AppContext);
   const userIsPrivileged = useSelector(selectUserIsPrivileged);
@@ -65,7 +66,9 @@ function CommentEditor({
         <Form onSubmit={handleSubmit}>
           {(reasonCodesEnabled
             && userIsPrivileged
-            && comment.author !== authenticatedUser.username) && (
+            && comment.author !== authenticatedUser.username
+            && editing
+          ) && (
             <Form.Group>
               <Form.Control
                 name="editReasonCode"
@@ -142,6 +145,11 @@ CommentEditor.propTypes = {
   }).isRequired,
   onCloseEditor: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
+  editing: PropTypes.bool,
+};
+
+CommentEditor.defaultProps = {
+  editing: true,
 };
 
 export default injectIntl(CommentEditor);

--- a/src/discussions/comments/comment/CommentEditor.jsx
+++ b/src/discussions/comments/comment/CommentEditor.jsx
@@ -20,7 +20,7 @@ function CommentEditor({
   intl,
   comment,
   onCloseEditor,
-  editing,
+  edit,
 }) {
   const { authenticatedUser } = useContext(AppContext);
   const userIsPrivileged = useSelector(selectUserIsPrivileged);
@@ -67,7 +67,7 @@ function CommentEditor({
           {(reasonCodesEnabled
             && userIsPrivileged
             && comment.author !== authenticatedUser.username
-            && editing
+            && edit
           ) && (
             <Form.Group>
               <Form.Control
@@ -145,11 +145,11 @@ CommentEditor.propTypes = {
   }).isRequired,
   onCloseEditor: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
-  editing: PropTypes.bool,
+  edit: PropTypes.bool,
 };
 
 CommentEditor.defaultProps = {
-  editing: true,
+  edit: true,
 };
 
 export default injectIntl(CommentEditor);

--- a/src/discussions/comments/comment/ResponseEditor.jsx
+++ b/src/discussions/comments/comment/ResponseEditor.jsx
@@ -14,7 +14,11 @@ function ResponseEditor({
   const [addingResponse, setAddingResponse] = useState(false);
   return addingResponse
     ? (
-      <CommentEditor comment={{ threadId: postId }} onCloseEditor={() => setAddingResponse(false)} />
+      <CommentEditor
+        comment={{ threadId: postId }}
+        editing={false}
+        onCloseEditor={() => setAddingResponse(false)}
+      />
     ) : (
       <div className="actions d-flex">
         <Button variant="primary" onClick={() => setAddingResponse(true)}>

--- a/src/discussions/comments/comment/ResponseEditor.jsx
+++ b/src/discussions/comments/comment/ResponseEditor.jsx
@@ -16,7 +16,7 @@ function ResponseEditor({
     ? (
       <CommentEditor
         comment={{ threadId: postId }}
-        editing={false}
+        edit={false}
         onCloseEditor={() => setAddingResponse(false)}
       />
     ) : (


### PR DESCRIPTION
### [INF-149](https://openedx.atlassian.net/browse/INF-149)
- Hide the `Reason for editing` dropdown when the user (with moderator role and not a post/comment author) adds a response or a comment

**Add Response**
<img width="927" alt="Screenshot 2022-04-21 at 4 29 30 PM" src="https://user-images.githubusercontent.com/79941147/164448803-45dc600b-fecb-4e49-a145-d4431cab7d2b.png">

**Add Comment**
<img width="930" alt="Screenshot 2022-04-21 at 10 04 51 PM" src="https://user-images.githubusercontent.com/79941147/164513496-fff10f7c-c6b2-4bd6-b47b-64ed51221b4b.png">

