### PR TITLE
fix: add flag for transifex pull command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ push_translations:
 
 # Pulls translations from Transifex.
 pull_translations:
-	tx pull -f --mode reviewed --languages=$(transifex_langs)
+	tx pull -t -f --mode reviewed --languages=$(transifex_langs)
 
 # This target is used by Travis.
 validate-no-uncommitted-package-lock-changes:


### PR DESCRIPTION
### [INF-641](https://2u-internal.atlassian.net/browse/INF-641)

### Description
The Transifex cli started requiring the `-t` or `--translations` flag in the pull command in order to fetch translations. 
More details on ticket.

