### PR TITLE
fix: post editor images and preview images responsiveness

### DIFF
--- a/src/components/PostPreviewPane.jsx
+++ b/src/components/PostPreviewPane.jsx
@@ -16,7 +16,7 @@ function PostPreviewPane({
   return (
     <>
       {showPreviewPane && (
-        <div className={`p-2 bg-light-200 rounded shadow-sm ${isPost ? 'mt-3 mb-5.5' : 'my-3'}`} style={{ maxHeight: '200px', overflow: 'scroll' }}>
+        <div className={`p-2 bg-light-200 rounded shadow-sm post-preview ${isPost ? 'mt-3 mb-5.5' : 'my-3'}`} style={{ maxHeight: '200px', overflow: 'scroll' }}>
           <Close onClick={() => setShowPreviewPane(false)} className="float-right text-primary-500 mb" />
           <HTMLLoader htmlNode={htmlNode} />
         </div>

--- a/src/components/TinyMCEEditor.jsx
+++ b/src/components/TinyMCEEditor.jsx
@@ -96,7 +96,7 @@ export default function TinyMCEEditor(props) {
           + ' | charmap',
         content_css: false,
         content_style: contentStyle,
-        body_class: 'm-2',
+        body_class: 'm-2 text-editor',
         default_link_target: '_blank',
         target_list: false,
         images_upload_handler: uploadHandler,

--- a/src/index.scss
+++ b/src/index.scss
@@ -9,7 +9,9 @@ $fa-font-path: "~font-awesome/fonts";
 #post,
 #comment,
 #reply,
-.discussion-comments {
+.discussion-comments,
+.text-editor,
+.post-preview {
   img {
     height: auto;
     max-width: 100%;


### PR DESCRIPTION
**[INF-286](https://2u-internal.atlassian.net/browse/INF-286)**

- Post, comments, and responses images are responsive in the post editor and preview area.

### Before fix
<img width="927" alt="Screenshot 2022-06-27 at 2 18 57 PM" src="https://user-images.githubusercontent.com/79941147/175905942-20e213e2-543f-46e9-b366-fa69e472616f.png">
<img width="952" alt="Screenshot 2022-06-27 at 2 19 26 PM" src="https://user-images.githubusercontent.com/79941147/175905972-9c73aaf0-3a24-4738-9e20-f6d85004a49a.png">


### After fix
<img width="918" alt="Screenshot 2022-06-27 at 2 02 18 PM" src="https://user-images.githubusercontent.com/79941147/175905163-a94e543c-cdaf-4e97-ab0a-1f627b9697ad.png">
<img width="935" alt="Screenshot 2022-06-27 at 2 02 45 PM" src="https://user-images.githubusercontent.com/79941147/175905193-2cb9b5f6-dca9-4b66-a774-2355bf5a6d51.png">
<img width="949" alt="Screenshot 2022-06-27 at 2 03 02 PM" src="https://user-images.githubusercontent.com/79941147/175905199-04ea910f-4eaf-4f8b-9d24-273cf9dc4132.png">
