### PR TITLE
fix: reported filter is missing for discussion moderator roles

### DIFF
--- a/src/discussions/posts/PostsView.test.jsx
+++ b/src/discussions/posts/PostsView.test.jsx
@@ -85,6 +85,7 @@ describe('PostsView', () => {
 
     store = initializeStore({
       blocks: { blocks: { 'test-usage-key': { topics: ['some-topic-2', 'some-topic-0'] } } },
+      config: { userIsPrivileged: true },
     });
     Factory.resetAll();
     axiosMock = new MockAdapter(getAuthenticatedHttpClient());

--- a/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
+++ b/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
@@ -1,17 +1,17 @@
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import classNames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { AppContext } from '@edx/frontend-platform/react';
 import { Collapsible, Form, Icon } from '@edx/paragon';
 import { Check, Sort } from '@edx/paragon/icons';
 
 import {
   PostsStatusFilter, ThreadOrdering, ThreadType,
 } from '../../../data/constants';
+import { selectUserIsPrivileged } from '../../data/selectors';
 import { setPostsTypeFilter, setSortedBy, setStatusFilter } from '../data';
 import { selectThreadFilters, selectThreadSorting } from '../data/selectors';
 import messages from './messages';
@@ -44,8 +44,8 @@ function PostFilterBar({
   filterSelfPosts,
   intl,
 }) {
-  const { authenticatedUser } = useContext(AppContext);
   const dispatch = useDispatch();
+  const userIsPrivileged = useSelector(selectUserIsPrivileged);
   const currentSorting = useSelector(selectThreadSorting());
   const currentFilters = useSelector(selectThreadFilters());
   const [isOpen, setOpen] = useState(false);
@@ -147,7 +147,7 @@ function PostFilterBar({
             value={PostsStatusFilter.FOLLOWING}
             selected={currentFilters.status}
           />
-          {authenticatedUser.administrator
+          {userIsPrivileged
           && (
           <ActionItem
             id="status-reported"


### PR DESCRIPTION
## [Ticket](https://openedx.atlassian.net/browse/INF-165)

The reported filter is now available for discussion moderator roles.
<img width="470" alt="Screenshot 2022-04-27 at 9 24 29 AM" src="https://user-images.githubusercontent.com/51022010/165440457-d38b55d3-fa77-4a8a-b2b3-08fef198d2de.png">

