### PR TITLE
feat: copy post functionality

### DIFF
--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -45,6 +45,7 @@ export const ContentActions = {
   PIN: 'pinned',
   ENDORSE: 'endorsed',
   CLOSE: 'closed',
+  COPY_LINK: 'copy_link',
   REPORT: 'abuse_flagged',
   DELETE: 'delete',
   FOLLOWING: 'following',

--- a/src/discussions/common/ActionsDropdown.test.jsx
+++ b/src/discussions/common/ActionsDropdown.test.jsx
@@ -152,6 +152,36 @@ describe('ActionsDropdown', () => {
     await waitFor(() => expect(screen.queryByTestId('actions-dropdown-modal-popup')).not.toBeInTheDocument());
   });
 
+  it('copy link action should be visible on posts', async () => {
+    const commentOrPost = {
+      testFor: 'thread',
+      ...camelCaseObject(Factory.build('thread', { editable_fields: ['copy_link'] }, null)),
+    };
+    renderComponent(commentOrPost, { disabled: false });
+
+    const openButton = await findOpenActionsDropdownButton();
+    await act(async () => {
+      fireEvent.click(openButton);
+    });
+
+    await waitFor(() => expect(screen.queryByText('Copy link')).toBeInTheDocument());
+  });
+
+  it('copy link action should not be visible on a comment', async () => {
+    const commentOrPost = {
+      testFor: 'comments',
+      ...camelCaseObject(Factory.build('comment', {}, null)),
+    };
+    renderComponent(commentOrPost, { disabled: false });
+
+    const openButton = await findOpenActionsDropdownButton();
+    await act(async () => {
+      fireEvent.click(openButton);
+    });
+
+    await waitFor(() => expect(screen.queryByText('Copy link')).not.toBeInTheDocument());
+  });
+
   describe.each(canPerformActionTestData)('Actions', ({
     testFor, action, label, reason, ...commentOrPost
   }) => {

--- a/src/discussions/messages.js
+++ b/src/discussions/messages.js
@@ -11,6 +11,11 @@ const messages = defineMessages({
     defaultMessage: 'Back',
     description: 'Text on button for back to posts list',
   },
+  copyLink: {
+    id: 'discussions.actions.copylink',
+    defaultMessage: 'Copy link',
+    description: 'Action to copy post link',
+  },
   editAction: {
     id: 'discussions.actions.edit',
     defaultMessage: 'Edit',

--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -28,6 +28,7 @@ function Post({
   const location = useLocation();
   const history = useHistory();
   const dispatch = useDispatch();
+  const { courseId } = useSelector((state) => state.courseTabs);
   const topic = useSelector(selectTopic(post.topicId));
   const getTopicSubsection = useSelector(selectorForUnitSubsection);
   const topicContext = useSelector(selectTopicContext(post.topicId));
@@ -49,6 +50,7 @@ function Post({
         dispatch(updateExistingThread(post.id, { closed: true }));
       }
     },
+    [ContentActions.COPY_LINK]: () => { navigator.clipboard.writeText(`${window.location.origin}/${courseId}/posts/${post.id}`); },
     [ContentActions.PIN]: () => dispatch(updateExistingThread(post.id, { pinned: !post.pinned })),
     [ContentActions.REPORT]: () => dispatch(updateExistingThread(post.id, { flagged: !post.abuseFlagged })),
   };

--- a/src/discussions/utils.js
+++ b/src/discussions/utils.js
@@ -5,7 +5,7 @@ import { generatePath, useRouteMatch } from 'react-router';
 
 import { getConfig } from '@edx/frontend-platform';
 import {
-  Delete, Edit, Pin, QuestionAnswer, Report, VerifiedBadge,
+  Delete, Edit, InsertLink, Pin, QuestionAnswer, Report, VerifiedBadge,
 } from '@edx/paragon/icons';
 
 import { ContentActions, Routes, ThreadType } from '../data/constants';
@@ -71,6 +71,12 @@ export function checkPermissions(content, action) {
  *    e.g. for {pinned:false} the action will show up if the content/post has post.pinned==false
  */
 export const ACTIONS_LIST = [
+  {
+    id: 'copy-link',
+    action: ContentActions.COPY_LINK,
+    icon: InsertLink,
+    label: messages.copyLink,
+  },
   {
     id: 'edit',
     action: ContentActions.EDIT_CONTENT,


### PR DESCRIPTION
"Copy link" functionality in list of actions for posts. Comment actions should not show "copy link"


Ticket Link:
https://2u-internal.atlassian.net/browse/INF-299

Backend PR:
https://github.com/openedx/edx-platform/pull/30941

For Post
![copy_thread](https://user-images.githubusercontent.com/77053848/188406828-cc3951c4-6bae-41b5-be85-23ea40588bae.png)


For comment
![copy_comment](https://user-images.githubusercontent.com/77053848/188406929-dfe87faa-9310-4959-8453-88566c459dde.png)



