### PR TITLE
fix: display comment actions alert in single row

### DIFF
--- a/src/discussions/comments/comment/Reply.jsx
+++ b/src/discussions/comments/comment/Reply.jsx
@@ -45,11 +45,17 @@ function Reply({
           hideDeleteConfirmation();
         }}
       />
-      <div className="d-flex flex-fill ml-6">
-        <AlertBanner postType={null} content={reply} intl={intl} />
-      </div>
-      <div className="d-flex">
 
+      <div className="d-flex">
+        <div className="d-flex mx-3 invisible">
+          <Avatar className="m-2" />
+        </div>
+        <div className="w-100">
+          <AlertBanner postType={null} content={reply} intl={intl} />
+        </div>
+      </div>
+
+      <div className="d-flex">
         <div className="d-flex m-3">
           <Avatar
             className={`m-2 ${colorClass && `border-${colorClass}`}`}
@@ -74,7 +80,6 @@ function Reply({
             // eslint-disable-next-line react/no-danger
             : <div dangerouslySetInnerHTML={{ __html: reply.renderedBody }} />}
         </div>
-
       </div>
       <div className="text-gray-500 align-self-end mt-2" title={reply.createdAt}>
         {timeago.format(reply.createdAt, intl.locale)}

--- a/src/discussions/common/AlertBanner.jsx
+++ b/src/discussions/common/AlertBanner.jsx
@@ -56,7 +56,7 @@ function AlertBanner({
         </Alert>
       )}
       {content.abuseFlagged && (
-        <Alert icon={Error} variant="danger" className="p-3 m-0 shadow-none mb-1 flex-fill">
+        <Alert icon={Error} variant="danger" className="p-3 m-0 shadow-none my-1 flex-fill">
           {intl.formatMessage(messages.abuseFlaggedMessage)}
         </Alert>
       )}


### PR DESCRIPTION
### [INF-159](https://openedx.atlassian.net/browse/INF-159)
- Comment endorse, close, report, edit the reason each alert will display on an individual single row.
- Comment endorse action will remove in the next ticket
### Before
<img width="917" alt="Screenshot 2022-04-22 at 12 25 11 PM" src="https://user-images.githubusercontent.com/79941147/164765145-a0eab560-baad-4f5e-a43c-bd00f01f7cab.png">
<img width="938" alt="Screenshot 2022-04-22 at 12 26 44 PM" src="https://user-images.githubusercontent.com/79941147/164765157-4170a3e3-1267-4f1a-ab55-8c82b1468677.png">

### After
<img width="948" alt="Screenshot 2022-04-22 at 8 31 30 PM" src="https://user-images.githubusercontent.com/79941147/164748783-f298345f-e726-4bcc-9a21-a38e1e3a44bb.png">
<img width="952" alt="Screenshot 2022-04-22 at 8 31 44 PM" src="https://user-images.githubusercontent.com/79941147/164748786-f452d1a6-a104-420c-bb1e-6d5ffbc5aaa3.png">
<img width="956" alt="Screenshot 2022-04-22 at 8 30 49 PM" src="https://user-images.githubusercontent.com/79941147/164748764-67c17cfb-ff38-4b65-a8c7-c2950362560a.png">
