### PR TITLE
fix: learner tab is now visible irrespective of user role

### DIFF
--- a/src/discussions/data/hooks.js
+++ b/src/discussions/data/hooks.js
@@ -23,7 +23,7 @@ import {
   selectModerationSettings,
   selectPostThreadCount,
   selectUserHasModerationPrivileges,
-  selectUserIsGroupTa, selectUserIsStaff, selectUserRoles,
+  selectUserIsGroupTa,
 } from './selectors';
 import { fetchCourseConfig } from './thunks';
 
@@ -151,15 +151,7 @@ export const useAlertBannerVisible = (content) => {
   );
 };
 
-export const useShowLearnersTab = () => {
-  const learnersTabEnabled = useSelector(selectLearnersTabEnabled);
-  const userRoles = useSelector(selectUserRoles);
-  const isAdmin = useSelector(selectUserIsStaff);
-  const IsGroupTA = useSelector(selectUserIsGroupTa);
-  const privileged = useSelector(selectUserHasModerationPrivileges);
-  const allowedUsers = isAdmin || IsGroupTA || privileged || (userRoles.includes('Student') && userRoles.length > 1);
-  return learnersTabEnabled && allowedUsers;
-};
+export const useShowLearnersTab = () => useSelector(selectLearnersTabEnabled);
 
 /**
  * React hook that gets the current topic ID from the current topic or category.


### PR DESCRIPTION
Related Ticket: https://2u-internal.atlassian.net/browse/INF-612

Learners Tab will be visible to learners.

<img width="1680" alt="Screen Shot 2022-10-13 at 8 44 34 PM" src="https://user-images.githubusercontent.com/67791278/195643417-d34594f7-c5f8-4fe8-a4ac-7f6b4b68f695.png">

The above screenshot represents a logged-in user without any moderation privileges who is not admin or TA or has any special roles. The learner tab is visible to the user.
