### PR TITLE
fix: remove post sorting from frontend

### DIFF
--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -52,7 +52,7 @@ function DiscussionPostType({
     <label htmlFor={`post-type-${value}`} className="d-flex p-0 my-2 mr-3">
       <Form.Radio value={value} id={`post-type-${value}`} className="sr-only">{type}</Form.Radio>
       <Card
-        className={classNames('border-2', {
+        className={classNames('border-2 shadow-none', {
           'border-primary': selected,
           'border-light-400': !selected,
         })}

--- a/src/discussions/utils.js
+++ b/src/discussions/utils.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import { getIn } from 'formik';
-import { orderBy, uniqBy } from 'lodash';
+import { uniqBy } from 'lodash';
 import { generatePath, useRouteMatch } from 'react-router';
 
 import { getConfig } from '@edx/frontend-platform';
@@ -252,13 +252,9 @@ export const isPostPreviewAvailable = (htmlNode) => {
  * @param {array} posts arrays of posts
  * @param {string} filterBy name of post object attribute. un will use for reverse
  *  condition. like pinned attribute for pinned post and unpinned for non pinned posts.
- * @param {string} sortBy name of post object attribute
- * @param {string} order order of the sorting list
  */
-export const filterPosts = (posts, filterBy, sortBy = 'createdAt', order = 'desc') => orderBy(
-  uniqBy(posts, 'id').filter(
-    post => (filterBy.startsWith('un') ? !post[filterBy.slice(2)] : post[filterBy]),
-  ), [sortBy], [order],
+export const filterPosts = (posts, filterBy) => uniqBy(posts, 'id').filter(
+  post => (filterBy.startsWith('un') ? !post[filterBy.slice(2)] : post[filterBy]),
 );
 
 /**


### PR DESCRIPTION
### [INF-567](https://2u-internal.atlassian.net/browse/INF-567)

- Fixed Post, My post, and learner post sorting. 
- Recent activity filtering is working
- Removed sorting from the frontend

### Before Fix
<img width="480" alt="Screenshot 2022-09-28 at 7 24 41 PM" src="https://user-images.githubusercontent.com/79941147/192818616-52a10879-8dca-4903-b585-d0ff25d87a87.png">

### After Fix
<img width="408" alt="Screenshot 2022-09-28 at 7 26 02 PM" src="https://user-images.githubusercontent.com/79941147/192818742-d0f5d543-3385-412e-b870-f51f9b72159a.png">

