### PR TITLE
fix: removed highlighted header-action-bar on confirmation pop-up

### DIFF
--- a/src/discussions/common/DeleteConfirmation.jsx
+++ b/src/discussions/common/DeleteConfirmation.jsx
@@ -15,7 +15,7 @@ function DeleteConfirmation({
   onDelete,
 }) {
   return (
-    <ModalDialog title={title} isOpen={isOpen} hasCloseButton={false} onClose={onClose}>
+    <ModalDialog title={title} isOpen={isOpen} hasCloseButton={false} onClose={onClose} zIndex={5000}>
       <ModalDialog.Header>
         <ModalDialog.Title>
           {title}

--- a/src/index.scss
+++ b/src/index.scss
@@ -118,7 +118,7 @@ $fa-font-path: "~font-awesome/fonts";
 
 header {
   .user-dropdown {
-    z-index: 10000;
+    z-index: 2005;
   }
   .logo {
     margin-right: 1rem;
@@ -227,7 +227,7 @@ header {
 
 .header-action-bar {
   background-color: #fff;
-  z-index: 9999;
+  z-index: 2002;
   box-shadow: 0px 2px 4px rgb(0 0 0 / 15%), 0px 2px 8px rgb(0 0 0 / 15%);
   position: sticky;
   top: 0;
@@ -240,3 +240,8 @@ header {
 .discussion-topic-group:last-of-type .divider{
   display: none;
 }
+
+.zindex-5000{
+ z-index: 5000;
+}
+


### PR DESCRIPTION
### [INF-646](https://2u-internal.atlassian.net/browse/INF-646)

- On Delete  only confirmation pop-up highlights

**Before Fix:**

![before](https://user-images.githubusercontent.com/73840786/197700217-635d5e84-28ef-48be-9e23-572505f907d2.png)


**After Fix:**
<img width="1678" alt="Screenshot 2022-10-25 at 11 20 28 AM" src="https://user-images.githubusercontent.com/73840786/197700883-cd8cb366-e361-4454-9c72-8b3a4df25172.png">


<img width="1678" alt="Screenshot 2022-10-25 at 11 20 14 AM" src="https://user-images.githubusercontent.com/73840786/197700255-fb89faa2-7b21-4263-aff2-35ae79e69c4e.png">


https://user-images.githubusercontent.com/73840786/198048188-58c9443f-be0a-4782-b7fb-76db420c5490.mp4




