### PR TITLE
feat: add header footer for discussion MFE behind inIframe query_param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
+        "@edx/frontend-component-footer": "10.2.1",
+        "@edx/frontend-component-header": "2.4.5",
         "@edx/frontend-platform": "1.15.4",
         "@edx/paragon": "19.10.1",
         "@reduxjs/toolkit": "1.8.0",
@@ -3392,6 +3394,58 @@
         "node": ">=6"
       }
     },
+    "node_modules/@edx/frontend-component-footer": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer/-/frontend-component-footer-10.2.1.tgz",
+      "integrity": "sha512-ZhXOKWQ8sw9b8boRKOtZT8BkI5ULYPXPaTR4PeRQUBSDu3CA6J/NwcCOlh8OftR4fOY2oI19D9BImhYIB4o6eA==",
+      "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "1.2.36",
+        "@fortawesome/free-brands-svg-icons": "5.15.4",
+        "@fortawesome/free-regular-svg-icons": "5.15.4",
+        "@fortawesome/free-solid-svg-icons": "5.15.4",
+        "@fortawesome/react-fontawesome": "0.1.16"
+      },
+      "peerDependencies": {
+        "@edx/frontend-platform": "^1.8.0",
+        "prop-types": "^15.5.10",
+        "react": "^16.9.0",
+        "react-dom": "^16.9.0"
+      }
+    },
+    "node_modules/@edx/frontend-component-footer/node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.16.tgz",
+      "integrity": "sha512-aLmzDwC9rEOAJv2UJdMns89VZR5Ry4IHu5dQQh24Z/lWKEm44lfQr1UNalZlkUaQN8d155tNh+CS7ntntj1VMA==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || >=1.3.0-beta1",
+        "react": ">=16.x"
+      }
+    },
+    "node_modules/@edx/frontend-component-header": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-2.4.5.tgz",
+      "integrity": "sha512-II0+1cKLKLT954uStqWNpFo+gVn3AyFSD+kIer7NOaH5PB/XpYdsxu4PUIftFeYbrFY3SHsBDALjOsRT+LFNsg==",
+      "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "1.2.36",
+        "@fortawesome/free-brands-svg-icons": "5.15.4",
+        "@fortawesome/free-regular-svg-icons": "5.15.4",
+        "@fortawesome/free-solid-svg-icons": "5.15.4",
+        "@fortawesome/react-fontawesome": "^0.1.14",
+        "babel-polyfill": "6.26.0",
+        "react-responsive": "8.2.0",
+        "react-transition-group": "4.4.2"
+      },
+      "peerDependencies": {
+        "@edx/frontend-platform": "^1.8.0",
+        "@edx/paragon": ">= 7.0.0 < 20.0.0",
+        "prop-types": "^15.5.10",
+        "react": "^16.9.0",
+        "react-dom": "^16.9.0"
+      }
+    },
     "node_modules/@edx/frontend-platform": {
       "version": "1.15.4",
       "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-1.15.4.tgz",
@@ -3435,6 +3489,14 @@
       "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
       "dependencies": {
         "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/@edx/frontend-platform/node_modules/localforage": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.9.0.tgz",
+      "integrity": "sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==",
+      "dependencies": {
+        "lie": "3.1.1"
       }
     },
     "node_modules/@edx/new-relic-source-map-webpack-plugin": {
@@ -3572,6 +3634,30 @@
       "version": "1.2.36",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
       "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.15.4.tgz",
+      "integrity": "sha512-f1witbwycL9cTENJegcmcZRYyawAFbm8+c6IirLmwbbpqz46wyjbQYLuxOc7weXFXfB7QR8/Vd2u5R3q6JYD9g==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.15.4.tgz",
+      "integrity": "sha512-9VNNnU3CXHy9XednJ3wzQp6SwNwT3XaM26oS4Rp391GsxVYA+0oDR2J194YCIWf7jNRCYKjUCOduxdceLrx+xw==",
       "hasInstallScript": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^0.2.36"
@@ -19102,9 +19188,9 @@
       }
     },
     "node_modules/localforage": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.9.0.tgz",
-      "integrity": "sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
       "dependencies": {
         "lie": "3.1.1"
       }
@@ -29569,6 +29655,43 @@
         }
       }
     },
+    "@edx/frontend-component-footer": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer/-/frontend-component-footer-10.2.1.tgz",
+      "integrity": "sha512-ZhXOKWQ8sw9b8boRKOtZT8BkI5ULYPXPaTR4PeRQUBSDu3CA6J/NwcCOlh8OftR4fOY2oI19D9BImhYIB4o6eA==",
+      "requires": {
+        "@fortawesome/fontawesome-svg-core": "1.2.36",
+        "@fortawesome/free-brands-svg-icons": "5.15.4",
+        "@fortawesome/free-regular-svg-icons": "5.15.4",
+        "@fortawesome/free-solid-svg-icons": "5.15.4",
+        "@fortawesome/react-fontawesome": "0.1.16"
+      },
+      "dependencies": {
+        "@fortawesome/react-fontawesome": {
+          "version": "0.1.16",
+          "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.16.tgz",
+          "integrity": "sha512-aLmzDwC9rEOAJv2UJdMns89VZR5Ry4IHu5dQQh24Z/lWKEm44lfQr1UNalZlkUaQN8d155tNh+CS7ntntj1VMA==",
+          "requires": {
+            "prop-types": "^15.7.2"
+          }
+        }
+      }
+    },
+    "@edx/frontend-component-header": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-2.4.5.tgz",
+      "integrity": "sha512-II0+1cKLKLT954uStqWNpFo+gVn3AyFSD+kIer7NOaH5PB/XpYdsxu4PUIftFeYbrFY3SHsBDALjOsRT+LFNsg==",
+      "requires": {
+        "@fortawesome/fontawesome-svg-core": "1.2.36",
+        "@fortawesome/free-brands-svg-icons": "5.15.4",
+        "@fortawesome/free-regular-svg-icons": "5.15.4",
+        "@fortawesome/free-solid-svg-icons": "5.15.4",
+        "@fortawesome/react-fontawesome": "^0.1.14",
+        "babel-polyfill": "6.26.0",
+        "react-responsive": "8.2.0",
+        "react-transition-group": "4.4.2"
+      }
+    },
     "@edx/frontend-platform": {
       "version": "1.15.4",
       "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-1.15.4.tgz",
@@ -29599,6 +29722,14 @@
           "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
           "requires": {
             "follow-redirects": "^1.14.8"
+          }
+        },
+        "localforage": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.9.0.tgz",
+          "integrity": "sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==",
+          "requires": {
+            "lie": "3.1.1"
           }
         }
       }
@@ -29726,6 +29857,22 @@
       "version": "1.2.36",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
       "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      }
+    },
+    "@fortawesome/free-brands-svg-icons": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.15.4.tgz",
+      "integrity": "sha512-f1witbwycL9cTENJegcmcZRYyawAFbm8+c6IirLmwbbpqz46wyjbQYLuxOc7weXFXfB7QR8/Vd2u5R3q6JYD9g==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      }
+    },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.15.4.tgz",
+      "integrity": "sha512-9VNNnU3CXHy9XednJ3wzQp6SwNwT3XaM26oS4Rp391GsxVYA+0oDR2J194YCIWf7jNRCYKjUCOduxdceLrx+xw==",
       "requires": {
         "@fortawesome/fontawesome-common-types": "^0.2.36"
       }
@@ -41665,9 +41812,9 @@
       }
     },
     "localforage": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.9.0.tgz",
-      "integrity": "sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
       "requires": {
         "lie": "3.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   },
   "dependencies": {
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
+    "@edx/frontend-component-footer": "10.2.1",
+    "@edx/frontend-component-header": "2.4.5",
     "@edx/frontend-platform": "1.15.4",
     "@edx/paragon": "19.10.1",
     "@reduxjs/toolkit": "1.8.0",

--- a/src/discussions/discussions-home/DiscussionsHome.jsx
+++ b/src/discussions/discussions-home/DiscussionsHome.jsx
@@ -5,6 +5,9 @@ import {
   Route, Switch, useLocation, useRouteMatch,
 } from 'react-router';
 
+import Footer from '@edx/frontend-component-footer';
+import Header from '@edx/frontend-component-header';
+
 import { PostActionsBar } from '../../components';
 import { CourseTabsNavigation } from '../../components/NavigationBar';
 import { ALL_ROUTES, DiscussionProvider, Routes } from '../../data/constants';
@@ -73,6 +76,7 @@ export default function DiscussionsHome() {
       learnerUsername,
     }}
     >
+      {!inIframe && <Header />}
       <main className="container-fluid d-flex flex-column p-0 h-100 w-100 overflow-hidden">
         {!inIframe
           && <CourseTabsNavigation activeTab="discussion" courseId={courseId} />}
@@ -108,6 +112,7 @@ export default function DiscussionsHome() {
           )}
         </div>
       </main>
+      {!inIframe && <Footer />}
     </DiscussionContext.Provider>
   );
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,6 +4,8 @@ import 'regenerator-runtime/runtime';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import { messages as footerMessages } from '@edx/frontend-component-footer';
+import { messages as headerMessages } from '@edx/frontend-component-header';
 import {
   APP_INIT_ERROR, APP_READY, initialize, subscribe,
 } from '@edx/frontend-platform';
@@ -32,6 +34,8 @@ subscribe(APP_INIT_ERROR, (error) => {
 initialize({
   requireAuthenticatedUser: true,
   messages: [
+    headerMessages,
+    footerMessages,
     appMessages,
   ],
 });

--- a/src/index.scss
+++ b/src/index.scss
@@ -107,3 +107,7 @@ $fa-font-path: "~font-awesome/fonts";
   margin-top: 17px;
   margin-left: 17px;
 }
+
+header nav.nav.secondary-menu-container {
+  z-index: 10000;
+}


### PR DESCRIPTION
### [INF-334](https://2u-internal.atlassian.net/browse/INF-334)

### Description

Add back the header and footer components to the MFE, based on `inIframe` query_param.


#### Header Screenshot
<img width="1440" alt="Screen Shot 2022-08-04 at 1 36 48 PM" src="https://user-images.githubusercontent.com/30112155/182802956-d0a1f7e0-febd-4eb4-8cf0-8fa85d87a7ab.png">


#### Footer Screenshot
<img width="1437" alt="Screen Shot 2022-08-04 at 1 37 04 PM" src="https://user-images.githubusercontent.com/30112155/182802915-4674d7e2-f2ff-45ee-9154-0da92f0388ed.png">

**NOTE: _theme in screenshot is different to theme that is live on site. Screenshot was just to give an idea of how the header and footer look._**