### PR TITLE
fix: follow button should not open post

### DIFF
--- a/src/discussions/posts/post/PostFooter.jsx
+++ b/src/discussions/posts/post/PostFooter.jsx
@@ -50,7 +50,8 @@ function PostFooter({
         src={post.following ? StarFilled : StarOutline}
         iconAs={Icon}
         alt="Follow"
-        onClick={() => {
+        onClick={(e) => {
+          e.preventDefault();
           dispatch(updateExistingThread(post.id, { following: !post.following }));
           return true;
         }}


### PR DESCRIPTION
Clicking on follow/unfollow button in post summary should not open post

Ticket Link:
https://2u-internal.atlassian.net/browse/INF-371
