### PR TITLE
revert: reverting wiris integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@edx/paragon": "19.10.1",
         "@reduxjs/toolkit": "1.8.0",
         "@tinymce/tinymce-react": "3.13.1",
-        "@wiris/mathtype-tinymce5": "^7.28.0",
         "babel-polyfill": "6.26.0",
         "classnames": "2.3.1",
         "core-js": "3.21.1",
@@ -24,7 +23,7 @@
         "raw-loader": "4.0.2",
         "react": "16.14.0",
         "react-dom": "16.14.0",
-        "react-mathjax-preview": "^2.2.6",
+        "react-mathjax-preview": "2.2.6",
         "react-redux": "7.2.6",
         "react-router": "5.2.1",
         "react-router-dom": "5.3.0",
@@ -4520,28 +4519,6 @@
         "webpack-dev-server": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@wiris/mathtype-html-integration-devkit": {
-      "version": "1.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "raw-loader": "^4.0.2",
-        "uuid": "^8.3.2"
-      }
-    },
-    "node_modules/@wiris/mathtype-html-integration-devkit/node_modules/uuid": {
-      "version": "8.3.2",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@wiris/mathtype-tinymce5": {
-      "version": "7.28.0",
-      "license": "MIT",
-      "dependencies": {
-        "@wiris/mathtype-html-integration-devkit": "1.7.0"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -26298,24 +26275,6 @@
       "version": "1.6.1",
       "dev": true,
       "requires": {}
-    },
-    "@wiris/mathtype-html-integration-devkit": {
-      "version": "1.7.0",
-      "requires": {
-        "raw-loader": "^4.0.2",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2"
-        }
-      }
-    },
-    "@wiris/mathtype-tinymce5": {
-      "version": "7.28.0",
-      "requires": {
-        "@wiris/mathtype-html-integration-devkit": "1.7.0"
-      }
     },
     "@xtuc/ieee754": {
       "version": "1.2.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@edx/paragon": "19.10.1",
     "@reduxjs/toolkit": "1.8.0",
     "@tinymce/tinymce-react": "3.13.1",
-    "@wiris/mathtype-tinymce5": "7.28.0",
     "babel-polyfill": "6.26.0",
     "classnames": "2.3.1",
     "core-js": "3.21.1",

--- a/src/components/TinyMCEEditor.jsx
+++ b/src/components/TinyMCEEditor.jsx
@@ -25,7 +25,6 @@ import 'tinymce/plugins/link';
 import 'tinymce/plugins/lists';
 import 'tinymce/plugins/emoticons';
 import 'tinymce/plugins/emoticons/js/emojis';
-import '@wiris/mathtype-tinymce5';
 /* eslint import/no-webpack-loader-syntax: off */
 // eslint-disable-next-line import/no-unresolved
 import edxBrandCss from '!!raw-loader!sass-loader!../index.scss';
@@ -85,20 +84,14 @@ export default function TinyMCEEditor(props) {
         a11y_advanced_options: true,
         autosave_interval: '1s',
         autosave_restore_when_empty: true,
-        external_plugins: {
-          tiny_mce_wiris: 'node_modules/@wiris/mathtype-tinymce5/plugin.min.js',
-        },
-        plugins: 'autosave codesample link lists image imagetools code spellchecker emoticons',
+        plugins: 'autosave codesample link lists image imagetools code emoticons',
         toolbar: 'formatselect | bold italic underline'
           + ' | link blockquote openedx_code image'
           + ' | bullist numlist outdent indent'
           + ' | removeformat'
           + ' | openedx_html'
           + ' | undo redo'
-          + ' | emoticons'
-          + ' | tiny_mce_wiris_formulaEditor | tiny_mce_wiris_formulaEditorChemistry',
-        spellchecker_active: true,
-        spellchecker_dialog: true,
+          + ' | emoticons',
         content_css: false,
         content_style: contentStyle,
         body_class: 'm-2',


### PR DESCRIPTION
- related to the discussion posted in this [document](https://2u-internal.atlassian.net/wiki/spaces/PT/pages/15440774/Tiny+MCE+Plugins). wiris integration with TinyMCE has been reverted. 
for context new plugins will be explored and a decision will be based after keeping in mind all the aspects.  