### PR TITLE
fix: fixed failing tests for reported badge in learners post view

### DIFF
--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -42,7 +42,7 @@ function PostLink({
   });
   const showAnsweredBadge = post.hasEndorsed && post.type === ThreadType.QUESTION;
   const authorLabelColor = AvatarOutlineAndLabelColors[post.authorLabel];
-  const canSeeReportedBadge = post.abuseFlagged;
+  const canSeeReportedBadge = post.abuseFlagged || post.abuseFlaggedCount;
   const read = post.read || (!post.read && post.commentCount !== post.unreadCommentCount);
 
   return (


### PR DESCRIPTION
Fixed tests that were failing on transifex

Test cases related to reported badge for learners area were fixed. 
Added condition to show reported symbol is post.abuseFlaggedCount. abuseFlaggedCount shows number of responses and replies of post that are marked reported. 