### PR TITLE
feat: add a posts list back button for small devices and improve responsiveness 

### DIFF
--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -199,6 +199,14 @@ export const Routes = {
   },
 };
 
+export const PostsPages = {
+  category: `${BASE_PATH}/category/:category/posts`,
+  topics: `${BASE_PATH}/topics/:topicId/posts`,
+  posts: `${BASE_PATH}/posts`,
+  'my-posts': `${BASE_PATH}/my-posts`,
+  learners: `${BASE_PATH}/learners/:learnerUsername/posts`,
+};
+
 export const ALL_ROUTES = []
   .concat([Routes.TOPICS.CATEGORY_POST, Routes.TOPICS.CATEGORY])
   .concat(Routes.COMMENTS.PATH)

--- a/src/discussions/common/AlertBanner.jsx
+++ b/src/discussions/common/AlertBanner.jsx
@@ -33,7 +33,7 @@ function AlertBanner({
         <>
           {content.lastEdit?.reason && (
             <Alert variant="info" className="px-3 shadow-none mb-2 py-10px bg-light-200">
-              <div className="d-flex align-items-center">
+              <div className="d-flex align-items-center flex-wrap">
                 {intl.formatMessage(messages.editedBy)}
                 <span className="ml-1 mr-3">
                   <AuthorLabel author={content.lastEdit.editorUsername} linkToProfile />
@@ -44,7 +44,7 @@ function AlertBanner({
           )}
           {content.closed && (
             <Alert variant="info" className="px-3 shadow-none mb-2 py-10px bg-light-200">
-              <div className="d-flex align-items-center">
+              <div className="d-flex align-items-center flex-wrap">
                 {intl.formatMessage(messages.closedBy)}
                 <span className="ml-1 ">
                   <AuthorLabel author={content.closedBy} linkToProfile />

--- a/src/discussions/common/EndorsedAlertBanner.jsx
+++ b/src/discussions/common/EndorsedAlertBanner.jsx
@@ -29,14 +29,14 @@ function EndorsedAlertBanner({
         style={{ borderRadius: '0.375rem 0.375rem 0 0' }}
         icon={iconClass}
       >
-        <div className="d-flex justify-content-between">
+        <div className="d-flex justify-content-between flex-wrap">
           <strong className="lead">{intl.formatMessage(
             isQuestion
               ? messages.answer
               : messages.endorsed,
           )}
           </strong>
-          <span className="d-flex align-items-center mr-1">
+          <span className="d-flex align-items-center mr-1 flex-wrap">
             <span className="mr-2">
               {intl.formatMessage(
                 isQuestion

--- a/src/discussions/data/hooks.js
+++ b/src/discussions/data/hooks.js
@@ -91,6 +91,11 @@ export function useIsOnDesktop() {
   return windowSize.width >= breakpoints.large.minWidth;
 }
 
+export function useIsOnXLDesktop() {
+  const windowSize = useWindowSize();
+  return windowSize.width >= breakpoints.extraLarge.minWidth;
+}
+
 /**
  * Given an element this attempts to get the height of the entire UI.
  *

--- a/src/discussions/discussions-home/DiscussionContent.jsx
+++ b/src/discussions/discussions-home/DiscussionContent.jsx
@@ -1,21 +1,48 @@
-import React, { useRef } from 'react';
+import React, { useContext, useRef } from 'react';
 
 import { useSelector } from 'react-redux';
 import { Route, Switch } from 'react-router';
+import { useHistory, useLocation } from 'react-router-dom';
 
-import { Routes } from '../../data/constants';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { Icon, IconButton } from '@edx/paragon';
+import { ArrowBack } from '@edx/paragon/icons';
+
+import { PostsPages, Routes } from '../../data/constants';
 import { CommentsView } from '../comments';
-import { useContainerSizeForParent } from '../data/hooks';
+import { DiscussionContext } from '../common/context';
+import { useContainerSizeForParent, useIsOnDesktop } from '../data/hooks';
+import messages from '../messages';
 import { PostEditor } from '../posts';
+import { discussionsPath } from '../utils';
 
-export default function DiscussionContent() {
+function DiscussionContent({ intl }) {
+  const location = useLocation();
+  const history = useHistory();
   const refContainer = useRef(null);
   const postEditorVisible = useSelector((state) => state.threads.postEditorVisible);
+  const isOnDesktop = useIsOnDesktop();
+  const {
+    courseId, learnerUsername, category, topicId, page,
+  } = useContext(DiscussionContext);
   useContainerSizeForParent(refContainer);
 
   return (
     <div className="d-flex bg-light-400 flex-column w-75 w-xs-100 w-xl-75 align-items-center h-100 overflow-auto">
-      <div className="d-flex flex-column w-100 mw-xl" ref={refContainer}>
+      <div className="d-flex flex-column w-100" ref={refContainer}>
+        {!isOnDesktop && (
+          <IconButton
+            src={ArrowBack}
+            iconAs={Icon}
+            style={{ padding: '18px' }}
+            size="inline"
+            className="ml-4 mt-4"
+            onClick={() => history.push(discussionsPath(PostsPages[page], {
+              courseId, learnerUsername, category, topicId,
+            })(location))}
+            alt={intl.formatMessage(messages.backAlt)}
+          />
+        )}
         {postEditorVisible ? (
           <Route path={Routes.POSTS.NEW_POST}>
             <PostEditor />
@@ -34,3 +61,9 @@ export default function DiscussionContent() {
     </div>
   );
 }
+
+DiscussionContent.propTypes = {
+  intl: intlShape.isRequired,
+};
+
+export default injectIntl(DiscussionContent);

--- a/src/discussions/discussions-home/DiscussionSidebar.jsx
+++ b/src/discussions/discussions-home/DiscussionSidebar.jsx
@@ -7,20 +7,25 @@ import {
 } from 'react-router';
 
 import { Routes } from '../../data/constants';
+import { useIsOnDesktop, useIsOnXLDesktop } from '../data/hooks';
 import { LearnerPostsView, LearnersView } from '../learners';
 import { PostsView } from '../posts';
 import { TopicsView } from '../topics';
 
 export default function DiscussionSidebar({ displaySidebar }) {
   const location = useLocation();
+  const isOnDesktop = useIsOnDesktop();
+  const isOnXLDesktop = useIsOnXLDesktop();
 
   return (
     <div
       className={classNames('flex-column', {
         'd-none': !displaySidebar,
-        'd-flex w-25 w-xs-100 w-lg-25 h-100 overflow-auto': displaySidebar,
+        'd-flex h-100 overflow-auto': displaySidebar,
+        'w-100': !isOnDesktop,
+        'sidebar-desktop-width': isOnDesktop && !isOnXLDesktop,
+        'w-25 sidebar-XL-width': isOnXLDesktop,
       })}
-      style={{ minWidth: '29rem' }}
       data-testid="sidebar"
     >
       <Switch>

--- a/src/discussions/messages.js
+++ b/src/discussions/messages.js
@@ -6,6 +6,11 @@ const messages = defineMessages({
     defaultMessage: 'Actions menu',
     description: 'Alt-text for dropdown button for actions related to a post or comment',
   },
+  backAlt: {
+    id: 'discussions.actions.back.alt',
+    defaultMessage: 'Back',
+    description: 'Text on button for back to posts list',
+  },
   editAction: {
     id: 'discussions.actions.edit',
     defaultMessage: 'Edit',

--- a/src/index.scss
+++ b/src/index.scss
@@ -118,3 +118,11 @@ header nav.nav.secondary-menu-container {
     text-decoration: underline;
   }
 }
+
+.sidebar-desktop-width {
+  min-width: 25rem;
+}
+
+.sidebar-XL-width {
+  min-width: 29rem;
+}


### PR DESCRIPTION
### [INF-426](https://2u-internal.atlassian.net/browse/INF-426)

**Description** 
- A back button is added in the post content area for small devices from where users can navigate back to the posts list.
- Back button is working for all tabs post content.
- Posts list items are mobile responsive.
- Sidebar and Post content ratio adjusted according to screen size.
- Set alignment issue for Alert and endorsed banners text on the mobile screen.  


### Figma mockup for the back button 
<img width="504" alt="Screenshot 2022-08-03 at 9 56 34 PM" src="https://user-images.githubusercontent.com/79941147/182665936-e6afe9d3-bbfa-4af7-ab55-824b3971431f.png">

### Responsiveness Issue
<img width="462" alt="Screenshot 2022-08-03 at 10 00 56 PM" src="https://user-images.githubusercontent.com/79941147/182667064-8ed68345-7248-4f34-8ca1-9dbe6f9e63c2.png">
<img width="514" alt="Screenshot 2022-08-03 at 10 02 03 PM" src="https://user-images.githubusercontent.com/79941147/182667071-e453b2bc-baea-46fc-9f3c-c2a7f9798ac8.png">
<img width="390" alt="Screenshot 2022-08-03 at 10 02 15 PM" src="https://user-images.githubusercontent.com/79941147/182667080-3f6d8049-a8d5-440d-95be-fccf9d38a8c9.png">
<img width="846" alt="Screenshot 2022-08-03 at 10 02 37 PM" src="https://user-images.githubusercontent.com/79941147/182667085-f9235e43-f8e7-42a9-941b-315539d2d2b9.png">
<img width="930" alt="Screenshot 2022-08-03 at 10 02 52 PM" src="https://user-images.githubusercontent.com/79941147/182667094-62cc5ce9-cbe2-405e-952a-aee06cd19344.png">


### Updated UI
<img width="459" alt="Screenshot 2022-08-03 at 9 34 04 PM" src="https://user-images.githubusercontent.com/79941147/182666387-fa2dee01-7391-44ce-9113-693cbde03ed9.png">
<img width="1440" alt="Screenshot 2022-08-01 at 5 08 24 PM" src="https://user-images.githubusercontent.com/79941147/182666447-4c59e4a6-fbe3-4bbb-a038-b2775d019b30.png">
<img width="398" alt="Screenshot 2022-08-03 at 9 33 33 PM" src="https://user-images.githubusercontent.com/79941147/182666458-499d5bbc-32ce-4582-88cc-abe40ba92930.png">
<img width="355" alt="Screenshot 2022-08-03 at 9 34 17 PM" src="https://user-images.githubusercontent.com/79941147/182666462-3fd85fc5-1f5a-4bd8-aefc-d8c1442ea8e6.png">
<img width="830" alt="Screenshot 2022-08-03 at 9 35 00 PM" src="https://user-images.githubusercontent.com/79941147/182666465-d23458c3-bdd1-4b18-819e-16cfe0fa8190.png">
<img width="932" alt="Screenshot 2022-08-03 at 9 35 09 PM" src="https://user-images.githubusercontent.com/79941147/182666474-44be8eb4-6967-4cf4-b4ea-0d144b4b59a2.png">
<img width="946" alt="Screenshot 2022-08-03 at 9 35 23 PM" src="https://user-images.githubusercontent.com/79941147/182666477-e6b34d82-5138-45e6-aa3a-9fb05684d64c.png">