### PR TITLE
feat: made violates-guidelines edit reason code default for admin

### DIFF
--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -29,6 +29,7 @@ import {
   selectModerationSettings,
   selectUserHasModerationPrivileges,
   selectUserIsGroupTa,
+  selectUserIsStaff,
 } from '../../data/selectors';
 import { selectCoursewareTopics, selectNonCoursewareIds, selectNonCoursewareTopics } from '../../topics/data/selectors';
 import {
@@ -102,9 +103,10 @@ function PostEditor({
   const settings = useSelector(selectDivisionSettings);
   const { allowAnonymous, allowAnonymousToPeers } = useSelector(selectAnonymousPostingConfig);
   const { reasonCodesEnabled, editReasons } = useSelector(selectModerationSettings);
+  const userIsStaff = useSelector(selectUserIsStaff);
 
   const canDisplayEditReason = (reasonCodesEnabled && editExisting
-    && (userHasModerationPrivileges || userIsGroupTa) && post?.author !== authenticatedUser.username
+    && (userHasModerationPrivileges || userIsGroupTa || userIsStaff) && post?.author !== authenticatedUser.username
   );
 
   const editReasonCodeValidation = canDisplayEditReason && {
@@ -345,7 +347,7 @@ function PostEditor({
                   name="editReasonCode"
                   className="m-0"
                   as="select"
-                  value={values.editReasonCode}
+                  value={userIsStaff ? 'violates-guidelines' : values.editReasonCode}
                   onChange={handleChange}
                   onBlur={handleBlur}
                   aria-describedby="editReasonCodeInput"


### PR DESCRIPTION
## Description
Made violates-guidelines edit reason code default for admin, it depends on this PR https://github.com/openedx/edx-platform/pull/30984

## Ticket
https://2u-internal.atlassian.net/browse/INF-538

## Testing instructions
Login with a global staff account and edit other user's posts, observe that in edit reasons `Violates community guidelines` is selected by default.