### PR TITLE
fix: show deactivated in case of retired user

### DIFF
--- a/src/discussions/common/AuthorLabel.jsx
+++ b/src/discussions/common/AuthorLabel.jsx
@@ -45,7 +45,7 @@ function AuthorLabel({
         role="heading"
         aria-level="2"
       >
-        {author}
+        {author.startsWith('retired__user') ? '(Deactivated)' : author }
       </span>
       {icon && (
         <Icon

--- a/src/discussions/common/AuthorLabel.jsx
+++ b/src/discussions/common/AuthorLabel.jsx
@@ -34,7 +34,7 @@ function AuthorLabel({
     authorLabelMessage = intl.formatMessage(messages.authorLabelTA);
   }
 
-  const isRetiredUser = author.startsWith('retired__user');
+  const isRetiredUser = author ? author.startsWith('retired__user') : false;
 
   const className = classNames('d-flex align-items-center', labelColor);
 

--- a/src/discussions/common/AuthorLabel.jsx
+++ b/src/discussions/common/AuthorLabel.jsx
@@ -34,18 +34,21 @@ function AuthorLabel({
     authorLabelMessage = intl.formatMessage(messages.authorLabelTA);
   }
 
+  const isRetiredUser = author.startsWith('retired__user');
+
   const className = classNames('d-flex align-items-center', labelColor);
 
   const labelContents = (
     <div className={className}>
       <span
         className={classNames('mr-1 font-size-14 font-style-normal font-family-inter font-weight-500', {
-          'text-primary-500': !authorLabelMessage,
+          'text-primary-500': !authorLabelMessage && !isRetiredUser,
+          'text-gray-700': isRetiredUser,
         })}
         role="heading"
         aria-level="2"
       >
-        {author.startsWith('retired__user') ? '(Deactivated)' : author }
+        {isRetiredUser ? '[Deactivated]' : author }
       </span>
       {icon && (
         <Icon


### PR DESCRIPTION
In case when user is retired show Deactivated instead of user name because user name is converted to hash after it is retired.

Before
<img width="562" alt="Screen Shot 2022-07-22 at 4 46 18 PM" src="https://user-images.githubusercontent.com/26253150/180720334-a5093d6c-f685-4770-9655-2ca0e059da27.png">

After
<img width="492" alt="Screen Shot 2022-07-25 at 12 16 39 PM" src="https://user-images.githubusercontent.com/26253150/180720362-b4f3b270-7db2-418a-991d-86f9c352090d.png">

