### PR TITLE
fix: resolve issues with search functionality

### DIFF
--- a/src/components/Search.jsx
+++ b/src/components/Search.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo } from 'react';
+import React, { useContext, useEffect } from 'react';
 
 import camelCase from 'lodash/camelCase';
 import { useDispatch, useSelector } from 'react-redux';
@@ -22,18 +22,14 @@ function Search({ intl }) {
   const isPostSearch = ['posts', 'my-posts'].includes(page);
   const isTopicSearch = 'topics'.includes(page);
   let searchValue = '';
-
-  const currentValue = useMemo(() => {
-    let value = '';
-    if (isPostSearch) {
-      value = postSearch;
-    } else if (isTopicSearch) {
-      value = topicSearch;
-    } else {
-      value = learnerSearch;
-    }
-    return value;
-  }, [isPostSearch, isTopicSearch, learnerSearch]);
+  let currentValue = '';
+  if (isPostSearch) {
+    currentValue = postSearch;
+  } else if (isTopicSearch) {
+    currentValue = topicSearch;
+  } else {
+    currentValue = learnerSearch;
+  }
 
   const onClear = () => {
     dispatch(setSearchQuery(''));

--- a/src/components/SearchInfo.jsx
+++ b/src/components/SearchInfo.jsx
@@ -18,7 +18,7 @@ function SearchInfo({
   return (
     <div className="d-flex flex-row border-bottom">
       <Icon src={Search} className="justify-content-start ml-3.5 mr-2 mb-2 mt-2.5" />
-      <Button variant="" size="inline">
+      <Button variant="" size="inline" className="text-primary-500">
         {
           loadingStatus === RequestStatus.SUCCESSFUL
             ? intl.formatMessage(messages.searchInfo, { count, text })

--- a/src/discussions/learners/data/slices.js
+++ b/src/discussions/learners/data/slices.js
@@ -44,6 +44,7 @@ const learnersSlice = createSlice({
     },
     setUsernameSearch: (state, { payload }) => {
       state.usernameSearch = payload;
+      state.pages = [];
     },
   },
 });

--- a/src/discussions/messages.js
+++ b/src/discussions/messages.js
@@ -128,6 +128,11 @@ const messages = defineMessages({
     defaultMessage: 'Try searching different keywords or removing some filters',
     description: 'Message shown on discussion sidebar if user searched with keywords.',
   },
+  removeKeywordsOnly: {
+    id: 'discussions.sidebar.removeKeywordsOnly',
+    defaultMessage: 'Try searching different keywords',
+    description: 'Message shown on discussion sidebar if user searched with keywords only.',
+  },
   removeFilters: {
     id: 'discussions.sidebar.removeFilters',
     defaultMessage: 'Try removing some filters',

--- a/src/discussions/posts/NoResults.jsx
+++ b/src/discussions/posts/NoResults.jsx
@@ -15,8 +15,10 @@ function NoResults({ intl }) {
   let helpMessage = messages.removeFilters;
   if (!isFiltered) {
     return null;
-  } if (filters.search || topicsFilter || learnersFilter) {
+  } if (filters.search || learnersFilter) {
     helpMessage = messages.removeKeywords;
+  } if (topicsFilter) {
+    helpMessage = messages.removeKeywordsOnly;
   }
 
   return (

--- a/src/discussions/posts/post-actions-bar/messages.js
+++ b/src/discussions/posts/post-actions-bar/messages.js
@@ -32,7 +32,7 @@ const messages = defineMessages({
   },
   clearSearch: {
     id: 'discussions.actionBar.clearSearch',
-    defaultMessage: 'Clear',
+    defaultMessage: 'Clear results',
     description: 'Button to clear search',
   },
   addAPost: {


### PR DESCRIPTION
### [INF-457](https://2u-internal.atlassian.net/browse/INF-457)

### Description

Address issues with search functionalities.

Points Addressed:

- Replace `Clear` with `Clear results` for all 4 tabs.
- Match text color of `Showing {count} results for {search string}` for all 4 tabs.
- `Clear results` button should also clear the search string in the search bar in all 4 tabs. As of now, this only happens in Learners tab.
- Navigating to another tab, without clearing the search results, should clear the search results as well as the search bar, in all 4 tabs. As of now, the search string remains there, and nothing happens if i search the same string in the new tab.
- For the learners tab, when the search api is triggered, the list of learners should disappear and a loading icon should appear. This loading icon should disappear once the search is concluded. This behavior is working correctly in All posts and My posts tab.
- `No search results` in Topics tab should match the mockups (Add keyword specific text for No Results found).