### PR TITLE
feat: add unresponded posts filter in UI 

### DIFF
--- a/src/discussions/posts/PostsView.test.jsx
+++ b/src/discussions/posts/PostsView.test.jsx
@@ -197,7 +197,7 @@ describe('PostsView', () => {
       // 5 status filters: any, unread, following, reported, unanswered
       // 3 sort: activity, comments, likes
       // 2 cohort: all groups, 1 api mock response cohort
-      expect(screen.queryAllByRole('radio')).toHaveLength(13);
+      expect(screen.queryAllByRole('radio')).toHaveLength(14);
     });
 
     test('test that the cohorts filter works', async () => {

--- a/src/discussions/posts/data/thunks.js
+++ b/src/discussions/posts/data/thunks.js
@@ -120,6 +120,9 @@ export function fetchThreads(courseId, {
   if (filters.status === PostsStatusFilter.UNANSWERED) {
     options.view = 'unanswered';
   }
+  if (filters.status === PostsStatusFilter.UNRESPONDED) {
+    options.view = 'unresponded';
+  }
   if (filters.status === PostsStatusFilter.REPORTED) {
     options.flagged = true;
   }

--- a/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
+++ b/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
@@ -95,6 +95,10 @@ function PostFilterBar({
         // You can't filter discussions by unanswered so switch type to questions
         dispatch(setPostsTypeFilter(ThreadType.QUESTION));
       }
+      if (value === PostsStatusFilter.UNRESPONDED && currentType !== ThreadType.DISCUSSION) {
+        // You can't filter questions by not responded so switch type to discussion
+        dispatch(setPostsTypeFilter(ThreadType.DISCUSSION));
+      }
     }
     if (name === 'sort') {
       dispatch(setSortedBy(value));
@@ -198,6 +202,12 @@ function PostFilterBar({
                 id="status-unanswered"
                 label={intl.formatMessage(messages.filterUnanswered)}
                 value={PostsStatusFilter.UNANSWERED}
+                selected={currentFilters.status}
+              />
+              <ActionItem
+                id="status-unresponded"
+                label={intl.formatMessage(messages.filterUnresponded)}
+                value={PostsStatusFilter.UNRESPONDED}
                 selected={currentFilters.status}
               />
             </Form.RadioSet>

--- a/src/discussions/posts/post-filter-bar/messages.js
+++ b/src/discussions/posts/post-filter-bar/messages.js
@@ -48,7 +48,7 @@ const messages = defineMessages({
   },
   filterUnresponded: {
     id: 'discussions.posts.status.filter.unresponded',
-    defaultMessage: 'Unresponded',
+    defaultMessage: 'Not responded',
     description: 'Option in dropdown to filter to unresponded posts',
   },
   myPosts: {


### PR DESCRIPTION
Addition of not responded posts filter in fetch threads lists API.
**Jira ticket: https://2u-internal.atlassian.net/browse/INF-524
related BE PR: https://github.com/openedx/frontend-app-discussions/pull/286**

**Useful information to include:**

Which edX user roles will this change impact? Common user roles are "Learner".

**Supporting information**
Jira ticket: https://2u-internal.atlassian.net/browse/INF-524
related BE PR: https://github.com/openedx/edx-platform/pull/31275

**Testing instructions**
checkout to this branch and make sure you have the latest changes from cs_comment_service as well
use mehak/INF-475 https://github.com/openedx/frontend-app-discussions/pull/286 of discussions MFE
run devstack and open the filters section in all posts/ and my posts
select not responded from the filters section now scroll through the list and. it should display a list of all such discussion posts which have not been responded to.
Click load more posts to validate no such posts are returned in the paginated response as well.


<img width="1249" alt="Screen Shot 2022-11-10 at 2 33 33 AM" src="https://user-images.githubusercontent.com/67791278/200946510-589aba88-4859-493b-8147-99d4699b3fb5.png">
