### PR TITLE
fix: display direct link post at top of the list

### DIFF
--- a/src/discussions/comments/CommentsView.jsx
+++ b/src/discussions/comments/CommentsView.jsx
@@ -114,7 +114,7 @@ function CommentsView({ intl }) {
   const thread = usePost(postId);
   const dispatch = useDispatch();
   if (!thread) {
-    dispatch(fetchThread(postId));
+    dispatch(fetchThread(postId, true));
     return (
       <Spinner animation="border" variant="primary" data-testid="loading-indicator" />
     );

--- a/src/discussions/posts/data/slices.js
+++ b/src/discussions/posts/data/slices.js
@@ -55,8 +55,12 @@ const threadsSlice = createSlice({
         state.pages = [];
         state.author = payload.author;
       }
+      if (state.pages[payload.page - 1]) {
+        state.pages[payload.page - 1] = [...state.pages[payload.page - 1], ...payload.ids];
+      } else {
+        state.pages[payload.page - 1] = payload.ids;
+      }
       state.status = RequestStatus.SUCCESSFUL;
-      state.pages[payload.page - 1] = payload.ids;
       state.threadsById = { ...state.threadsById, ...payload.threadsById };
       state.threadsInTopic = { ...state.threadsInTopic, ...payload.threadsInTopic };
       state.avatars = { ...state.avatars, ...payload.avatars };
@@ -76,6 +80,13 @@ const threadsSlice = createSlice({
     fetchThreadSuccess: (state, { payload }) => {
       state.status = RequestStatus.SUCCESSFUL;
       state.threadsById = { ...state.threadsById, ...payload.threadsById };
+      state.avatars = { ...state.avatars, ...payload.avatars };
+    },
+    fetchThreadByDirectLinkSuccess: (state, { payload }) => {
+      state.status = RequestStatus.SUCCESSFUL;
+      state.pages[payload.page - 1] = payload.ids;
+      state.threadsInTopic = { ...payload.threadsInTopic, ...state.threadsInTopic };
+      state.threadsById = { ...payload.threadsById, ...state.threadsById };
       state.avatars = { ...state.avatars, ...payload.avatars };
     },
     fetchThreadFailed: (state) => {
@@ -194,6 +205,7 @@ export const {
   fetchThreadsRequest,
   fetchThreadsSuccess,
   fetchThreadSuccess,
+  fetchThreadByDirectLinkSuccess,
   postThreadDenied,
   postThreadFailed,
   postThreadRequest,

--- a/src/discussions/posts/data/thunks.js
+++ b/src/discussions/posts/data/thunks.js
@@ -14,6 +14,7 @@ import {
   deleteThreadFailed,
   deleteThreadRequest,
   deleteThreadSuccess,
+  fetchThreadByDirectLinkSuccess,
   fetchThreadDenied,
   fetchThreadFailed,
   fetchThreadRequest,
@@ -148,12 +149,16 @@ export function fetchThreads(courseId, {
   };
 }
 
-export function fetchThread(threadId) {
+export function fetchThread(threadId, isDirectLinkPost = false) {
   return async (dispatch) => {
     try {
       dispatch(fetchThreadRequest({ threadId }));
       const data = await getThread(threadId);
-      dispatch(fetchThreadSuccess(normaliseThreads(camelCaseObject(data))));
+      if (isDirectLinkPost) {
+        dispatch(fetchThreadByDirectLinkSuccess({ ...normaliseThreads(camelCaseObject(data)), page: 1 }));
+      } else {
+        dispatch(fetchThreadSuccess(normaliseThreads(camelCaseObject(data))));
+      }
     } catch (error) {
       if (getHttpErrorStatus(error) === 403) {
         dispatch(fetchThreadDenied());


### PR DESCRIPTION
### [INF-353](https://2u-internal.atlassian.net/browse/INF-353)

- That post will be opened and rendered in the All posts tab.
- A Direct link post will display on top of the list then Pinned posts will show, then the remaining posts.
- In the list pane, all remaining posts will load according to the default filters and sorts for the user (learner vs moderator)

<img width="1440" alt="Screenshot 2022-08-01 at 5 08 24 PM" src="https://user-images.githubusercontent.com/79941147/182144857-699086e8-6792-43c4-8fb5-39c7f817fe3f.png">
