### PR TITLE
fix: add validation for edit reason code dropdown

### DIFF
--- a/src/discussions/comments/comment/CommentEditor.jsx
+++ b/src/discussions/comments/comment/CommentEditor.jsx
@@ -29,8 +29,8 @@ function CommentEditor({
   const { reasonCodesEnabled, editReasons } = useSelector(selectModerationSettings);
   const [submitting, dispatch] = useDispatchWithState();
 
-  const canDisplayEditReason = (reasonCodesEnabled && userIsPrivileged && edit
-    && comment.author !== authenticatedUser.username
+  const canDisplayEditReason = (reasonCodesEnabled && userIsPrivileged
+    && edit && comment.author !== authenticatedUser.username
   );
 
   const editReasonCodeValidation = canDisplayEditReason && {

--- a/src/discussions/comments/messages.js
+++ b/src/discussions/comments/messages.js
@@ -26,7 +26,7 @@ const messages = defineMessages({
   },
   endorsedResponseCount: {
     id: 'discussions.comments.comment.endorsedResponseCount',
-    defaultMessage: `{num, plural, 
+    defaultMessage: `{num, plural,
       =0 {No endorsed responses}
       one {Showing # endorsed response}
       other {Showing # endorsed responses}
@@ -146,6 +146,11 @@ const messages = defineMessages({
     id: 'discussions.editor.comments.editReasonCode',
     defaultMessage: 'Reason for editing',
     description: 'Label for field visible to moderators that allows them to select a reason for editing another user\'s response',
+  },
+  editReasonCodeError: {
+    id: 'discussions.editor.posts.editReasonCode.error',
+    defaultMessage: 'Select reason for editing',
+    description: 'Error message visible to moderators when they submit the post/response/comment without select reason for editing',
   },
   editedBy: {
     id: 'discussions.comment.comments.editedBy',

--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -91,8 +91,8 @@ function PostEditor({
   const { allowAnonymous, allowAnonymousToPeers } = useSelector(selectAnonymousPostingConfig);
   const { reasonCodesEnabled, editReasons } = useSelector(selectModerationSettings);
 
-  const canDisplayEditReason = (reasonCodesEnabled && editExisting && userIsPrivileged
-    && post.author !== authenticatedUser.username
+  const canDisplayEditReason = (reasonCodesEnabled && editExisting
+    && userIsPrivileged && post.author !== authenticatedUser.username
   );
 
   const editReasonCodeValidation = canDisplayEditReason && {

--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
 import { Formik } from 'formik';
+import { isEmpty } from 'lodash';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import * as Yup from 'yup';
@@ -83,14 +84,21 @@ function PostEditor({
   const nonCoursewareTopics = useSelector(selectNonCoursewareTopics);
   const nonCoursewareIds = useSelector(selectNonCoursewareIds);
   const coursewareTopics = useSelector(selectCoursewareTopics);
-  const {
-    allowAnonymous,
-    allowAnonymousToPeers,
-  } = useSelector(selectAnonymousPostingConfig);
   const cohorts = useSelector(selectCourseCohorts);
   const post = useSelector(selectThread(postId));
   const userIsPrivileged = useSelector(selectUserIsPrivileged);
   const settings = useSelector(selectDivisionSettings);
+  const { allowAnonymous, allowAnonymousToPeers } = useSelector(selectAnonymousPostingConfig);
+  const { reasonCodesEnabled, editReasons } = useSelector(selectModerationSettings);
+
+  const canDisplayEditReason = (reasonCodesEnabled && editExisting && userIsPrivileged
+    && post.author !== authenticatedUser.username
+  );
+
+  const editReasonCodeValidation = canDisplayEditReason && {
+    editReasonCode: Yup.string().required(intl.formatMessage(messages.editReasonCodeError)),
+  };
+
   const canSelectCohort = (tId) => {
     // If the user isn't privileged, they can't edit the cohort.
     // If the topic is being edited the cohort can't be changed.
@@ -164,60 +172,48 @@ function PostEditor({
       </div>
     );
   }
-  let initialValues = {
-    postType: 'discussion',
-    topic: topicId || nonCoursewareTopics?.[0]?.id,
-    title: '',
-    comment: '',
-    follow: true,
-    anonymous: false,
-    anonymousToPeers: false,
+
+  const initialValues = {
+    postType: post?.type || 'discussion',
+    topic: post?.topicId || topicId || nonCoursewareTopics?.[0]?.id,
+    title: post?.title || '',
+    comment: post?.rawBody || '',
+    follow: isEmpty(post?.following) ? true : post?.following,
+    anonymous: allowAnonymous ? false : undefined,
+    anonymousToPeers: allowAnonymousToPeers ? false : undefined,
+    editReasonCode: post?.lastEdit?.reasonCode || '',
   };
-  if (editExisting) {
-    initialValues = {
-      postType: post.type,
-      topic: post.topicId,
-      title: post.title,
-      comment: post.rawBody,
-      follow: (post.following === null || post.following === undefined) ? true : post.following,
-      anonymous: allowAnonymous ? false : undefined,
-      anonymousToPeers: allowAnonymousToPeers ? false : undefined,
-    };
-  }
+
+  const validationSchema = Yup.object().shape({
+    postType: Yup.mixed()
+      .oneOf(['discussion', 'question']),
+    topic: Yup.string()
+      .required(),
+    title: Yup.string()
+      .required(intl.formatMessage(messages.titleError)),
+    comment: Yup.string()
+      .required(intl.formatMessage(messages.commentError)),
+    follow: Yup.bool()
+      .default(true),
+    anonymous: Yup.bool()
+      .default(false)
+      .nullable(),
+    anonymousToPeers: Yup.bool()
+      .default(false)
+      .nullable(),
+    cohort: Yup.string()
+      .nullable()
+      .default(null),
+    ...editReasonCodeValidation,
+  });
 
   const postEditorId = `post-editor-${editExisting ? postId : 'new'}`;
-
-  const { reasonCodesEnabled, editReasons } = useSelector(selectModerationSettings);
 
   return (
     <Formik
       enableReinitialize
       initialValues={initialValues}
-      validationSchema={Yup.object()
-        .shape({
-          postType: Yup.mixed()
-            .oneOf(['discussion', 'question']),
-          topic: Yup.string()
-            .required(),
-          title: Yup.string()
-            .required(intl.formatMessage(messages.titleError)),
-          comment: Yup.string()
-            .required(intl.formatMessage(messages.commentError)),
-          follow: Yup.bool()
-            .default(true),
-          anonymous: Yup.bool()
-            .default(false)
-            .nullable(),
-          anonymousToPeers: Yup.bool()
-            .default(false)
-            .nullable(),
-          cohort: Yup.string()
-            .nullable()
-            .default(null),
-          editReasonCode: Yup.string()
-            .nullable()
-            .default(null),
-        })}
+      validationSchema={validationSchema}
       onSubmit={submitForm}
     >{
       ({
@@ -304,7 +300,7 @@ function PostEditor({
           <div className="border-bottom my-1" />
           <div className="d-flex flex-row py-2 mt-4 justify-content-between">
             <Form.Group
-              className="d-flex flex-fill"
+              className="w-100"
               isInvalid={isFormikFieldInvalid('title', {
                 errors,
                 touched,
@@ -321,27 +317,31 @@ function PostEditor({
               />
               <FormikErrorFeedback name="title" />
             </Form.Group>
-            {(reasonCodesEnabled
-              && editExisting
-              && userIsPrivileged
-              && post.author !== authenticatedUser.username) && (
-                <Form.Group className="d-flex flex-fill">
-                  <Form.Control
-                    name="editReasonCode"
-                    className="ml-4"
-                    as="select"
-                    value={values.editReasonCode}
-                    onChange={handleChange}
-                    onBlur={handleBlur}
-                    aria-describedby="editReasonCodeInput"
-                    floatingLabel={intl.formatMessage(messages.editReasonCode)}
-                  >
-                    <option key="empty" value="">---</option>
-                    {editReasons.map(({ code, label }) => (
-                      <option key={code} value={code}>{label}</option>
-                    ))}
-                  </Form.Control>
-                </Form.Group>
+            {canDisplayEditReason && (
+              <Form.Group
+                className="w-100"
+                isInvalid={isFormikFieldInvalid('editReasonCode', {
+                  errors,
+                  touched,
+                })}
+              >
+                <Form.Control
+                  name="editReasonCode"
+                  className="m-0"
+                  as="select"
+                  value={values.editReasonCode}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  aria-describedby="editReasonCodeInput"
+                  floatingLabel={intl.formatMessage(messages.editReasonCode)}
+                >
+                  <option key="empty" value="">---</option>
+                  {editReasons.map(({ code, label }) => (
+                    <option key={code} value={code}>{label}</option>
+                  ))}
+                </Form.Control>
+                <FormikErrorFeedback name="editReasonCode" />
+              </Form.Group>
             )}
           </div>
           <div className="py-2">

--- a/src/discussions/posts/post-editor/messages.js
+++ b/src/discussions/posts/post-editor/messages.js
@@ -106,6 +106,11 @@ const messages = defineMessages({
     defaultMessage: 'Reason for editing',
     description: 'Label for field visible to moderators that allows them to select a reason for editing another user\'s post',
   },
+  editReasonCodeError: {
+    id: 'discussions.editor.posts.editReasonCode.error',
+    defaultMessage: 'Select reason for editing',
+    description: 'Error message visible to moderators when they submit the post/response/comment without select reason for editing',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
### [INF-156](https://openedx.atlassian.net/browse/INF-156)
- Add validation for edit reason code dropdown
- Display an error message when the moderator submits a response/comment/post without selecting Edit reason

<img width="940" alt="Screenshot 2022-04-21 at 10 55 24 PM" src="https://user-images.githubusercontent.com/79941147/164530047-a6dd7fe8-01a5-4878-9e46-8f2b3f165340.png">
<img width="930" alt="Screenshot 2022-04-21 at 10 54 58 PM" src="https://user-images.githubusercontent.com/79941147/164530028-85f1e37b-17ef-4203-8e3d-df1731efd15f.png">
