### PR TITLE
fix: post summary pinned bar

### DIFF
--- a/src/discussions/posts/PostsView.jsx
+++ b/src/discussions/posts/PostsView.jsx
@@ -58,7 +58,7 @@ function PostsList({ posts, topics }) {
       // Add a spacing after the group of pinned posts
       return (
         <React.Fragment key={post.id}>
-          <div className="p-1 bg-light-300" />
+          <div className="p-1 bg-light-400" />
           <PostLink post={post} key={post.id} />
         </React.Fragment>
       );


### PR DESCRIPTION
Color of pinned bar in post summary was merging with card of posts that was read.

Ticket Link:
https://openedx.atlassian.net/browse/INF-158

Before
![post_summary_evidence](https://user-images.githubusercontent.com/77053848/164592862-9ee982be-718c-4ac9-b56a-74735800faea.png)

After
 ![post_summary_after](https://user-images.githubusercontent.com/77053848/164592948-31cabf76-7764-4dbb-bb2a-1df1ea88507f.png)
