### PR TITLE
fix: handle inIframe query_param when it is False

### DIFF
--- a/src/discussions/discussions-home/DiscussionsHome.jsx
+++ b/src/discussions/discussions-home/DiscussionsHome.jsx
@@ -42,8 +42,7 @@ export default function DiscussionsHome() {
     learnerUsername,
   } = params;
   const inContext = new URLSearchParams(location.search).get('inContext') !== null;
-  const inIframe = new URLSearchParams(location.search).get('inIframe') !== null;
-
+  const inIframe = new URLSearchParams(location.search).get('inIframe')?.toLowerCase() === 'true';
   // Display the content area if we are currently viewing/editing a post or creating one.
   const displayContentArea = postId || postEditorVisible || (learnerUsername && postId);
   let displaySidebar = useSidebarVisible();

--- a/src/discussions/discussions-home/DiscussionsHome.test.jsx
+++ b/src/discussions/discussions-home/DiscussionsHome.test.jsx
@@ -87,4 +87,36 @@ describe('DiscussionsHome', () => {
     await waitFor(() => expect(window.parent.postMessage).toHaveBeenCalled());
     window.parent = parent;
   });
+
+  describe.each([
+    {
+      queryParam: 'inIframe=True',
+      iframeView: true,
+    },
+    {
+      queryParam: 'inIframe=False',
+      iframeView: false,
+    },
+    {
+      queryParam: '',
+      iframeView: false,
+    },
+  ])(
+    'Header/Footer visibility',
+    ({
+      queryParam,
+      iframeView,
+    }) => {
+      test(`inIframe query param ${queryParam}`, async () => {
+        renderComponent(`/${courseId}/topics?${queryParam}`);
+        if (iframeView) {
+          expect(screen.queryByRole('banner')).not.toBeInTheDocument();
+          expect(screen.queryByRole('contentinfo')).not.toBeInTheDocument();
+        } else {
+          expect(screen.queryByRole('banner')).toBeInTheDocument();
+          expect(screen.queryByRole('contentinfo')).toBeInTheDocument();
+        }
+      });
+    },
+  );
 });


### PR DESCRIPTION
### [INF-471](https://2u-internal.atlassian.net/browse/INF-471)

### Description

Handle `inIframe` query_param on FE to show header and footer when query_param is `False`.
This happens when a user has a link copied from iFrame view with the query_param set to `False` (edge case).