### PR TITLE
Preview options

### DIFF
--- a/src/components/HTMLLoader.jsx
+++ b/src/components/HTMLLoader.jsx
@@ -23,9 +23,10 @@ const baseConfig = {
 
 function HTMLLoader({ htmlNode, componentId, cssClassName }) {
   const isLatex = htmlNode.match(/(\${1,2})((?:\\.|.)*)\1/)
-                  || htmlNode.match(/(\[mathjax](.+?)\[\\mathjax])+/)
-                  || htmlNode.match(/(\[mathjaxinline](.+?)\[\\mathjaxinline])+/)
-                  || htmlNode.match(/(\\\[(.+?)\\\])+/);
+                  || htmlNode.match(/(\[mathjax](.+?)\[\/mathjax])+/)
+                  || htmlNode.match(/(\[mathjaxinline](.+?)\[\/mathjaxinline])+/)
+                  || htmlNode.match(/(\\\[(.+?)\\\])+/)
+                  || htmlNode.match(/(\\\((.+?)\\\))+/);
 
   return (
     isLatex ? (

--- a/src/components/PostPreviewPane.jsx
+++ b/src/components/PostPreviewPane.jsx
@@ -8,7 +8,9 @@ import { Close } from '@edx/paragon/icons';
 import messages from '../discussions/posts/post-editor/messages';
 import HTMLLoader from './HTMLLoader';
 
-function PostPreviewPane({ htmlNode, intl, isPost }) {
+function PostPreviewPane({
+  htmlNode, intl, isPost, editExisting,
+}) {
   const [showPreviewPane, setShowPreviewPane] = useState(false);
 
   return (
@@ -26,7 +28,7 @@ function PostPreviewPane({ htmlNode, intl, isPost }) {
             variant="link"
             size="md"
             onClick={() => setShowPreviewPane(true)}
-            className="text-primary-500"
+            className={`text-primary-500 ${editExisting && 'mb-4.5'}`}
           >
             {intl.formatMessage(messages.showPreviewButton)}
           </Button>
@@ -40,10 +42,12 @@ PostPreviewPane.propTypes = {
   intl: intlShape.isRequired,
   htmlNode: PropTypes.node.isRequired,
   isPost: PropTypes.bool,
+  editExisting: PropTypes.bool,
 };
 
 PostPreviewPane.defaultProps = {
   isPost: false,
+  editExisting: false,
 };
 
 export default injectIntl(PostPreviewPane);

--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -363,7 +363,7 @@ function PostEditor({
             <FormikErrorFeedback name="comment" />
           </div>
 
-          <PostPreviewPane htmlNode={values.comment} isPost />
+          <PostPreviewPane htmlNode={values.comment} isPost editExisting={editExisting} />
 
           <div className="d-flex flex-row mt-n4.5 w-75">
             {!editExisting


### PR DESCRIPTION
Amir mentioned following issues after testing on stage,

- Regex check was creating an issue in rendering mathjax for custom syntax 
- Show preview button was hiding behind other elements on screen when editing post.

Both these issues are fixed in this PR
<img width="724" alt="Screenshot 2022-06-06 at 4 37 16 PM" src="https://user-images.githubusercontent.com/67791278/172155179-af03fce3-9384-4dbe-9f40-de850ebc2420.png">

<img width="710" alt="Screenshot 2022-06-06 at 4 14 13 PM" src="https://user-images.githubusercontent.com/67791278/172154911-06b67c4d-db7a-418b-9d18-37b5c414d9bf.png">
