### PR TITLE
fix: image rendering fix for those uploaded using legacy experience

### DIFF
--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -75,7 +75,7 @@ function Post({
       </div>
       <PostHeader post={post} actionHandlers={actionHandlers} />
       <div className="d-flex my-2 text-break">
-        <HTMLLoader htmlNode={post.rawBody} id="post" />
+        <HTMLLoader htmlNode={post.renderedBody} id="post" />
       </div>
       {topicContext && topic && (
         <div className="border p-3 rounded mb-3 mt-2 align-self-start">

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -83,7 +83,7 @@ function PostLink({
             </div>
           </div>
           <div className="text-truncate text-primary-500 font-weight-normal font-size-14 font-style-normal font-family-inter" style={{ 'max-height': '1.6em' }}>
-            <HTMLLoader htmlNode={post.rawBody} />
+            <HTMLLoader htmlNode={post.renderedBody || post.rawBody} />
           </div>
           <PostFooter post={post} preview intl={intl} />
         </div>


### PR DESCRIPTION
TICKET: https://2u-internal.atlassian.net/browse/INF-231

Image loaded from the legacy experience was not rendering in new MFE due to a change made for rendering MathML in a previous PR. as we no longer using MathML syntax and wiris support has been dropped that change is reverted and MFE will again use `renderedBody` key from API to preview post in different areas, and the ripple effect is reverted. now image uploaded from legacy will be visible in new discussion Experience.