### PR TITLE
Move clickable username behind the discussions.enable_learners_tab_in_discussions_mfe

### DIFF
--- a/src/discussions/comments/comment/Reply.jsx
+++ b/src/discussions/comments/comment/Reply.jsx
@@ -75,7 +75,10 @@ function Reply({
             }}
           />
         </div>
-        <div className="bg-light-300 px-4 pb-2 pt-2.5 flex-fill">
+        <div
+          className="bg-light-300 px-4 pb-2 pt-2.5 flex-fill"
+          style={{ borderRadius: '0rem 0.375rem 0.375rem' }}
+        >
           <div className="d-flex flex-row justify-content-between align-items-center mb-0.5">
             <AuthorLabel author={reply.author} authorLabel={reply.authorLabel} labelColor={colorClass && `text-${colorClass}`} linkToProfile />
             <ActionsDropdown

--- a/src/discussions/common/AuthorLabel.jsx
+++ b/src/discussions/common/AuthorLabel.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import classNames from 'classnames';
+import { useSelector } from 'react-redux';
 import { Link, useLocation } from 'react-router-dom';
 
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
@@ -9,6 +10,7 @@ import { Icon } from '@edx/paragon';
 import { Institution, School } from '@edx/paragon/icons';
 
 import { Routes } from '../../data/constants';
+import { selectLearnersTabEnabled } from '../data/selectors';
 import messages from '../messages';
 import { discussionsPath } from '../utils';
 import { DiscussionContext } from './context';
@@ -22,6 +24,7 @@ function AuthorLabel({
 }) {
   const location = useLocation();
   const { courseId } = useContext(DiscussionContext);
+  const learnersTabEnabled = useSelector(selectLearnersTabEnabled);
   let icon = null;
   let authorLabelMessage = null;
 
@@ -72,7 +75,7 @@ function AuthorLabel({
     </div>
   );
 
-  return linkToProfile && author
+  return linkToProfile && author && learnersTabEnabled
     ? (
       <Link
         data-testid="learner-posts-link"


### PR DESCRIPTION
### [INF-458](https://2u-internal.atlassian.net/browse/INF-458)

- Move clickable username behind the `discussions.enable_learners_tab_in_discussions_mfe`

<img width="481" alt="Screenshot 2022-08-12 at 9 46 52 PM" src="https://user-images.githubusercontent.com/79941147/184405545-1540bc87-4616-4034-b826-682200c7af9d.png">
<img width="494" alt="Screenshot 2022-08-12 at 9 45 21 PM" src="https://user-images.githubusercontent.com/79941147/184405585-e6f8b9e5-9006-4563-b3c7-17a1a79664ae.png">

