### PR TITLE
fix: pinned post sorting issue

### DIFF
--- a/src/discussions/posts/PostsList.jsx
+++ b/src/discussions/posts/PostsList.jsx
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
+import uniqBy from 'lodash/uniqBy';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
@@ -54,7 +55,9 @@ function PostsList({ posts, topics, intl }) {
   const checkIsSelected = (id) => window.location.pathname.includes(id);
 
   let lastPinnedIdx = null;
-  const postInstances = posts && posts.map((post, idx) => {
+  const sortedPosts = uniqBy(posts, 'id').sort((a, b) => b.pinned - a.pinned);
+
+  const postInstances = sortedPosts.map((post, idx) => {
     if (post.pinned && lastPinnedIdx !== false) {
       lastPinnedIdx = idx;
     } else if (lastPinnedIdx != null && lastPinnedIdx !== false) {


### PR DESCRIPTION
### [INF-431)](https://2u-internal.atlassian.net/browse/INF-431)

This PR reloved these issues.
- Pin/unpin posts sorting
- Duplicate posts
- Direct link post will visible in unpin post section

<img width="1440" alt="Screenshot 2022-08-11 at 12 50 00 AM" src="https://user-images.githubusercontent.com/79941147/184007666-3802ac3f-060b-45b4-9cd1-0eecce3e0100.png">
<img width="1440" alt="Screenshot 2022-08-11 at 12 50 09 AM" src="https://user-images.githubusercontent.com/79941147/184007708-94e3c866-403a-43f7-9820-bd1bb34e868d.png">
