### PR TITLE
fix: discussion moderators can't create posts for specific cohorts

### DIFF
--- a/src/discussions/data/thunks.js
+++ b/src/discussions/data/thunks.js
@@ -18,7 +18,7 @@ export function fetchCourseConfig(courseId) {
     try {
       dispatch(fetchConfigRequest());
       const config = await getDiscussionsConfig(courseId);
-      if (config.is_user_admin) {
+      if (config.is_user_admin || config.user_is_privileged) {
         const settings = await getDiscussionsSettings(courseId);
         Object.assign(config, { settings });
       }


### PR DESCRIPTION
## [Ticket](https://openedx.atlassian.net/browse/INF-166)

Users with discussion moderation roles were not getting the option to create a post for a specific cohort.

Before:
<img width="1083" alt="Screenshot 2022-05-06 at 8 09 30 PM" src="https://user-images.githubusercontent.com/51022010/167161073-2a815fe0-6523-4cd6-89ab-fbf503c4f3f2.png">

Fixed:
<img width="1083" alt="Screenshot 2022-05-06 at 8 07 49 PM" src="https://user-images.githubusercontent.com/51022010/167160726-68f71ab4-47f2-42be-b224-25fad0cfed75.png">

