### PR TITLE
 [Blocked] Added count_flagged param to learners tab

### DIFF
--- a/src/discussions/learners/LearnerPostsView.jsx
+++ b/src/discussions/learners/LearnerPostsView.jsx
@@ -22,6 +22,7 @@ import { PostLink } from '../posts/post';
 import { discussionsPath } from '../utils';
 import { fetchUserPosts } from './data/thunks';
 import messages from './messages';
+import { selectconfigLoadingStatus, selectUserIsPrivileged, selectUserIsStaff } from '../data/selectors';
 
 function LearnerPostsView({ intl }) {
   const location = useLocation();
@@ -32,15 +33,25 @@ function LearnerPostsView({ intl }) {
   const loadingStatus = useSelector(threadsLoadingStatus());
   const { courseId, learnerUsername: username } = useContext(DiscussionContext);
   const nextPage = useSelector(selectThreadNextPage());
+  const userIsPrivileged = useSelector(selectUserIsPrivileged);
+  const userIsStaff = useSelector(selectUserIsStaff);
+  const configStatus = useSelector(selectconfigLoadingStatus);
+
+  const getUserPosts = (pageNumber = 1) => {
+    dispatch(fetchUserPosts(courseId, username, {
+      page: pageNumber,
+      countFlagged: userIsPrivileged || userIsStaff,
+    }));
+  };
 
   useEffect(() => {
-    dispatch(fetchUserPosts(courseId, username));
-  }, [courseId, username]);
+    if (configStatus === RequestStatus.SUCCESSFUL) {
+      getUserPosts();
+    }
+  }, [courseId, username, configStatus]);
 
   const loadMorePosts = () => (
-    dispatch(fetchUserPosts(courseId, username, {
-      page: nextPage,
-    }))
+    getUserPosts(nextPage)
   );
 
   const checkIsSelected = (id) => window.location.pathname.includes(id);

--- a/src/discussions/learners/LearnerPostsView.jsx
+++ b/src/discussions/learners/LearnerPostsView.jsx
@@ -20,9 +20,9 @@ import {
 import NoResults from '../posts/NoResults';
 import { PostLink } from '../posts/post';
 import { discussionsPath } from '../utils';
-import { fetchUserPosts } from './data/thunks';
 import messages from './messages';
 import { selectconfigLoadingStatus, selectUserIsPrivileged, selectUserIsStaff } from '../data/selectors';
+import { fetchThreads } from '../posts/data/thunks';
 
 function LearnerPostsView({ intl }) {
   const location = useLocation();
@@ -38,8 +38,9 @@ function LearnerPostsView({ intl }) {
   const configStatus = useSelector(selectconfigLoadingStatus);
 
   const getUserPosts = (pageNumber = 1) => {
-    dispatch(fetchUserPosts(courseId, username, {
+    dispatch(fetchThreads(courseId, {
       page: pageNumber,
+      author: username,
       countFlagged: userIsPrivileged || userIsStaff,
     }));
   };
@@ -91,8 +92,8 @@ function LearnerPostsView({ intl }) {
       </div>
       <div className="bg-light-400 border border-light-300" />
       <div className="list-group list-group-flush">
-        {postInstances}
-        {posts?.length === 0 && <NoResults />}
+        {loadingStatus === RequestStatus.SUCCESSFUL && postInstances}
+        {posts?.length === 0 && loadingStatus === RequestStatus.SUCCESSFUL && <NoResults />}
         {loadingStatus === RequestStatus.IN_PROGRESS ? (
           <div className="d-flex justify-content-center p-4">
             <Spinner animation="border" variant="primary" size="lg" />

--- a/src/discussions/learners/data/api.js
+++ b/src/discussions/learners/data/api.js
@@ -18,7 +18,6 @@ export const userProfileApiUrl = `${apiBaseUrl}/api/user/v1/accounts`;
  * @returns {Promise<{}>}
  */
 export async function getLearners(courseId, params) {
-  debugger;
   const url = `${coursesApiUrl}${courseId}/activity_stats/`;
   const { data } = await getAuthenticatedHttpClient().get(url, { params });
   return data;

--- a/src/discussions/learners/data/api.js
+++ b/src/discussions/learners/data/api.js
@@ -18,6 +18,7 @@ export const userProfileApiUrl = `${apiBaseUrl}/api/user/v1/accounts`;
  * @returns {Promise<{}>}
  */
 export async function getLearners(courseId, params) {
+  debugger;
   const url = `${coursesApiUrl}${courseId}/activity_stats/`;
   const { data } = await getAuthenticatedHttpClient().get(url, { params });
   return data;
@@ -39,16 +40,16 @@ export async function getUserProfiles(usernames) {
  * @param {string} courseId Course ID of the course
  * @param {string} username Username of the user
  * @param {number} page
+ * @param {boolean} countFlagged
  * @returns API Response object in the format
  *  {
  *    results: [array of posts],
  *    pagination: {count, num_pages, next, previous}
  *  }
  */
-export async function getUserPosts(courseId, username, { page }) {
+export async function getUserPosts(courseId, username, { page, countFlagged }) {
   const learnerPostsApiUrl = `${coursesApiUrl}${courseId}/learner/`;
-
   const { data } = await getAuthenticatedHttpClient()
-    .get(learnerPostsApiUrl, { params: { username, page } });
+    .get(learnerPostsApiUrl, { params: { username, page, count_flagged: countFlagged } });
   return data;
 }

--- a/src/discussions/learners/data/thunks.js
+++ b/src/discussions/learners/data/thunks.js
@@ -65,14 +65,17 @@ export function fetchLearners(courseId, {
  * @param {string} courseId Course ID of the course eg., course-v1:X+Y+Z
  * @param {string} username name of the learner
  * @param page
+ * @param countFlagged
  * @returns a promise that will update the state with the learner's posts
  */
-export function fetchUserPosts(courseId, username, { page = 1 } = {}) {
+export function fetchUserPosts(courseId, username, {
+  page = 1,
+  countFlagged = false,
+} = {}) {
   return async (dispatch) => {
     try {
       dispatch(fetchLearnerThreadsRequest({ courseId, author: username }));
-
-      const data = await getUserPosts(courseId, username, { page });
+      const data = await getUserPosts(courseId, username, { page, countFlagged });
       const normalisedData = normaliseThreads(camelCaseObject(data));
 
       dispatch(fetchThreadsSuccess({ ...normalisedData, page, author: username }));


### PR DESCRIPTION
Show reported tag on post link if comment on the post is flagged
The learner tab was using `fetchUserPosts` API it  does not support `count_flagged` now It is updated to use `fetchThreads`.

https://2u-internal.atlassian.net/browse/INF-365