### PR TITLE
fix: post content images overflow

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -8,7 +8,8 @@ $fa-font-path: "~font-awesome/fonts";
 
 #post,
 #comment,
-#reply {
+#reply,
+.discussion-comments {
   img {
     height: auto;
     max-width: 100%;


### PR DESCRIPTION
### [INF-286](https://2u-internal.atlassian.net/browse/INF-286)

- Fix the post content images overflow issue. Now images are responsive in the post content area.

### Before Fix
<img width="992" alt="Screenshot 2022-06-22 at 11 41 06 PM" src="https://user-images.githubusercontent.com/79941147/175112406-e5bdeca6-d61e-4799-85f5-6dca18f1fbee.png">

### After fix
<img width="956" alt="Screenshot 2022-06-22 at 11 42 21 PM" src="https://user-images.githubusercontent.com/79941147/175112632-6bc16716-92f8-46dd-b2e5-53b32f30844d.png">

