### PR TITLE
fix: sort order of responses is changing immediately

### DIFF
--- a/src/discussions/comments/CommentsView.jsx
+++ b/src/discussions/comments/CommentsView.jsx
@@ -1,6 +1,7 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
+import { orderBy } from 'lodash';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router';
 
@@ -66,18 +67,21 @@ function DiscussionCommentsView({
     isLoading,
     handleLoadMoreResponses,
   } = usePostComments(postId, endorsed);
+  const sortedComments = useMemo(() => orderBy(comments, ['endorsed', 'createdAt'],
+    ['desc', 'desc']));
+
   return (
     <>
       <div className="mx-4 text-primary-700" role="heading" aria-level="2" style={{ lineHeight: '28px' }}>
         {endorsed === EndorsementStatus.ENDORSED
-          ? intl.formatMessage(messages.endorsedResponseCount, { num: comments.length })
-          : intl.formatMessage(messages.responseCount, { num: comments.length })}
+          ? intl.formatMessage(messages.endorsedResponseCount, { num: sortedComments.length })
+          : intl.formatMessage(messages.responseCount, { num: sortedComments.length })}
       </div>
       <div className="mx-4" role="list">
-        {comments.map(comment => (
+        {sortedComments.map(comment => (
           <Comment comment={comment} key={comment.id} postType={postType} isClosedPost={isClosed} />
         ))}
-        {!!comments.length && !isClosed
+        {!!sortedComments.length && !isClosed
           && <ResponseEditor postId={postId} addWrappingDiv />}
         {hasMorePages && !isLoading && (
           <Button

--- a/src/discussions/comments/comment/Comment.jsx
+++ b/src/discussions/comments/comment/Comment.jsx
@@ -47,7 +47,7 @@ function Comment({
   const actionHandlers = {
     [ContentActions.EDIT_CONTENT]: () => setEditing(true),
     [ContentActions.ENDORSE]: async () => {
-      await dispatch(editComment(comment.id, { endorsed: !comment.endorsed }));
+      await dispatch(editComment(comment.id, { endorsed: !comment.endorsed }, ContentActions.ENDORSE));
       await dispatch(fetchThread(comment.threadId));
     },
     [ContentActions.DELETE]: showDeleteConfirmation,

--- a/src/discussions/comments/comment/Reply.jsx
+++ b/src/discussions/comments/comment/Reply.jsx
@@ -31,7 +31,11 @@ function Reply({
   const [isDeleting, showDeleteConfirmation, hideDeleteConfirmation] = useToggle(false);
   const actionHandlers = {
     [ContentActions.EDIT_CONTENT]: () => setEditing(true),
-    [ContentActions.ENDORSE]: () => dispatch(editComment(reply.id, { endorsed: !reply.endorsed })),
+    [ContentActions.ENDORSE]: () => dispatch(editComment(
+      reply.id,
+      { endorsed: !reply.endorsed },
+      ContentActions.ENDORSE,
+    )),
     [ContentActions.DELETE]: showDeleteConfirmation,
     [ContentActions.REPORT]: () => dispatch(editComment(reply.id, { flagged: !reply.abuseFlagged })),
   };

--- a/src/discussions/comments/data/slices.js
+++ b/src/discussions/comments/data/slices.js
@@ -145,6 +145,18 @@ const commentsSlice = createSlice({
       state.commentsById[payload.id] = payload;
       state.commentDraft = null;
     },
+    updateCommentsList: (state, { payload }) => {
+      const { id: commentId, threadId, endorsed } = payload;
+      const commentAddListtype = endorsed ? EndorsementStatus.ENDORSED : EndorsementStatus.UNENDORSED;
+      const commentRemoveListType = !endorsed ? EndorsementStatus.ENDORSED : EndorsementStatus.UNENDORSED;
+
+      state.commentsInThreads[threadId][commentRemoveListType] = (
+          state.commentsInThreads[threadId]?.[commentRemoveListType]?.filter(item => item !== commentId)
+      );
+      state.commentsInThreads[threadId][commentAddListtype] = [
+        ...state.commentsInThreads[threadId][commentAddListtype], payload.id,
+      ];
+    },
     deleteCommentRequest: (state) => {
       state.postStatus = RequestStatus.IN_PROGRESS;
     },
@@ -189,6 +201,7 @@ export const {
   updateCommentFailed,
   updateCommentRequest,
   updateCommentSuccess,
+  updateCommentsList,
   deleteCommentDenied,
   deleteCommentFailed,
   deleteCommentRequest,

--- a/src/discussions/comments/data/thunks.js
+++ b/src/discussions/comments/data/thunks.js
@@ -2,7 +2,7 @@
 import { camelCaseObject } from '@edx/frontend-platform';
 import { logError } from '@edx/frontend-platform/logging';
 
-import { EndorsementStatus } from '../../../data/constants';
+import { ContentActions, EndorsementStatus } from '../../../data/constants';
 import { getHttpErrorStatus } from '../../utils';
 import {
   deleteComment, getCommentResponses, getThreadComments, postComment, updateComment,
@@ -27,6 +27,7 @@ import {
   updateCommentDenied,
   updateCommentFailed,
   updateCommentRequest,
+  updateCommentsList,
   updateCommentSuccess,
 } from './slices';
 
@@ -116,12 +117,15 @@ export function fetchCommentResponses(commentId, { page = 1 } = {}) {
   };
 }
 
-export function editComment(commentId, comment) {
+export function editComment(commentId, comment, action = null) {
   return async (dispatch) => {
     try {
       dispatch(updateCommentRequest({ commentId }));
       const data = await updateComment(commentId, comment);
       dispatch(updateCommentSuccess(camelCaseObject(data)));
+      if (action === ContentActions.ENDORSE) {
+        dispatch(updateCommentsList(camelCaseObject(data)));
+      }
     } catch (error) {
       if (getHttpErrorStatus(error) === 403) {
         dispatch(updateCommentDenied());

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -63,7 +63,7 @@ function PostLink({
       >
         <div
           className={
-            classNames('d-flex flex-row pt-2.5 pb-2 px-4 border-primary-500',
+            classNames('d-flex flex-row pt-2.5 pb-2 px-4 border-primary-500 position-relative',
               { 'bg-light-300': post.read })
           }
           style={post.id === postId ? {


### PR DESCRIPTION
### [INF-443](https://2u-internal.atlassian.net/browse/INF-443)

- Sort order of responses is changing immediately.
- Now responses are displayed in orderBy desc.
- Add position-relative class for summary card question icon

<img width="967" alt="Screenshot 2022-09-01 at 8 30 38 PM" src="https://user-images.githubusercontent.com/79941147/187953530-ba72f206-e06e-4971-a2d9-fb54be581dc8.png">
<img width="971" alt="Screenshot 2022-09-01 at 8 32 43 PM" src="https://user-images.githubusercontent.com/79941147/187953984-b1099e8a-1c05-4910-b591-ada5a359abcd.png">
<img width="475" alt="Screenshot 2022-09-01 at 8 32 57 PM" src="https://user-images.githubusercontent.com/79941147/187954022-a0aa3e67-a664-4c59-b897-a6038a9757cc.png">
