### PR TITLE
fix: filtering posts in a topic doesn't work when filtered results are empty [BD-38] []

### DIFF
--- a/src/discussions/posts/data/api.js
+++ b/src/discussions/posts/data/api.js
@@ -27,6 +27,7 @@ export const coursesApiUrl = `${apiBaseUrl}/api/discussion/v1/courses/`;
  * @param {string} threadType Can be 'discussion' or 'question'.
  * @param {ThreadViewStatus} view Set to "unread" on "unanswered" to filter to only those statuses.
  * @param {boolean} countFlagged If true, abuseFlaggedCount will be available.
+ * @param {number} cohort
  * @returns {Promise<{}>}
  */
 export async function getThreads(

--- a/src/discussions/posts/data/thunks.js
+++ b/src/discussions/posts/data/thunks.js
@@ -44,9 +44,10 @@ import {
  * Normalises raw data returned by threads API by mapping threads to id and
  * mapping topic ids to threads in them.
  * @param data
+ * @param {[string]?} topicIds
  * @returns {{pagination, threadsById: {}, threadsInTopic: {}, avatars: {}}}
  */
-export function normaliseThreads(data) {
+export function normaliseThreads(data, topicIds = null) {
   const normalized = {};
   let threads;
   if ('results' in data) {
@@ -59,6 +60,11 @@ export function normaliseThreads(data) {
   const threadsById = {};
   let avatars = {};
   const ids = [];
+  if (topicIds) {
+    topicIds.forEach(topicId => {
+      threadsInTopic[topicId] = [];
+    });
+  }
   threads.forEach(
     thread => {
       const { topicId, id } = thread;
@@ -129,7 +135,7 @@ export function fetchThreads(courseId, {
     try {
       dispatch(fetchThreadsRequest({ courseId }));
       const data = await getThreads(courseId, options);
-      const normalisedData = normaliseThreads(camelCaseObject(data));
+      const normalisedData = normaliseThreads(camelCaseObject(data), topicIds);
       dispatch(fetchThreadsSuccess({ ...normalisedData, page, author }));
     } catch (error) {
       if (getHttpErrorStatus(error) === 403) {


### PR DESCRIPTION
A list of all posts in a topic is stored in an object for quick lookup. This is used when switching between topics to get the list of posts in that topic. When filters change, the list of posts in a topic is updated and this is picked up by the UI. If changing filters when browsing a topic results in an empty result, this would cause the original list of topics for that topic to be retained, causing the filter to simply not apply. This commit fixes that by resetting the post list in that case.


**Testing instructions**

Before checking out this PR try the following:
- In an empty topic, create a few discussion posts. 
- Navigate to that topic
- Filter that topic by "discussions"
- Now filter by "questions"
- The "questions" filter will not apply. 
- Now try creating one or more question posts in the same topic. 
- Switch between the "discussion" and "question" filter again. It should work now. 

Now try the above after checking out this PR. Switching between "discussions" and "questions" will work now, even if one of the filters is empty. 