### PR TITLE
fix: Updated state logic for reported content

### DIFF
--- a/src/discussions/posts/data/slices.js
+++ b/src/discussions/posts/data/slices.js
@@ -127,7 +127,11 @@ const threadsSlice = createSlice({
     },
     updateThreadSuccess: (state, { payload }) => {
       state.postStatus = RequestStatus.SUCCESSFUL;
-      state.threadsById[payload.id] = { ...state.threadsById[payload.id], ...payload };
+      state.threadsById[payload.id] = {
+        ...state.threadsById[payload.id],
+        ...payload,
+        abuseFlaggedCount: state.threadsById[payload.id].abuseFlaggedCount || false,
+      };
       state.avatars = { ...state.avatars, ...payload.avatars };
       state.threadDraft = null;
     },


### PR DESCRIPTION
## Description 
Pinning a thread having “Reported” and “Answered” label removes the “Reported” label, This PR resolves this issue by omitting abuse_flag_count from state update.
## Ticket 
https://2u-internal.atlassian.net/browse/INF-432
## Testing Instructions
1. In the new discussion MFE pin a reported post.
2. Observe that the reported tag is still there and visible with the pin icon.
