### PR TITLE
fix: set posts filters based on user role

### DIFF
--- a/src/discussions/data/hooks.js
+++ b/src/discussions/data/hooks.js
@@ -87,8 +87,7 @@ export function useRedirectToThread(courseId) {
 }
 
 export function useIsOnDesktop() {
-  const windowSize = useWindowSize();
-  return windowSize.width >= breakpoints.large.minWidth;
+  return window.outerWidth >= breakpoints.large.minWidth;
 }
 
 export function useIsOnXLDesktop() {

--- a/src/discussions/data/thunks.js
+++ b/src/discussions/data/thunks.js
@@ -2,8 +2,12 @@
 import { camelCaseObject } from '@edx/frontend-platform';
 import { logError } from '@edx/frontend-platform/logging';
 
-import { LearnersOrdering } from '../../data/constants';
+import {
+  LearnersOrdering,
+  PostsStatusFilter,
+} from '../../data/constants';
 import { setSortedBy } from '../learners/data';
+import { setStatusFilter } from '../posts/data';
 import { getHttpErrorStatus } from '../utils';
 import { getDiscussionsConfig, getDiscussionsSettings } from './api';
 import {
@@ -19,6 +23,8 @@ export function fetchCourseConfig(courseId) {
   return async (dispatch) => {
     try {
       let learnerSort = LearnersOrdering.BY_LAST_ACTIVITY;
+      let postsFilterStatus = PostsStatusFilter.ALL;
+
       dispatch(fetchConfigRequest());
 
       const config = await getDiscussionsConfig(courseId);
@@ -26,10 +32,12 @@ export function fetchCourseConfig(courseId) {
         const settings = await getDiscussionsSettings(courseId);
         Object.assign(config, { settings });
         learnerSort = LearnersOrdering.BY_FLAG;
+        postsFilterStatus = PostsStatusFilter.REPORTED;
       }
 
       dispatch(fetchConfigSuccess(camelCaseObject(config)));
       dispatch(setSortedBy(learnerSort));
+      dispatch(setStatusFilter(postsFilterStatus));
     } catch (error) {
       if (getHttpErrorStatus(error) === 403) {
         dispatch(fetchConfigDenied());

--- a/src/discussions/discussions-home/DiscussionSidebar.jsx
+++ b/src/discussions/discussions-home/DiscussionSidebar.jsx
@@ -2,12 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import classNames from 'classnames';
+import { useSelector } from 'react-redux';
 import {
   Redirect, Route, Switch, useLocation,
 } from 'react-router';
 
-import { Routes } from '../../data/constants';
+import { RequestStatus, Routes } from '../../data/constants';
 import { useIsOnDesktop, useIsOnXLDesktop } from '../data/hooks';
+import { selectconfigLoadingStatus, selectUserIsPrivileged } from '../data/selectors';
 import { LearnerPostsView, LearnersView } from '../learners';
 import { PostsView } from '../posts';
 import { TopicsView } from '../topics';
@@ -16,6 +18,8 @@ export default function DiscussionSidebar({ displaySidebar }) {
   const location = useLocation();
   const isOnDesktop = useIsOnDesktop();
   const isOnXLDesktop = useIsOnXLDesktop();
+  const userIsPrivileged = useSelector(selectUserIsPrivileged);
+  const configStatus = useSelector(selectconfigLoadingStatus);
 
   return (
     <div
@@ -36,13 +40,15 @@ export default function DiscussionSidebar({ displaySidebar }) {
         <Route path={Routes.TOPICS.PATH} component={TopicsView} />
         <Route path={Routes.LEARNERS.POSTS} component={LearnerPostsView} />
         <Route path={Routes.LEARNERS.PATH} component={LearnersView} />
-        <Redirect
-          from={Routes.DISCUSSIONS.PATH}
-          to={{
-            ...location,
-            pathname: Routes.POSTS.ALL_POSTS,
-          }}
-        />
+        {configStatus === RequestStatus.SUCCESSFUL && (
+          <Redirect
+            from={Routes.DISCUSSIONS.PATH}
+            to={{
+              ...location,
+              pathname: userIsPrivileged ? Routes.POSTS.ALL_POSTS : Routes.POSTS.MY_POSTS,
+            }}
+          />
+        )}
       </Switch>
     </div>
   );

--- a/src/discussions/discussions-home/DiscussionsHome.jsx
+++ b/src/discussions/discussions-home/DiscussionsHome.jsx
@@ -78,15 +78,12 @@ export default function DiscussionsHome() {
     >
       {!inIframe && <Header />}
       <main className="container-fluid d-flex flex-column p-0 h-100 w-100 overflow-hidden">
-        {!inIframe
-          && <CourseTabsNavigation activeTab="discussion" courseId={courseId} />}
+        {!inIframe && <CourseTabsNavigation activeTab="discussion" courseId={courseId} />}
         <div
           className="d-flex flex-row justify-content-between navbar fixed-top"
           style={{ boxShadow: '0px 2px 4px rgb(0 0 0 / 15%), 0px 2px 8px rgb(0 0 0 / 15%)' }}
         >
-          {!inContext && (
-            <Route path={Routes.DISCUSSIONS.PATH} component={NavigationBar} />
-          )}
+          {!inContext && <Route path={Routes.DISCUSSIONS.PATH} component={NavigationBar} />}
           <PostActionsBar inContext={inContext} />
         </div>
         <Route
@@ -97,18 +94,18 @@ export default function DiscussionsHome() {
           <DiscussionSidebar displaySidebar={displaySidebar} />
           {displayContentArea && <DiscussionContent />}
           {!displayContentArea && (
-          <Switch>
-            <Route path={Routes.TOPICS.PATH} component={EmptyTopics} />
-            <Route
-              path={Routes.POSTS.MY_POSTS}
-              render={routeProps => <EmptyPosts {...routeProps} subTitleMessage={messages.emptyMyPosts} />}
-            />
-            <Route
-              path={[Routes.POSTS.PATH, Routes.POSTS.ALL_POSTS, Routes.LEARNERS.POSTS]}
-              render={routeProps => <EmptyPosts {...routeProps} subTitleMessage={messages.emptyAllPosts} />}
-            />
-            <Route path={Routes.LEARNERS.PATH} component={EmptyLearners} />
-          </Switch>
+            <Switch>
+              <Route path={Routes.TOPICS.PATH} component={EmptyTopics} />
+              <Route
+                path={Routes.POSTS.MY_POSTS}
+                render={routeProps => <EmptyPosts {...routeProps} subTitleMessage={messages.emptyMyPosts} />}
+              />
+              <Route
+                path={[Routes.POSTS.PATH, Routes.POSTS.ALL_POSTS, Routes.LEARNERS.POSTS]}
+                render={routeProps => <EmptyPosts {...routeProps} subTitleMessage={messages.emptyAllPosts} />}
+              />
+              <Route path={Routes.LEARNERS.PATH} component={EmptyLearners} />
+            </Switch>
           )}
         </div>
       </main>


### PR DESCRIPTION
### [INF-342](https://2u-internal.atlassian.net/browse/INF-342)

- Users having moderator role land on the All Posts tab with **Reported** as the selected filter and **Most Recent** as the selected sort.
- Learners land on the My-Posts tab with **Most Recent** as the selected sort.

### Moderator Role pre-define filters
<img width="496" alt="Screenshot 2022-08-04 at 4 41 18 PM" src="https://user-images.githubusercontent.com/79941147/182838608-039026a1-24d1-45ff-b379-35e86844e30a.png">
<img width="842" alt="Screenshot 2022-08-04 at 11 03 55 PM" src="https://user-images.githubusercontent.com/79941147/182919746-635b1e5f-e5d3-4089-ba69-64e6a40dcdc6.png">


### Learner pre-define filters
<img width="483" alt="Screenshot 2022-08-04 at 4 42 17 PM" src="https://user-images.githubusercontent.com/79941147/182838657-f9dbef53-cb99-49bf-84f5-20048f98ac56.png">
<img width="774" alt="Screenshot 2022-08-04 at 11 04 14 PM" src="https://user-images.githubusercontent.com/79941147/182919791-edf5d2d9-8e4e-4060-ba6c-017799b712d8.png">

