### PR TITLE
Long Post title UI fix

### DIFF
--- a/src/discussions/posts/post/PostHeader.jsx
+++ b/src/discussions/posts/post/PostHeader.jsx
@@ -93,8 +93,10 @@ function PostHeader({
   const hasAnyAlert = useAlertBannerVisible(post);
 
   return (
-    <div className={classNames('d-flex flex-fill mw-100', { 'mt-2': hasAnyAlert && !preview })} style={{ height: '2.625rem' }}>
-      <PostAvatar post={post} authorLabel={post.authorLabel} />
+    <div className={classNames('d-flex flex-fill mw-100', { 'mt-2': hasAnyAlert && !preview })}>
+      <div className="flex-shrink-0">
+        <PostAvatar post={post} authorLabel={post.authorLabel} />
+      </div>
       <div className="align-items-center d-flex flex-row">
         <div className="d-flex flex-column justify-content-start mw-100">
           {preview


### PR DESCRIPTION
# Description
Long Post title was breaking the UI , This PR fixes this issue.

# Ticket :
https://2u-internal.atlassian.net/browse/INF-452

# Testing Instructions:
1. Create a post with a long title in the discussion forum.
2. Observe UI is not breaking anymore.

<img width="905" alt="Screen Shot 2022-08-18 at 3 14 05 PM" src="https://user-images.githubusercontent.com/26253150/185372411-34230124-ee1e-45a0-85b0-acbc1902fa3b.png">
