### PR TITLE
feat: blackout dates information banner added

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@edx/frontend-component-footer": "11.2.0",
         "@edx/frontend-component-header": "3.2.0",
         "@edx/frontend-platform": "2.6.1",
-        "@edx/paragon": "20.12.1",
+        "@edx/paragon": "20.15.0",
         "@reduxjs/toolkit": "1.8.0",
         "@tinymce/tinymce-react": "3.13.1",
         "babel-polyfill": "6.26.0",
@@ -3514,9 +3514,9 @@
       }
     },
     "node_modules/@edx/paragon": {
-      "version": "20.12.1",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.12.1.tgz",
-      "integrity": "sha512-U/kcxgFDSsy6y+hWSwglRMtLaXSwLbqoZoBg9LYZQPbPGMfEQoqQHewZYJOEwxL5GBgzyid/RjWCMr2PYqdOiA==",
+      "version": "20.15.0",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.15.0.tgz",
+      "integrity": "sha512-Sq5/je3Ub3UpXrrneaCShz+kB6wuMNmeF1Y/XfVt6X2i+ZCQGlQrBa3KtcwGwDOHIQ65eC6dqJpL9LISHg+xtg==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
@@ -30114,9 +30114,9 @@
       }
     },
     "@edx/paragon": {
-      "version": "20.12.1",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.12.1.tgz",
-      "integrity": "sha512-U/kcxgFDSsy6y+hWSwglRMtLaXSwLbqoZoBg9LYZQPbPGMfEQoqQHewZYJOEwxL5GBgzyid/RjWCMr2PYqdOiA==",
+      "version": "20.15.0",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.15.0.tgz",
+      "integrity": "sha512-Sq5/je3Ub3UpXrrneaCShz+kB6wuMNmeF1Y/XfVt6X2i+ZCQGlQrBa3KtcwGwDOHIQ65eC6dqJpL9LISHg+xtg==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@edx/frontend-component-footer": "11.2.0",
     "@edx/frontend-component-header": "3.2.0",
     "@edx/frontend-platform": "2.6.1",
-    "@edx/paragon": "20.12.1",
+    "@edx/paragon": "20.15.0",
     "@reduxjs/toolkit": "1.8.0",
     "@tinymce/tinymce-react": "3.13.1",
     "babel-polyfill": "6.26.0",

--- a/src/discussions/discussions-home/BlackoutInformationBanner.jsx
+++ b/src/discussions/discussions-home/BlackoutInformationBanner.jsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+
+import { useSelector } from 'react-redux';
+
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { PageBanner } from '@edx/paragon';
+
+import { selectBlackoutDate } from '../data/selectors';
+import messages from '../messages';
+import { inBlackoutDateRange } from '../utils';
+
+function BlackoutInformationBanner({
+  intl,
+}) {
+  const isDiscussionsBlackout = inBlackoutDateRange(useSelector(selectBlackoutDate));
+  const [showBanner, setShowBanner] = useState(true);
+
+  return (
+    <PageBanner
+      variant="warning"
+      show={isDiscussionsBlackout && showBanner}
+      dismissible
+      onDismiss={() => setShowBanner(false)}
+    >
+      <div className="font-weight-500">
+        {intl.formatMessage(messages.blackoutDiscussionInformation)}
+      </div>
+    </PageBanner>
+  );
+}
+
+BlackoutInformationBanner.propTypes = {
+  intl: intlShape.isRequired,
+};
+
+export default injectIntl(BlackoutInformationBanner);

--- a/src/discussions/discussions-home/BlackoutInformationBanner.jsx
+++ b/src/discussions/discussions-home/BlackoutInformationBanner.jsx
@@ -17,7 +17,7 @@ function BlackoutInformationBanner({
 
   return (
     <PageBanner
-      variant="warning"
+      variant="accentB"
       show={isDiscussionsBlackout && showBanner}
       dismissible
       onDismiss={() => setShowBanner(false)}

--- a/src/discussions/discussions-home/BlackoutInformationBanner.test.jsx
+++ b/src/discussions/discussions-home/BlackoutInformationBanner.test.jsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+
+import { initializeMockApp } from '@edx/frontend-platform';
+import { AppProvider } from '@edx/frontend-platform/react';
+
+import { initializeStore } from '../../store';
+import { DiscussionContext } from '../common/context';
+import { fetchConfigSuccess } from '../data/slices';
+import messages from '../messages';
+import BlackoutInformationBanner from './BlackoutInformationBanner';
+
+let store;
+let container;
+const courseId = 'course-v1:edX+DemoX+Demo_Course';
+let activeStartDate = new Date();
+activeStartDate.setDate(activeStartDate.getDate() - 2);
+let activeEndDate = new Date();
+activeEndDate.setDate(activeEndDate.getDate() + 2);
+activeStartDate = activeStartDate.toISOString();
+activeEndDate = activeEndDate.toISOString();
+
+const getConfigData = (blackouts = []) => ({
+  id: 'course-v1:edX+DemoX+Demo_Course',
+  userRoles: ['Admin', 'Student'],
+  hasModerationPrivileges: false,
+  isGroupTa: false,
+  isUserAdmin: false,
+  blackouts,
+});
+
+function renderComponent() {
+  const wrapper = render(
+    <IntlProvider locale="en">
+      <AppProvider store={store}>
+        <DiscussionContext.Provider value={{ courseId }}>
+          <BlackoutInformationBanner />
+        </DiscussionContext.Provider>
+      </AppProvider>
+    </IntlProvider>,
+  );
+  container = wrapper.container;
+  return container;
+}
+
+describe('Blackout Information Banner', () => {
+  beforeEach(async () => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 3,
+        username: 'abc123',
+        administrator: false,
+        roles: ['Student'],
+      },
+    });
+  });
+
+  test.each([
+    { blackouts: [], visibility: false },
+    { blackouts: ['2021-12-31T10:15', '2021-12-31T10:20'], visibility: false },
+    { blackouts: [{ start: activeStartDate, end: activeEndDate }], visibility: true },
+    { blackouts: [{ start: activeEndDate, end: activeEndDate }], visibility: false },
+  ])('Test Blackout Banner is visible on app load if blackout date is active', async ({ blackouts, visibility }) => {
+    store = initializeStore();
+    await store.dispatch(fetchConfigSuccess(getConfigData(blackouts)));
+    renderComponent();
+    if (visibility) {
+      const element = await screen.findByRole('alert');
+      expect(element).toBeInTheDocument();
+      expect(element).toHaveTextContent(messages.blackoutDiscussionInformation.defaultMessage);
+    } else {
+      const element = await screen.queryByRole('alert');
+      expect(element).not.toBeInTheDocument();
+    }
+  });
+});

--- a/src/discussions/discussions-home/DiscussionsHome.jsx
+++ b/src/discussions/discussions-home/DiscussionsHome.jsx
@@ -21,6 +21,7 @@ import { EmptyLearners, EmptyPosts, EmptyTopics } from '../empty-posts';
 import messages from '../messages';
 import { BreadcrumbMenu, LegacyBreadcrumbMenu, NavigationBar } from '../navigation';
 import { postMessageToParent } from '../utils';
+import BlackoutInformationBanner from './BlackoutInformationBanner';
 import DiscussionContent from './DiscussionContent';
 import DiscussionSidebar from './DiscussionSidebar';
 import InformationBanner from './InformationsBanner';
@@ -96,6 +97,7 @@ export default function DiscussionsHome() {
             <PostActionsBar inContext={inContext} />
           </div>
           {isFeedbackBannerVisible && <InformationBanner />}
+          <BlackoutInformationBanner />
         </div>
         <Route
           path={[Routes.POSTS.PATH, Routes.TOPICS.CATEGORY]}

--- a/src/discussions/discussions-home/InformationsBanner.jsx
+++ b/src/discussions/discussions-home/InformationsBanner.jsx
@@ -27,7 +27,7 @@ function InformationBanner({
       dismissible
       onDismiss={() => setShowBanner(false)}
     >
-      <div style={{ fontWeight: '500' }}>
+      <div className="font-weight-500">
         {intl.formatMessage(messages.bannerMessage)}
         {!hideLearnMoreButton
           && (

--- a/src/discussions/messages.js
+++ b/src/discussions/messages.js
@@ -176,7 +176,7 @@ const messages = defineMessages({
   bannerMessage: {
     id: 'discussion.banner.welcomeMessage',
     defaultMessage: '🎉 Welcome to the new and improved discussions experience!',
-    description: 'Author name displayed when a post is anonymous',
+    description: 'Information banner welcome text',
   },
   learnMoreBannerLink: {
     id: 'discussion.banner.learnMore',
@@ -187,6 +187,11 @@ const messages = defineMessages({
     id: 'discussion.banner.shareFeedback',
     defaultMessage: 'Share feedback',
     description: 'Share feedback button to open feedback forms',
+  },
+  blackoutDiscussionInformation: {
+    id: 'discussion.blackoutBanner.information',
+    defaultMessage: 'Blackout dates are currently active. Posting in discussions is unavailable at this time.',
+    description: 'Informative text when discussions blackout is active',
   },
 });
 


### PR DESCRIPTION
Related ticket https://2u-internal.atlassian.net/browse/INF-599
background color change is required which will be based on the Paragon PR merge and version upgrade in this PR - DONE

<img width="1679" alt="Screen Shot 2022-10-14 at 8 46 40 PM" src="https://user-images.githubusercontent.com/67791278/195887822-554d1469-81f0-427b-8108-1dfea76895a5.png">

After paragon upgrade
<img width="1680" alt="Screen Shot 2022-10-20 at 1 40 31 AM" src="https://user-images.githubusercontent.com/67791278/196799540-d232cd13-7c5b-4a27-a2f2-a6bacd01f1ec.png">

Note needed paragon upgrade to match Figma designs.
