### PR TITLE
fix: double slash also supported now for mathjax rendering

### DIFF
--- a/src/components/HTMLLoader.jsx
+++ b/src/components/HTMLLoader.jsx
@@ -8,12 +8,14 @@ const baseConfig = {
   tex2jax: {
     inlineMath: [
       ['$', '$'],
+      ['\\\\(', '\\\\)'],
       ['\\(', '\\)'],
       ['[mathjaxinline]', '[/mathjaxinline]'],
     ],
     displayMath: [
       ['[mathjax]', '[/mathjax]'],
       ['$$', '$$'],
+      ['\\\\[', '\\\\]'],
       ['\\[', '\\]'],
     ],
   },


### PR DESCRIPTION
Course teams and learners provided feedback on the mathjax not rendering properly, according to the discovery it. was found the expression starting and ending with double slashes were not supported as in legacy experience, this is now added in mathjax config and MFE now supports that as well along with single slash.

<img width="1255" alt="Screen Shot 2022-09-28 at 10 45 14 PM" src="https://user-images.githubusercontent.com/67791278/192852513-417cfd4c-edce-44d4-9856-44dee0998c5a.png">
