### PR TITLE
feat: added preview option for posts/comments/reponses

### DIFF
--- a/src/components/HTMLLoader.jsx
+++ b/src/components/HTMLLoader.jsx
@@ -17,12 +17,13 @@ function HTMLLoader({ htmlNode, componentId, cssClassName }) {
 }
 
 HTMLLoader.propTypes = {
-  htmlNode: PropTypes.node.isRequired,
+  htmlNode: PropTypes.node,
   componentId: PropTypes.string,
   cssClassName: PropTypes.string,
 };
 
 HTMLLoader.defaultProps = {
+  htmlNode: '',
   componentId: null,
   cssClassName: '',
 };

--- a/src/components/PostPreviewPane.jsx
+++ b/src/components/PostPreviewPane.jsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { Button } from '@edx/paragon';
+import { Close } from '@edx/paragon/icons';
+
+import messages from '../discussions/posts/post-editor/messages';
+import HTMLLoader from './HTMLLoader';
+
+function PostPreviewPane({ htmlNode, intl, isPost }) {
+  const [showPreviewPane, setShowPreviewPane] = useState(false);
+
+  return (
+    <>
+      {showPreviewPane && (
+        <div className={`p-2 bg-light-200 rounded shadow-sm ${isPost ? 'mt-3 mb-5.5' : 'my-3'}`}>
+          <Close onClick={() => setShowPreviewPane(false)} className="float-right text-primary-500 mb" />
+          <HTMLLoader htmlNode={htmlNode} />
+        </div>
+      )}
+      <div className="d-flex justify-content-end">
+        {!showPreviewPane
+        && (
+          <Button
+            variant="link"
+            size="md"
+            onClick={() => setShowPreviewPane(true)}
+            className="text-primary-500"
+          >
+            {intl.formatMessage(messages.showPreviewButton)}
+          </Button>
+        )}
+      </div>
+    </>
+  );
+}
+
+PostPreviewPane.propTypes = {
+  intl: intlShape.isRequired,
+  htmlNode: PropTypes.node.isRequired,
+  isPost: PropTypes.bool,
+};
+
+PostPreviewPane.defaultProps = {
+  isPost: false,
+};
+
+export default injectIntl(PostPreviewPane);

--- a/src/discussions/comments/comment/CommentEditor.jsx
+++ b/src/discussions/comments/comment/CommentEditor.jsx
@@ -11,6 +11,7 @@ import { Button, Form, StatefulButton } from '@edx/paragon';
 
 import { TinyMCEEditor } from '../../../components';
 import FormikErrorFeedback from '../../../components/FormikErrorFeedback';
+import PostPreviewPane from '../../../components/PostPreviewPane';
 import { useDispatchWithState } from '../../../data/hooks';
 import { selectModerationSettings, selectUserIsPrivileged } from '../../data/selectors';
 import { formikCompatibleHandler, isFormikFieldInvalid } from '../../utils';
@@ -132,6 +133,7 @@ function CommentEditor({
                 {intl.formatMessage(messages.commentError)}
               </Form.Control.Feedback>
             )}
+          <PostPreviewPane htmlNode={values.comment} />
           <div className="d-flex py-2 justify-content-end">
             <Button
               variant="outline-primary"

--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -1,5 +1,5 @@
 import React, {
-  useContext, useEffect, useRef, useState,
+  useContext, useEffect, useRef,
 } from 'react';
 import PropTypes from 'prop-types';
 
@@ -14,11 +14,11 @@ import { AppContext } from '@edx/frontend-platform/react';
 import {
   Button, Card, Form, Spinner, StatefulButton,
 } from '@edx/paragon';
-import { Cancel, Help, Post } from '@edx/paragon/icons';
+import { Help, Post } from '@edx/paragon/icons';
 
 import { TinyMCEEditor } from '../../../components';
 import FormikErrorFeedback from '../../../components/FormikErrorFeedback';
-import HTMLLoader from '../../../components/HTMLLoader';
+import PostPreviewPane from '../../../components/PostPreviewPane';
 import { useDispatchWithState } from '../../../data/hooks';
 import { selectCourseCohorts } from '../../cohorts/data/selectors';
 import { fetchCourseCohorts } from '../../cohorts/data/thunks';
@@ -78,7 +78,6 @@ function PostEditor({
   const history = useHistory();
   const location = useLocation();
   const commentsPagePath = useCommentsPagePath();
-  const [showPreview, setShowPreview] = useState(false);
   const {
     courseId,
     topicId,
@@ -363,29 +362,25 @@ function PostEditor({
             />
             <FormikErrorFeedback name="comment" />
           </div>
-          {!showPreview
-            ? <Button onClick={() => setShowPreview(true)} size="sm">{intl.formatMessage(messages.showPreviewButton)}</Button>
-            : (
-              <div className="p-2 bg-gray-100">
-                <Cancel onClick={() => setShowPreview(false)} className="float-right" />
-                <HTMLLoader htmlNode={values.comment} />
-              </div>
-            )}
-          {!editExisting
-            && (
-              <div className="d-flex flex-row mt-3">
-                <Form.Group>
-                  <Form.Checkbox
-                    name="follow"
-                    checked={values.follow}
-                    onChange={handleChange}
-                    onBlur={handleBlur}
-                    className="mr-4"
-                  >
-                    {intl.formatMessage(messages.followPost)}
-                  </Form.Checkbox>
-                </Form.Group>
-                {allowAnonymousToPeers
+
+          <PostPreviewPane htmlNode={values.comment} isPost />
+
+          <div className="d-flex flex-row mt-n4.5 w-75">
+            {!editExisting
+              && (
+                <>
+                  <Form.Group>
+                    <Form.Checkbox
+                      name="follow"
+                      checked={values.follow}
+                      onChange={handleChange}
+                      onBlur={handleBlur}
+                      className="mr-4"
+                    >
+                      {intl.formatMessage(messages.followPost)}
+                    </Form.Checkbox>
+                  </Form.Group>
+                  {allowAnonymousToPeers
                   && (
                     <Form.Group>
                       <Form.Checkbox
@@ -398,14 +393,16 @@ function PostEditor({
                       </Form.Checkbox>
                     </Form.Group>
                   )}
-              </div>
-            )}
+                </>
+              )}
+          </div>
 
           <div className="d-flex justify-content-end">
             <Button
               variant="outline-primary"
               onClick={hideEditor}
-            >{intl.formatMessage(messages.cancel)}
+            >
+              {intl.formatMessage(messages.cancel)}
             </Button>
             <StatefulButton
               labels={{


### PR DESCRIPTION
- This PR is created to support mathjax visibility while creating/editing posts comments and responses


the details and screenshots with respect to Figma are attached below

FIGMA Screenshots
<img width="608" alt="Screenshot 2022-06-03 at 7 24 02 PM" src="https://user-images.githubusercontent.com/67791278/171873651-07d8c507-2a31-49e8-a89d-ba57970b4af8.png">
<img width="606" alt="Screenshot 2022-06-03 at 7 24 09 PM" src="https://user-images.githubusercontent.com/67791278/171873670-e185ef7f-d8ad-485d-a64b-78d3c773de40.png">
<img width="611" alt="Screenshot 2022-06-03 at 7 24 20 PM" src="https://user-images.githubusercontent.com/67791278/171873673-ff9a47b2-c201-4353-bf96-7a1e39237d3e.png">
<img width="613" alt="Screenshot 2022-06-03 at 7 24 28 PM" src="https://user-images.githubusercontent.com/67791278/171873677-7155fee0-e427-47c0-8f8e-9540851b6de5.png">


Application screenshots

<img width="918" alt="Screenshot 2022-06-03 at 7 25 42 PM" src="https://user-images.githubusercontent.com/67791278/171874178-ab611602-5818-49db-b65e-4c2ef5cb3b97.png">
<img width="929" alt="Screenshot 2022-06-03 at 7 25 57 PM" src="https://user-images.githubusercontent.com/67791278/171874193-e3c36d4d-7502-4a57-854b-fa985a6da561.png">
<img width="920" alt="Screenshot 2022-06-03 at 7 26 04 PM" src="https://user-images.githubusercontent.com/67791278/171874199-dd133673-8cf4-4a3d-b73f-bfe91148348b.png">
<img width="919" alt="Screenshot 2022-06-03 at 7 26 16 PM" src="https://user-images.githubusercontent.com/67791278/171874207-a395088b-de09-49f8-9c86-07759a2a193e.png">
