### PR TITLE
fix: removed extra zero in user stats

### DIFF
--- a/src/discussions/learners/data/slices.js
+++ b/src/discussions/learners/data/slices.js
@@ -40,6 +40,7 @@ const learnersSlice = createSlice({
       state.status = RequestStatus.IN_PROGRESS;
     },
     setSortedBy: (state, { payload }) => {
+      state.pages = [];
       state.sortedBy = payload;
     },
     setUsernameSearch: (state, { payload }) => {

--- a/src/discussions/learners/learner/LearnerFooter.jsx
+++ b/src/discussions/learners/learner/LearnerFooter.jsx
@@ -31,7 +31,7 @@ function LearnerFooter({
         <Icon src={Edit} className="icon-size mr-2 ml-4" />
         {learner.replies + learner.responses}
       </div>
-      {canSeeLearnerReportedStats && (
+      {Boolean(canSeeLearnerReportedStats) && (
         <OverlayTrigger
           overlay={(
             <Tooltip id={`learner-${learner.username}`}>


### PR DESCRIPTION
## Description:
 Response+comment count for some learners is showing an extra trailing zero as seen in the screenshot below. This issue is resolved in this PR.
Fixed Learners sorting issue.

<img width="902" alt="image-20220920-062947" src="https://user-images.githubusercontent.com/26253150/191191363-16be55e6-9848-427b-a2ff-bb3f61b212ec.png">



## Ticket : 
https://2u-internal.atlassian.net/browse/INF-553
https://2u-internal.atlassian.net/browse/INF-499
