### PR TITLE
fix: no result found text remove when call in progress

### DIFF
--- a/src/discussions/learners/LearnerPostsView.jsx
+++ b/src/discussions/learners/LearnerPostsView.jsx
@@ -80,7 +80,7 @@ function LearnerPostsView({ intl }) {
       <div className="bg-light-400 border border-light-300" />
       <div className="list-group list-group-flush">
         {postInstances}
-        {posts?.length === 0 && <NoResults />}
+        {loadingStatus !== RequestStatus.IN_PROGRESS && posts?.length === 0 && <NoResults />}
         {loadingStatus === RequestStatus.IN_PROGRESS ? (
           <div className="d-flex justify-content-center p-4">
             <Spinner animation="border" variant="primary" size="lg" />


### PR DESCRIPTION
No result found text will not be visible in case an API call is in progress.


https://user-images.githubusercontent.com/67791278/185651852-4fedf6e1-e979-48c2-96f7-a301dfa3a58a.mov

