### PR TITLE
feat: Add support for grouping at subsections [BD-38]

### DIFF
--- a/src/data/selectors.js
+++ b/src/data/selectors.js
@@ -2,7 +2,7 @@
 
 import { createSelector } from '@reduxjs/toolkit';
 
-import { selectDiscussionProvider } from '../discussions/data/selectors';
+import { selectDiscussionProvider, selectGroupAtSubsection } from '../discussions/data/selectors';
 import { DiscussionProvider } from './constants';
 
 export const selectTopicContext = (topicId) => (state) => state.blocks.topics[topicId];
@@ -12,6 +12,18 @@ export const selectBlocks = (state) => state.blocks.blocks;
 export const selectorForUnitSubsection = createSelector(
   selectBlocks,
   blocks => key => blocks[blocks[key]?.parent],
+);
+
+// If subsection grouping is enabled, and the current selection is a unit, then get the current subsection.
+export const selectCurrentCategoryGrouping = createSelector(
+  selectDiscussionProvider,
+  selectGroupAtSubsection,
+  selectBlocks,
+  (provider, groupAtSubsection, blocks) => blockId => (
+    (provider !== 'openedx' || !groupAtSubsection || blocks[blockId]?.type !== 'vertical')
+      ? blockId
+      : blocks[blockId].parent
+  ),
 );
 
 export const selectChapters = (state) => state.blocks.chapters;

--- a/src/discussions/data/hooks.js
+++ b/src/discussions/data/hooks.js
@@ -11,7 +11,9 @@ import { AppContext } from '@edx/frontend-platform/react';
 import { breakpoints, useWindowSize } from '@edx/paragon';
 
 import { Routes } from '../../data/constants';
+import { selectTopicsUnderCategory } from '../../data/selectors';
 import { fetchCourseBlocks } from '../../data/thunks';
+import { DiscussionContext } from '../common/context';
 import { clearRedirect } from '../posts/data';
 import { selectTopics } from '../topics/data/selectors';
 import { fetchCourseTopics } from '../topics/data/thunks';
@@ -157,4 +159,25 @@ export const useShowLearnersTab = () => {
   const privileged = useSelector(selectUserHasModerationPrivileges);
   const allowedUsers = isAdmin || IsGroupTA || privileged || (userRoles.includes('Student') && userRoles.length > 1);
   return learnersTabEnabled && allowedUsers;
+};
+
+/**
+ * React hook that gets the current topic ID from the current topic or category.
+ * The topicId in the DiscussionContext only return the direct topicId from the URL.
+ * If the URL has the current block ID it cannot get the topicID from that. This hook
+ * gets the topic ID from the URL if available, or from the current category otherwise.
+ * It only returns an ID if a single ID is available, if navigating a subsection it
+ * returns null.
+ * @returns {null|string} A topic ID if a single one available in the current context.
+ */
+export const useCurrentDiscussionTopic = () => {
+  const { topicId, category } = useContext(DiscussionContext);
+  const topics = useSelector(selectTopicsUnderCategory)(category);
+  if (topicId) {
+    return topicId;
+  }
+  if (topics?.length === 1) {
+    return topics[0];
+  }
+  return null;
 };

--- a/src/discussions/data/hooks.test.jsx
+++ b/src/discussions/data/hooks.test.jsx
@@ -1,0 +1,85 @@
+import { render } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+
+import { initializeMockApp } from '@edx/frontend-platform';
+import { AppProvider } from '@edx/frontend-platform/react';
+
+import { initializeStore } from '../../store';
+import { DiscussionContext } from '../common/context';
+import { useCurrentDiscussionTopic } from './hooks';
+
+let store;
+initializeMockApp();
+describe('Hooks', () => {
+  describe('useCurrentDiscussionTopic', () => {
+    function ComponentWithHook() {
+      const topic = useCurrentDiscussionTopic();
+      return (
+        <div>
+          {String(topic)}
+        </div>
+      );
+    }
+
+    function renderComponent({ topicId, category }) {
+      return render(
+        <IntlProvider locale="en">
+          <AppProvider store={store}>
+            <DiscussionContext.Provider
+              value={{
+                topicId,
+                category,
+              }}
+            >
+              <ComponentWithHook />
+            </DiscussionContext.Provider>
+          </AppProvider>
+        </IntlProvider>,
+      );
+    }
+
+    beforeEach(() => {
+      store = initializeStore({
+        blocks: {
+          blocks: {
+            'some-unit-key': { topics: ['some-topic-0'], parent: 'some-sequence-key' },
+            'some-sequence-key': { topics: ['some-topic-0'] },
+            'another-sequence-key': { topics: ['some-topic-1', 'some-topic-2'] },
+            'empty-key': { topics: [] },
+          },
+        },
+        config: { provider: 'openedx' },
+      });
+    });
+
+    test('when topicId is in context', () => {
+      const { queryByText } = renderComponent({ topicId: 'some-topic' });
+      expect(queryByText('some-topic')).toBeInTheDocument();
+    });
+
+    test('when the category is a unit', () => {
+      const { queryByText } = renderComponent({ category: 'some-unit-key' });
+      expect(queryByText('some-topic-0')).toBeInTheDocument();
+    });
+
+    test('when the category is a sequence with one unit', () => {
+      const { queryByText } = renderComponent({ category: 'some-sequence-key' });
+      expect(queryByText('some-topic-0')).toBeInTheDocument();
+    });
+
+    test('when the category is a sequence with multiple units', () => {
+      const { queryByText } = renderComponent({ category: 'another-sequence-key' });
+      expect(queryByText('null')).toBeInTheDocument();
+    });
+
+    test('when the category is invalid', () => {
+      const { queryByText } = renderComponent({ category: 'invalid-key' });
+      expect(queryByText('null')).toBeInTheDocument();
+    });
+
+    test('when the category has no topics', () => {
+      const { queryByText } = renderComponent({ category: 'empty-key' });
+      expect(queryByText('null')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/discussions/data/selectors.js
+++ b/src/discussions/data/selectors.js
@@ -22,6 +22,8 @@ export const selectDivisionSettings = state => state.config.settings;
 
 export const selectBlackoutDate = state => state.config.blackouts;
 
+export const selectGroupAtSubsection = state => state.config.groupAtSubsection;
+
 export const selectModerationSettings = state => ({
   postCloseReasons: state.config.postCloseReasons,
   editReasons: state.config.editReasons,

--- a/src/discussions/data/slices.js
+++ b/src/discussions/data/slices.js
@@ -11,6 +11,7 @@ const configSlice = createSlice({
     allowAnonymous: false,
     allowAnonymousToPeers: false,
     userRoles: [],
+    groupAtSubsection: false,
     hasModerationPrivileges: false,
     isGroupTa: false,
     isUserAdmin: false,

--- a/src/discussions/posts/PostsView.jsx
+++ b/src/discussions/posts/PostsView.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 
 import SearchInfo from '../../components/SearchInfo';
-import { selectTopicsUnderCategory } from '../../data/selectors';
+import { selectCurrentCategoryGrouping, selectTopicsUnderCategory } from '../../data/selectors';
 import { DiscussionContext } from '../common/context';
 import {
   selectAllThreads,
@@ -29,7 +29,10 @@ TopicPostsList.propTypes = {
 };
 
 function CategoryPostsList({ category }) {
-  const topicIds = useSelector(selectTopicsUnderCategory)(category);
+  const { inContext } = useContext(DiscussionContext);
+  const groupedCategory = useSelector(selectCurrentCategoryGrouping)(category);
+  // If grouping at subsection is enabled, only apply it when browsing discussions in context in the learning MFE.
+  const topicIds = useSelector(selectTopicsUnderCategory)(inContext ? groupedCategory : category);
   const posts = useSelector(selectTopicThreads(topicIds));
   return <PostsList posts={posts} topics={topicIds} />;
 }

--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -10,7 +10,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import * as Yup from 'yup';
 
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
 import {
   Button, Card, Form, Spinner, StatefulButton,
@@ -23,6 +23,7 @@ import PostPreviewPane from '../../../components/PostPreviewPane';
 import { useDispatchWithState } from '../../../data/hooks';
 import { selectCourseCohorts } from '../../cohorts/data/selectors';
 import { fetchCourseCohorts } from '../../cohorts/data/thunks';
+import { useCurrentDiscussionTopic } from '../../data/hooks';
 import {
   selectAnonymousPostingConfig,
   selectDivisionSettings,
@@ -77,9 +78,9 @@ DiscussionPostType.propTypes = {
 };
 
 function PostEditor({
-  intl,
   editExisting,
 }) {
+  const intl = useIntl();
   const { authenticatedUser } = useContext(AppContext);
   const dispatch = useDispatch();
   const editorRef = useRef(null);
@@ -89,9 +90,9 @@ function PostEditor({
   const commentsPagePath = useCommentsPagePath();
   const {
     courseId,
-    topicId,
     postId,
   } = useParams();
+  const topicId = useCurrentDiscussionTopic();
 
   const nonCoursewareTopics = useSelector(selectNonCoursewareTopics);
   const nonCoursewareIds = useSelector(selectNonCoursewareIds);
@@ -439,7 +440,6 @@ function PostEditor({
 }
 
 PostEditor.propTypes = {
-  intl: intlShape.isRequired,
   editExisting: PropTypes.bool,
 };
 
@@ -447,4 +447,4 @@ PostEditor.defaultProps = {
   editExisting: false,
 };
 
-export default injectIntl(PostEditor);
+export default PostEditor;

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { Badge, Icon } from '@edx/paragon';
 
 import { PushPin } from '../../../components/icons';
@@ -22,11 +22,11 @@ import { postShape } from './proptypes';
 function PostLink({
   post,
   isSelected,
-  intl,
   learnerTab,
   showDivider,
   idx,
 }) {
+  const intl = useIntl();
   const {
     page,
     postId,
@@ -118,7 +118,7 @@ function PostLink({
               author={post.author || intl.formatMessage(messages.anonymous)}
               authorLabel={post.authorLabel}
               labelColor={authorLabelColor && `text-${authorLabelColor}`}
-              linkToProfile={!learnerTab && post.author}
+              linkToProfile={!learnerTab && Boolean(post.author)}
             />
             <div
               className="text-truncate text-primary-500 font-weight-normal font-size-14 font-style-normal font-family-inter"
@@ -142,7 +142,6 @@ function PostLink({
 PostLink.propTypes = {
   post: postShape.isRequired,
   isSelected: PropTypes.func.isRequired,
-  intl: intlShape.isRequired,
   learnerTab: PropTypes.bool,
   showDivider: PropTypes.bool,
   idx: PropTypes.number,
@@ -154,4 +153,4 @@ PostLink.defaultProps = {
   idx: -1,
 };
 
-export default injectIntl(PostLink);
+export default PostLink;


### PR DESCRIPTION
For smaller courses, there is a feature under the new provider
for grouping topics at the subsection level so that when
navigating the course, all topics under a subsection show up in
the sidebar instead of just the current unit.

This implements that functionality by checking if the discussion
is loaded in-context, and if grouping at subsection is enabled,
and if so, displaying the current subsection's topics.
