### PR TITLE
fix: change votes to likes in search filter

### DIFF
--- a/src/discussions/posts/PostsView.test.jsx
+++ b/src/discussions/posts/PostsView.test.jsx
@@ -155,7 +155,7 @@ describe('PostsView', () => {
     test('test that the filter bar works', async () => {
       // 3 type filters: all, discussion, question
       // 5 status filters: any, unread, following, reported, unanswered
-      // 3 sort: activity, comments, votes
+      // 3 sort: activity, comments, likes
       expect(screen.queryAllByRole('radio')).toHaveLength(11);
     });
 
@@ -189,7 +189,7 @@ describe('PostsView', () => {
         queryParam: { order_by: 'comment_count' },
       },
       {
-        label: 'Most votes',
+        label: 'Most likes',
         queryParam: { order_by: 'vote_count' },
       },
     ])(

--- a/src/discussions/posts/post-filter-bar/messages.js
+++ b/src/discussions/posts/post-filter-bar/messages.js
@@ -78,7 +78,7 @@ const messages = defineMessages({
   },
   voteCount: {
     id: 'discussions.posts.sort.voteCount',
-    defaultMessage: 'Most votes',
+    defaultMessage: 'Most likes',
     description: 'Option in dropdown to sort posts by most votes',
   },
   sortFilterStatus: {


### PR DESCRIPTION
Changed text from "Most votes" to "Most likes" in search filter

Ticket Link:
https://2u-internal.atlassian.net/browse/INF-226

Before
![before](https://user-images.githubusercontent.com/77053848/169298839-e03d9be9-6421-4319-8cea-f0e6f068305c.png)

After
![after](https://user-images.githubusercontent.com/77053848/169298860-2de85685-16e6-41fc-a941-a398529a98bb.png)
