### PR TITLE
fix: more formats for mathjax support added

### DIFF
--- a/src/components/HTMLLoader.jsx
+++ b/src/components/HTMLLoader.jsx
@@ -11,12 +11,15 @@ const baseConfig = {
       ['\\\\(', '\\\\)'],
       ['\\(', '\\)'],
       ['[mathjaxinline]', '[/mathjaxinline]'],
+      ['\\begin{math}', '\\end{math}'],
     ],
     displayMath: [
       ['[mathjax]', '[/mathjax]'],
       ['$$', '$$'],
       ['\\\\[', '\\\\]'],
       ['\\[', '\\]'],
+      ['\\begin{displaymath}', '\\end{displaymath}'],
+      ['\\begin{equation}', '\\end{equation}'],
     ],
   },
 
@@ -27,6 +30,9 @@ function HTMLLoader({ htmlNode, componentId, cssClassName }) {
   const isLatex = htmlNode.match(/(\${1,2})((?:\\.|.)*)\1/)
                   || htmlNode.match(/(\[mathjax](.+?)\[\/mathjax])+/)
                   || htmlNode.match(/(\[mathjaxinline](.+?)\[\/mathjaxinline])+/)
+                  || htmlNode.match(/(\\begin\{math}(.+?)\\end\{math})+/)
+                  || htmlNode.match(/(\\begin\{displaymath}(.+?)\\end\{displaymath})+/)
+                  || htmlNode.match(/(\\begin\{equation}(.+?)\\end\{equation})+/)
                   || htmlNode.match(/(\\\[(.+?)\\\])+/)
                   || htmlNode.match(/(\\\((.+?)\\\))+/);
 

--- a/src/discussions/posts/post-editor/messages.js
+++ b/src/discussions/posts/post-editor/messages.js
@@ -116,6 +116,11 @@ const messages = defineMessages({
     defaultMessage: 'Show Preview',
     description: 'show preview button text to allow user to see their post content.',
   },
+  actionsAlt: {
+    id: 'discussions.actions.label',
+    defaultMessage: 'Actions menu',
+    description: 'Button to see actions for a post or comment',
+  },
 });
 
 export default messages;

--- a/src/discussions/topics/data/selectors.js
+++ b/src/discussions/topics/data/selectors.js
@@ -34,7 +34,7 @@ export const selectCoursewareTopics = createSelector(
       : sequences.map(sequence => ({
         id: sequence.id,
         name: sequence.displayName,
-        topics: sequence.topics.map(topicId => ({ id: topicId, name: topics[topicId].name })),
+        topics: sequence.topics.map(topicId => ({ id: topicId, name: topics[topicId]?.name || 'unnamed' })),
       }))
   ),
 );


### PR DESCRIPTION
- this Pr is fixing 3 issues
- console errors are coming due to missing objects in translation files. - fixed
- unnamed topics are crashing FE on visiting the topics tab and while trying to click the add post button.
- lastly, the mathjax syntax support is extended in MFE. by adding 3 new formats in config list

<img width="675" alt="Screen Shot 2022-10-25 at 11 15 58 PM" src="https://user-images.githubusercontent.com/67791278/197850587-e7545388-e4c3-4979-804f-11a1e48c02cc.png">
