### PR TITLE
fix: make the post, comment, response content images responsive

### DIFF
--- a/src/discussions/comments/comment/Comment.jsx
+++ b/src/discussions/comments/comment/Comment.jsx
@@ -74,7 +74,7 @@ function Comment({
             <CommentEditor comment={comment} onCloseEditor={() => setEditing(false)} />
           )
           // eslint-disable-next-line react/no-danger
-          : <div className="comment-body px-2" dangerouslySetInnerHTML={{ __html: comment.renderedBody }} />}
+          : <div className="comment-body px-2" id="comment" dangerouslySetInnerHTML={{ __html: comment.renderedBody }} />}
         <CommentIcons
           comment={comment}
           following={comment.following}

--- a/src/discussions/comments/comment/Reply.jsx
+++ b/src/discussions/comments/comment/Reply.jsx
@@ -78,7 +78,7 @@ function Reply({
           {isEditing
             ? <CommentEditor comment={reply} onCloseEditor={() => setEditing(false)} />
             // eslint-disable-next-line react/no-danger
-            : <div dangerouslySetInnerHTML={{ __html: reply.renderedBody }} />}
+            : <div id="reply" dangerouslySetInnerHTML={{ __html: reply.renderedBody }} />}
         </div>
       </div>
       <div className="text-gray-500 align-self-end mt-2" title={reply.createdAt}>

--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -75,7 +75,7 @@ function Post({
       <PostHeader post={post} actionHandlers={actionHandlers} />
       <div className="d-flex my-2 text-break">
         {/* eslint-disable-next-line react/no-danger */}
-        <div dangerouslySetInnerHTML={{ __html: post.renderedBody }} />
+        <div id="post" dangerouslySetInnerHTML={{ __html: post.renderedBody }} />
       </div>
       {topicContext && topic && (
         <div className="border p-3 rounded mb-3 mt-2 align-self-start">

--- a/src/index.scss
+++ b/src/index.scss
@@ -5,3 +5,11 @@
 
 $fa-font-path: "~font-awesome/fonts";
 @import "~font-awesome/scss/font-awesome";
+
+
+#post, #comment, #reply {
+  img {
+    height: auto;
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
### [INF-37](https://openedx.atlassian.net/browse/INF-37)

- High resolution images will be responsive according to screen size in the post, comment, and response content.

**Before**
<img width="941" alt="Screenshot 2022-04-25 at 1 54 51 PM" src="https://user-images.githubusercontent.com/79941147/165062827-9f048440-fca3-442e-ba18-187265f72804.png">

**After**
<img width="926" alt="Screenshot 2022-04-25 at 1 53 42 PM" src="https://user-images.githubusercontent.com/79941147/165063044-ae7ae1c9-df27-40ff-962d-f55676592462.png">

