### PR TITLE
fix: ui refactoring of load more responses and comments button

### DIFF
--- a/src/discussions/comments/CommentsView.jsx
+++ b/src/discussions/comments/CommentsView.jsx
@@ -80,14 +80,15 @@ function DiscussionCommentsView({
         {sortedComments.map(comment => (
           <Comment comment={comment} key={comment.id} postType={postType} isClosedPost={isClosed} />
         ))}
-        {!!sortedComments.length && !isClosed
-          && <ResponseEditor postId={postId} addWrappingDiv />}
         {hasMorePages && !isLoading && (
           <Button
             onClick={handleLoadMoreResponses}
             variant="link"
             block="true"
-            className="card p-4"
+            className="card p-4 mb-4 font-weight-500 font-size-14"
+            style={{
+              lineHeight: '20px',
+            }}
             data-testid="load-more-comments"
           >
             {intl.formatMessage(messages.loadMoreResponses)}
@@ -99,6 +100,8 @@ function DiscussionCommentsView({
             <Spinner animation="border" variant="primary" />
           </div>
         )}
+        {!!sortedComments.length && !isClosed
+          && <ResponseEditor postId={postId} addWrappingDiv />}
       </div>
     </>
 

--- a/src/discussions/comments/comment/Comment.jsx
+++ b/src/discussions/comments/comment/Comment.jsx
@@ -112,7 +112,7 @@ function Comment({
               lineHeight: '20px',
             }}
           >
-            {intl.formatMessage(messages.loadMoreResponses)}
+            {intl.formatMessage(messages.loadMoreComments)}
           </Button>
           )}
           {!isNested && showFullThread && (
@@ -130,8 +130,11 @@ function Comment({
                 {(!isClosedPost && !inBlackoutDateRange(blackoutDateRange))
                   && (
                     <Button
-                      className="d-flex flex-grow mt-4.5"
+                      className="d-flex flex-grow mt-3 py-2 font-size-14"
                       variant="outline-primary"
+                      style={{
+                        lineHeight: '20px',
+                      }}
                       onClick={() => setReplying(true)}
                     >
                       {intl.formatMessage(messages.addComment)}

--- a/src/discussions/comments/comment/ResponseEditor.jsx
+++ b/src/discussions/comments/comment/ResponseEditor.jsx
@@ -37,7 +37,14 @@ function ResponseEditor({
     )
     : !inBlackoutDateRange(blackoutDateRange) && (
       <div className={classNames({ 'mb-4': addWrappingDiv }, 'actions d-flex')}>
-        <Button variant="primary" className="px-2.5 py-2" onClick={() => setAddingResponse(true)}>
+        <Button
+          variant="primary"
+          className="px-2.5 py-2 font-size-14"
+          onClick={() => setAddingResponse(true)}
+          style={{
+            lineHeight: '20px',
+          }}
+        >
           {intl.formatMessage(messages.addResponse)}
         </Button>
       </div>


### PR DESCRIPTION
UI Refactoring 
- Corrected text for load more comments button
- Moved "Add a response" button below "Load more responses" button
- Change UI of "Load more responses", "Load more comments", "Add a response" and "Add a comment" button according to figma

Before
![inf-547_before](https://user-images.githubusercontent.com/77053848/193534576-92d17382-3c3d-4304-8be1-b9903ef68018.png)

After
![inf-547_after](https://user-images.githubusercontent.com/77053848/193534595-28fde523-da68-4b67-b757-9d98fdd3c188.png)


