### PR TITLE
fix: fix for reported alert banner and reported badge

### DIFF
--- a/src/discussions/common/AlertBanner.jsx
+++ b/src/discussions/common/AlertBanner.jsx
@@ -23,12 +23,11 @@ function AlertBanner({
   const { reasonCodesEnabled } = useSelector(selectModerationSettings);
   const userIsContentAuthor = getAuthenticatedUser().username === content.author;
   const canSeeLastEditOrClosedAlert = (userHasModerationPrivileges || userIsContentAuthor || userIsGroupTa);
-  const isReportedByCurrentUser = getAuthenticatedUser().username === content?.abuseFlaggedBy;
-  const canSeeReportedBanner = (userHasModerationPrivileges || userIsGroupTa || isReportedByCurrentUser);
+  const canSeeReportedBanner = content?.abuseFlagged;
 
   return (
     <>
-      {content.abuseFlagged && canSeeReportedBanner && (
+      {canSeeReportedBanner && (
         <Alert icon={Error} variant="danger" className="px-3 mb-2 py-10px shadow-none flex-fill">
           {intl.formatMessage(messages.abuseFlaggedMessage)}
         </Alert>

--- a/src/discussions/data/hooks.js
+++ b/src/discussions/data/hooks.js
@@ -140,8 +140,7 @@ export const useAlertBannerVisible = (content) => {
   const { reasonCodesEnabled } = useSelector(selectModerationSettings);
   const userIsContentAuthor = getAuthenticatedUser().username === content.author;
   const canSeeLastEditOrClosedAlert = (userHasModerationPrivileges || userIsContentAuthor || userIsGroupTa);
-  const isReportedByCurrentUser = getAuthenticatedUser().username === content?.abuseFlaggedBy;
-  const canSeeReportedBanner = (userHasModerationPrivileges || userIsGroupTa || isReportedByCurrentUser);
+  const canSeeReportedBanner = content.abuseFlagged;
 
   return (
     (reasonCodesEnabled && canSeeLastEditOrClosedAlert && (content.lastEdit?.reason || content.closed))

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -2,7 +2,6 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import classNames from 'classnames';
-import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
@@ -12,7 +11,6 @@ import { PushPin } from '../../../components/icons';
 import { AvatarOutlineAndLabelColors, Routes, ThreadType } from '../../../data/constants';
 import AuthorLabel from '../../common/AuthorLabel';
 import { DiscussionContext } from '../../common/context';
-import { selectUserHasModerationPrivileges, selectUserIsGroupTa } from '../../data/selectors';
 import { discussionsPath, isPostPreviewAvailable } from '../../utils';
 import messages from './messages';
 import PostFooter from './PostFooter';
@@ -42,12 +40,9 @@ function PostLink({
     category,
     learnerUsername,
   });
-  const userHasModerationPrivileges = useSelector(selectUserHasModerationPrivileges);
-  const userIsGroupTa = useSelector(selectUserIsGroupTa);
   const showAnsweredBadge = post.hasEndorsed && post.type === ThreadType.QUESTION;
   const authorLabelColor = AvatarOutlineAndLabelColors[post.authorLabel];
-  const postReported = post.abuseFlagged || post.abuseFlaggedCount;
-  const canSeeReportedBadge = postReported && (userHasModerationPrivileges || userIsGroupTa);
+  const canSeeReportedBadge = post.abuseFlagged;
   const read = post.read || (!post.read && post.commentCount !== post.unreadCommentCount);
 
   return (


### PR DESCRIPTION
### [INF-545](https://2u-internal.atlassian.net/browse/INF-545)

### Description

Update **Reported Alert Banner** and **Reported Badge** to use `abuseFlagged` param to show/hide Reported Label on content. 

The `abuseFlagged` param indicates the following for different roles:

- **Moderator Role:** **_Return True if content is reported by anyone._**
- **No Moderator Role:** _**Return True ONLY if content is reported by the user themselves.**_

We can avoid checking for different roles on the current user, and use the already calculated `abuseFlagged` value from backend.

