### PR TITLE
fix: load thread if thread data doesnot exist in redux

### DIFF
--- a/src/discussions/comments/CommentsView.jsx
+++ b/src/discussions/comments/CommentsView.jsx
@@ -11,7 +11,7 @@ import { EndorsementStatus, ThreadType } from '../../data/constants';
 import { useDispatchWithState } from '../../data/hooks';
 import { Post } from '../posts';
 import { selectThread } from '../posts/data/selectors';
-import { markThreadAsRead } from '../posts/data/thunks';
+import { fetchThread, markThreadAsRead } from '../posts/data/thunks';
 import { selectThreadComments, selectThreadCurrentPage, selectThreadHasMorePages } from './data/selectors';
 import { fetchThreadComments } from './data/thunks';
 import { Comment, ResponseEditor } from './comment';
@@ -109,7 +109,9 @@ DiscussionCommentsView.propTypes = {
 function CommentsView({ intl }) {
   const { postId } = useParams();
   const thread = usePost(postId);
+  const dispatch = useDispatch();
   if (!thread) {
+    dispatch(fetchThread(postId));
     return (
       <Spinner animation="border" variant="primary" data-testid="loading-indicator" />
     );


### PR DESCRIPTION
Thread is not loaded when thread data is not found in the redux store. After this change, it will send an API call to get thread from server.

This issue was found when working on the following ticket
https://2u-internal.atlassian.net/browse/INF-349
