### PR TITLE
fix: removed learners list footer

### DIFF
--- a/src/discussions/learners/learner/LearnerCard.jsx
+++ b/src/discussions/learners/learner/LearnerCard.jsx
@@ -45,7 +45,7 @@ function LearnerCard({
                 {learner.username}
               </div>
             </div>
-            <LearnerFooter learner={learner} />
+            {/* <LearnerFooter learner={learner} /> */}
           </div>
         </div>
       </div>

--- a/src/discussions/learners/learner/LearnerCard.jsx
+++ b/src/discussions/learners/learner/LearnerCard.jsx
@@ -45,7 +45,7 @@ function LearnerCard({
                 {learner.username}
               </div>
             </div>
-            {learner.threads === null ? <LearnerFooter learner={learner} /> : null}
+            {learner.threads === null ? null : <LearnerFooter learner={learner} /> }
           </div>
         </div>
       </div>

--- a/src/discussions/learners/learner/LearnerCard.jsx
+++ b/src/discussions/learners/learner/LearnerCard.jsx
@@ -45,7 +45,7 @@ function LearnerCard({
                 {learner.username}
               </div>
             </div>
-            {/* <LearnerFooter learner={learner} /> */}
+            {learner.threads === null ? <LearnerFooter learner={learner} /> : null}
           </div>
         </div>
       </div>


### PR DESCRIPTION
# Description

Removed learners list footer because we do not want to show learners stats for now because of performance issues.

# Ticket 

https://2u-internal.atlassian.net/browse/INF-444

# Related PR:
https://github.com/openedx/edx-platform/pull/30847


<img width="470" alt="Screen Shot 2022-08-12 at 12 28 03 PM" src="https://user-images.githubusercontent.com/26253150/184310018-beaab4df-a4e5-4277-b6b1-8645f87e97c8.png">

