### PR TITLE
fix: browser support config updated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "yup": "0.31.1"
       },
       "devDependencies": {
+        "@edx/browserslist-config": "1.1.0",
         "@edx/frontend-build": "9.1.4",
         "@testing-library/jest-dom": "5.16.2",
         "@testing-library/react": "12.1.4",
@@ -1894,6 +1895,12 @@
       "name": "@edx/brand-openedx",
       "version": "1.1.0",
       "license": "GPL-3.0-or-later"
+    },
+    "node_modules/@edx/browserslist-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.1.0.tgz",
+      "integrity": "sha512-2lxL2emt81vJZWa5ujil8yK2eBKVpbPMULI/ocqMuoJ6QVAKXcuonVGpzBHvKvliBzP14UDaF+yN5Ek/nUTByQ==",
+      "dev": true
     },
     "node_modules/@edx/eslint-config": {
       "version": "2.0.0",
@@ -24514,6 +24521,12 @@
     },
     "@edx/brand": {
       "version": "npm:@edx/brand-openedx@1.1.0"
+    },
+    "@edx/browserslist-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.1.0.tgz",
+      "integrity": "sha512-2lxL2emt81vJZWa5ujil8yK2eBKVpbPMULI/ocqMuoJ6QVAKXcuonVGpzBHvKvliBzP14UDaF+yN5Ek/nUTByQ==",
+      "dev": true
     },
     "@edx/eslint-config": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -6,14 +6,10 @@
     "type": "git",
     "url": "git+https://github.com/edx/frontend-app-discussions.git"
   },
-  "browserslist": [
-    "last 2 versions",
-    "ie 11"
-  ],
+  "browserslist": ["extends @edx/browserslist-config"],
   "scripts": {
     "build": "fedx-scripts webpack",
     "i18n_extract": "BABEL_ENV=i18n fedx-scripts babel src --quiet > /dev/null",
-    "is-es5": "es-check es5 ./dist/*.js",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .",
     "lint:fix": "fedx-scripts eslint --ext .js --ext .jsx . --fix",
     "snapshot": "fedx-scripts jest --updateSnapshot",
@@ -60,6 +56,7 @@
     "yup": "0.31.1"
   },
   "devDependencies": {
+    "@edx/browserslist-config": "1.1.0",
     "@edx/frontend-build": "9.1.4",
     "@testing-library/jest-dom": "5.16.2",
     "@testing-library/react": "12.1.4",


### PR DESCRIPTION
The changes in #34 had to be reverted when an upgrade was made from node 12 to 16 in favor of the test case failure issue. 
This has been re-added and edx config list is updated to the latest version for discussions MFE.