### PR TITLE
fix: permission fixes added for form

### DIFF
--- a/.jest/setEnvVars.js
+++ b/.jest/setEnvVars.js
@@ -1,0 +1,2 @@
+process.env.TA_FEEDBACK_FORM= 'https://learner-form.test';
+process.env.STAFF_FEEDBACK_FORM= 'https://staff-form.test';

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ const { createConfig } = require('@edx/frontend-build');
 module.exports = createConfig('jest', {
   // setupFilesAfterEnv is used after the jest environment has been loaded.  In general this is what you want.  
   // If you want to add config BEFORE jest loads, use setupFiles instead.
-  setupFiles: ['<rootDir>/.env.test'],
+  setupFiles: ['<rootDir>/.jest/setEnvVars.js'],
   setupFilesAfterEnv: [
     '<rootDir>/src/setupTest.js',
   ],

--- a/src/discussions/discussions-home/InformationBanner.test.jsx
+++ b/src/discussions/discussions-home/InformationBanner.test.jsx
@@ -119,7 +119,7 @@ describe('User is redirected according to url according to role', () => {
   });
 
   test('moderators/administrators are redirected to moderators feedback form', async () => {
-    store.dispatch(fetchConfigSuccess(getConfigData(true, ['Student', 'Moderator', 'Administrator'])));
+    store.dispatch(fetchConfigSuccess(getConfigData(false, ['Student', 'Moderator', 'Administrator'])));
     renderComponent(true);
     expect(screen.getByText(messages.shareFeedback.defaultMessage)
       .closest('a'))

--- a/src/discussions/discussions-home/InformationsBanner.jsx
+++ b/src/discussions/discussions-home/InformationsBanner.jsx
@@ -15,10 +15,10 @@ function InformationBanner({
   const userRoles = useSelector(selectUserRoles);
   const isAdmin = useSelector(selectUserIsStaff);
   const learnMoreLink = 'https://openedx.atlassian.net/wiki/spaces/COMM/pages/3509551260/Overview+New+discussions+experience';
-  const TAFeedbackLink = process.env.TA_FEEDBACK_FORM || '';
-  const staffFeedbackLink = process.env.STAFF_FEEDBACK_FORM || '';
+  const TAFeedbackLink = process.env.TA_FEEDBACK_FORM;
+  const staffFeedbackLink = process.env.STAFF_FEEDBACK_FORM;
   const hideLearnMoreButton = ((userRoles.includes('Student') && userRoles.length === 1) || !userRoles.length) && !isAdmin;
-  const showStaffLink = !hideLearnMoreButton || userRoles.includes('Moderator') || userRoles.includes('Administrator');
+  const showStaffLink = isAdmin || userRoles.includes('Moderator') || userRoles.includes('Administrator');
 
   return (
     <PageBanner


### PR DESCRIPTION
- test cases were false passing as both URLs were picking empty strings from env, this has been fixed
- fixed permission tests according to use cases. 

with that I have just figured out that .env.test. is pretty much useless in our codebase, however, I need to confirm it and look into it for more details, might remove that later as well.