### PR TITLE
fix: threads lost issue on load more in topics

### DIFF
--- a/src/discussions/posts/data/slices.js
+++ b/src/discussions/posts/data/slices.js
@@ -2,11 +2,24 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 import {
-  PostsStatusFilter,
-  RequestStatus,
-  ThreadOrdering,
-  ThreadType,
+  PostsStatusFilter, RequestStatus, ThreadOrdering, ThreadType,
 } from '../../../data/constants';
+
+const mergeThreadsInTopics = (dataFromState, dataFromPayload) => {
+  const mergedArray = [];
+  mergedArray.push(dataFromState);
+  mergedArray.push(dataFromPayload);
+  return mergedArray.reduce((acc, obj) => {
+    const keys = Object.keys(obj);
+    const values = Object.values(obj);
+    keys.forEach((key, index) => {
+      if (!acc[key]) { acc[key] = []; }
+      if (Array.isArray(acc[key])) { acc[key] = acc[key].concat(values[index]); } else { acc[key].push(values[index]); }
+      return acc;
+    });
+    return acc;
+  }, {});
+};
 
 const threadsSlice = createSlice({
   name: 'thread',
@@ -62,7 +75,7 @@ const threadsSlice = createSlice({
       }
       state.status = RequestStatus.SUCCESSFUL;
       state.threadsById = { ...state.threadsById, ...payload.threadsById };
-      state.threadsInTopic = { ...state.threadsInTopic, ...payload.threadsInTopic };
+      state.threadsInTopic = mergeThreadsInTopics(state.threadsInTopic, payload.threadsInTopic);
       state.avatars = { ...state.avatars, ...payload.avatars };
       state.nextPage = (payload.page < payload.pagination.numPages) ? payload.page + 1 : null;
       state.totalPages = payload.pagination.numPages;

--- a/src/discussions/posts/data/thunks.js
+++ b/src/discussions/posts/data/thunks.js
@@ -137,7 +137,9 @@ export function fetchThreads(courseId, {
       dispatch(fetchThreadsRequest({ courseId }));
       const data = await getThreads(courseId, options);
       const normalisedData = normaliseThreads(camelCaseObject(data), topicIds);
-      dispatch(fetchThreadsSuccess({ ...normalisedData, page, author }));
+      dispatch(fetchThreadsSuccess({
+        ...normalisedData, page, author,
+      }));
     } catch (error) {
       if (getHttpErrorStatus(error) === 403) {
         dispatch(fetchThreadsDenied());


### PR DESCRIPTION
On hitting the load more button the already loaded threads in the topics tab were getting lost. This is fixed in this PR