### PR TITLE
fix: fix timeago detail for months to be in weeks.

### DIFF
--- a/src/discussions/common/time-locale.js
+++ b/src/discussions/common/time-locale.js
@@ -11,8 +11,8 @@ export default function timeLocale(number, index, totalSec) {
     ['%sd', 'in %s days'],
     ['1w', 'in 1 week'],
     ['%sw', 'in %s weeks'],
-    ['1m', 'in 1 month'],
-    ['%sm', 'in %s months'],
+    ['4w', 'in 1 month'],
+    [`${number * 4}w`, 'in %s months'],
     ['1y', 'in 1 year'],
     ['%sy', 'in %s years'],
   ][index];


### PR DESCRIPTION
### [INF-395](https://2u-internal.atlassian.net/browse/INF-395)

#### Description

Change timeago detail to show months information in weeks. This is done to differentiate between minutes and month timeago detail (both were previously represented by `m`)