### PR TITLE
feat: added image upload size limit

### DIFF
--- a/src/components/TinyMCEEditor.jsx
+++ b/src/components/TinyMCEEditor.jsx
@@ -6,6 +6,7 @@ import { useParams } from 'react-router';
 // eslint-disable-next-line no-unused-vars,import/no-extraneous-dependencies
 import tinymce from 'tinymce/tinymce';
 
+import { MAX_UPLOAD_FILE_SIZE } from '../data/constants';
 import { uploadFile } from '../discussions/posts/data/api';
 
 import 'tinymce/plugins/code';
@@ -33,7 +34,6 @@ import edxBrandCss from '!!raw-loader!sass-loader!../index.scss';
 import contentCss from '!!raw-loader!tinymce/skins/content/default/content.min.css';
 // eslint-disable-next-line import/no-unresolved
 import contentUiCss from '!!raw-loader!tinymce/skins/ui/oxide/content.min.css';
-import { MAX_UPLOAD_FILE_SIZE } from '../data/constants';
 
 /* istanbul ignore next */
 const setup = (editor) => {

--- a/src/components/TinyMCEEditor.jsx
+++ b/src/components/TinyMCEEditor.jsx
@@ -33,6 +33,7 @@ import edxBrandCss from '!!raw-loader!sass-loader!../index.scss';
 import contentCss from '!!raw-loader!tinymce/skins/content/default/content.min.css';
 // eslint-disable-next-line import/no-unresolved
 import contentUiCss from '!!raw-loader!tinymce/skins/ui/oxide/content.min.css';
+import { MAX_UPLOAD_FILE_SIZE } from '../data/constants';
 
 /* istanbul ignore next */
 const setup = (editor) => {
@@ -60,6 +61,11 @@ export default function TinyMCEEditor(props) {
   const uploadHandler = async (blobInfo, success, failure) => {
     try {
       const blob = blobInfo.blob();
+      const imageSize = blobInfo.blob().size / 1024;
+      if (imageSize > MAX_UPLOAD_FILE_SIZE) {
+        failure(`Images size should not exceed ${MAX_UPLOAD_FILE_SIZE} KB`);
+        return;
+      }
       const filename = blobInfo.filename();
       const { location } = await uploadFile(blob, filename, courseId, postId || 'root');
       success(location);

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -206,3 +206,5 @@ export const ALL_ROUTES = []
   .concat([Routes.POSTS.ALL_POSTS, Routes.POSTS.MY_POSTS])
   .concat([Routes.LEARNERS.POSTS, Routes.LEARNERS.PATH])
   .concat([Routes.DISCUSSIONS.PATH]);
+
+export const MAX_UPLOAD_FILE_SIZE = 1024;


### PR DESCRIPTION
Issue : https://2u-internal.atlassian.net/browse/INF-397
There was no limit for Image upload size on frontend but backed has an upload size limit. ie 1 MB. This PR restricts users from uploading Images larger than 1MB from a frontend text editor. When a user tries to Large image it shows an error like this screenshot. 

<img width="532" alt="Screen Shot 2022-08-04 at 6 31 03 PM" src="https://user-images.githubusercontent.com/26253150/182859502-ded69daf-da2f-483a-8ed7-a8f276d35ef8.png">



