### PR TITLE
fix: convert clickable author label to text in posts summary list

### DIFF
--- a/src/discussions/comments/comment/CommentHeader.jsx
+++ b/src/discussions/comments/comment/CommentHeader.jsx
@@ -39,7 +39,12 @@ function CommentHeader({
             height: '32px',
           }}
         />
-        <AuthorLabel author={comment.author} authorLabel={comment.authorLabel} labelColor={colorClass && `text-${colorClass}`} linkToProfile />
+        <AuthorLabel
+          author={comment.author}
+          authorLabel={comment.authorLabel}
+          labelColor={colorClass && `text-${colorClass}`}
+          linkToProfile
+        />
       </div>
       <div className="d-flex align-items-center">
         <span className="btn-icon btn-icon-sm mr-1 align-items-center">

--- a/src/discussions/common/AuthorLabel.jsx
+++ b/src/discussions/common/AuthorLabel.jsx
@@ -40,7 +40,7 @@ function AuthorLabel({
   const className = classNames('d-flex align-items-center', labelColor);
 
   const showUserNameAsLink = useShowLearnersTab()
-      && linkToProfile && author && author !== messages.anonymous;
+      && linkToProfile && author && author !== 'anonymous';
 
   const labelContents = (
     <div className={className}>

--- a/src/discussions/common/AuthorLabel.test.jsx
+++ b/src/discussions/common/AuthorLabel.test.jsx
@@ -1,0 +1,107 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import MockAdapter from 'axios-mock-adapter';
+import { IntlProvider } from 'react-intl';
+
+import { initializeMockApp } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { AppProvider } from '@edx/frontend-platform/react';
+
+import { initializeStore } from '../../store';
+import { executeThunk } from '../../test-utils';
+import { courseConfigApiUrl } from '../data/api';
+import { fetchCourseConfig } from '../data/thunks';
+import AuthorLabel from './AuthorLabel';
+import { DiscussionContext } from './context';
+
+const courseId = 'course-v1:edX+DemoX+Demo_Course';
+let store;
+let axiosMock;
+let container;
+
+function renderComponent(author, authorLabel, linkToProfile, labelColor) {
+  const wrapper = render(
+    <IntlProvider locale="en">
+      <AppProvider store={store}>
+        <DiscussionContext.Provider value={{ courseId }}>
+          <AuthorLabel
+            author={author}
+            authorLabel={authorLabel}
+            linkToProfile={linkToProfile}
+            labelColor={labelColor}
+          />
+        </DiscussionContext.Provider>
+      </AppProvider>
+    </IntlProvider>,
+  );
+  container = wrapper.container;
+  return container;
+}
+
+describe('Author label', () => {
+  beforeEach(async () => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 3,
+        username: 'abc123',
+        administrator: true,
+        roles: [],
+      },
+    });
+    store = initializeStore();
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    axiosMock.onGet(`${courseConfigApiUrl}${courseId}/`).reply(200, {
+      learners_tab_enabled: true,
+      has_moderation_privileges: true,
+    });
+    axiosMock.onGet(`${courseConfigApiUrl}${courseId}/settings`).reply(200, {});
+    await executeThunk(fetchCourseConfig(courseId), store.dispatch, store.getState);
+  });
+
+  describe.each([
+    ['anonymous', null, false, ''],
+    ['ta_user', 'Community TA', true, 'text-TA-color'],
+    ['retired__user', null, false, ''],
+    ['staff_user', 'Staff', true, 'text-staff-color'],
+    ['learner_user', null, false, ''],
+  ])('for %s', (
+    author, authorLabel, linkToProfile, labelColor,
+  ) => {
+    it('it has author name text',
+      async () => {
+        renderComponent(author, authorLabel, linkToProfile, labelColor);
+        const authorElement = container.querySelector('[role=heading]');
+        const authorName = author.startsWith('retired__user') ? '[Deactivated]' : author;
+
+        expect(authorElement).toHaveTextContent(authorName);
+      });
+
+    it(`it is "${!linkToProfile && 'not'}" clickable when linkToProfile is ${!!linkToProfile}`,
+      async () => {
+        renderComponent(author, authorLabel, linkToProfile, labelColor);
+
+        if (linkToProfile) {
+          expect(screen.queryByTestId('learner-posts-link')).toBeInTheDocument();
+        } else {
+          expect(screen.queryByTestId('learner-posts-link')).not.toBeInTheDocument();
+        }
+      });
+
+    it(`it has "${!linkToProfile && 'not'}" label text and label color when linkToProfile is ${!!linkToProfile}`,
+      async () => {
+        renderComponent(author, authorLabel, linkToProfile, labelColor);
+        const authorElement = container.querySelector('[role=heading]');
+        const labelElement = authorElement.parentNode.lastChild;
+        const label = ['TA', 'Staff'].includes(labelElement.textContent) && labelElement.textContent;
+
+        if (linkToProfile) {
+          expect(authorElement.parentNode).toHaveClass(labelColor);
+          expect(authorElement.parentNode.lastChild).toHaveTextContent(label);
+        } else {
+          expect(authorElement.parentNode.lastChild).not.toHaveTextContent(label, { exact: true });
+          expect(authorElement.parentNode).not.toHaveClass(labelColor, { exact: true });
+        }
+      });
+  });
+});

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -20,7 +20,6 @@ import { postShape } from './proptypes';
 function PostLink({
   post,
   isSelected,
-  learnerTab,
   showDivider,
   idx,
 }) {
@@ -113,7 +112,6 @@ function PostLink({
               author={post.author || intl.formatMessage(messages.anonymous)}
               authorLabel={post.authorLabel}
               labelColor={authorLabelColor && `text-${authorLabelColor}`}
-              linkToProfile={!learnerTab && Boolean(post.author)}
             />
             <div
               className="text-truncate text-primary-500 font-weight-normal font-size-14 font-style-normal font-family-inter"
@@ -137,13 +135,11 @@ function PostLink({
 PostLink.propTypes = {
   post: postShape.isRequired,
   isSelected: PropTypes.func.isRequired,
-  learnerTab: PropTypes.bool,
   showDivider: PropTypes.bool,
   idx: PropTypes.number,
 };
 
 PostLink.defaultProps = {
-  learnerTab: false,
   showDivider: true,
   idx: -1,
 };

--- a/src/discussions/posts/post/PostLink.test.jsx
+++ b/src/discussions/posts/post/PostLink.test.jsx
@@ -19,12 +19,12 @@ const courseId = 'course-v1:edX+DemoX+Demo_Course';
 let store;
 let axiosMock;
 
-function renderComponent(post, learnerTab = false) {
+function renderComponent(post) {
   return render(
     <IntlProvider locale="en">
       <AppProvider store={store}>
         <DiscussionContext.Provider value={{ courseId }}>
-          <PostLink post={post} key={post.id} isSelected={() => true} learnerTab={learnerTab} />
+          <PostLink post={post} key={post.id} isSelected={() => true} />
         </DiscussionContext.Provider>
       </AppProvider>
     </IntlProvider>,
@@ -103,27 +103,10 @@ describe('Post username', () => {
   });
 
   it.each([
-    true,
-    false,
-  ])('is a clickable link %s', async (leanerTab) => {
-    renderComponent(mockPost, leanerTab);
-
-    if (leanerTab) {
-      expect(screen.queryByTestId('learner-posts-link')).not.toBeInTheDocument();
-    } else {
-      expect(screen.queryByTestId('learner-posts-link')).toBeInTheDocument();
-    }
-  });
-
-  it.each([
-    true,
-    false,
-  ])('is only clickable if user is not anonymous', async (isAnonymous) => {
-    renderComponent({ ...mockPost, author: isAnonymous ? null : 'test-user' });
-    if (isAnonymous) {
-      expect(screen.queryByTestId('learner-posts-link')).not.toBeInTheDocument();
-    } else {
-      expect(screen.queryByTestId('learner-posts-link')).toBeInTheDocument();
-    }
+    'anonymous',
+    'test-user',
+  ])('is not clickable for %s user', async (user) => {
+    renderComponent({ ...mockPost, author: user });
+    expect(screen.queryByTestId('learner-posts-link')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### [INF-596](https://2u-internal.atlassian.net/browse/INF-596)

- User name is no more clickable in the posts summary list in all 4 tabs
- Add new test cases for an author label component 

https://www.loom.com/share/e191efd27a744ac180d57cb0109de955
