### PR TITLE
Topic information moved next to username

### DIFF
--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -5,14 +5,12 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { Hyperlink, useToggle } from '@edx/paragon';
+import { useToggle } from '@edx/paragon';
 
 import HTMLLoader from '../../../components/HTMLLoader';
 import { ContentActions } from '../../../data/constants';
-import { selectorForUnitSubsection, selectTopicContext } from '../../../data/selectors';
 import { AlertBanner, DeleteConfirmation } from '../../common';
 import { selectModerationSettings } from '../../data/selectors';
-import { selectTopic } from '../../topics/data/selectors';
 import { removeThread, updateExistingThread } from '../data/thunks';
 import ClosePostReasonModal from './ClosePostReasonModal';
 import messages from './messages';
@@ -29,9 +27,7 @@ function Post({
   const history = useHistory();
   const dispatch = useDispatch();
   const { courseId } = useSelector((state) => state.courseTabs);
-  const topic = useSelector(selectTopic(post.topicId));
-  const getTopicSubsection = useSelector(selectorForUnitSubsection);
-  const topicContext = useSelector(selectTopicContext(post.topicId));
+
   const { reasonCodesEnabled } = useSelector(selectModerationSettings);
   const [isDeleting, showDeleteConfirmation, hideDeleteConfirmation] = useToggle(false);
   const [isClosing, showClosePostModal, hideClosePostModal] = useToggle(false);
@@ -55,10 +51,6 @@ function Post({
     [ContentActions.REPORT]: () => dispatch(updateExistingThread(post.id, { flagged: !post.abuseFlagged })),
   };
 
-  const getTopicCategoryName = topicData => (
-    topicData.usageKey ? getTopicSubsection(topicData.usageKey)?.displayName : topicData.categoryId
-  );
-
   return (
     <div className="d-flex flex-column w-100 mw-100" data-testid={`post-${post.id}`}>
       <DeleteConfirmation
@@ -77,17 +69,7 @@ function Post({
       <div className="d-flex mt-4 mb-2 text-break font-style-normal text-primary-500">
         <HTMLLoader htmlNode={post.renderedBody} id="post" />
       </div>
-      {topicContext && topic && (
-        <div className="border px-3 rounded mb-4 border-light-400 align-self-start py-2.5">
-          <span className="text-gray-500">{intl.formatMessage(messages.relatedTo)}{' '}</span>
-          <Hyperlink
-            destination={topicContext.unitLink}
-            target="_top"
-          >
-            {`${getTopicCategoryName(topic)} / ${topic.name}`}
-          </Hyperlink>
-        </div>
-      )}
+
       <div className="mb-3">
         <PostFooter post={post} preview={preview} />
       </div>

--- a/src/discussions/posts/post/PostHeader.jsx
+++ b/src/discussions/posts/post/PostHeader.jsx
@@ -95,7 +95,6 @@ function PostHeader({
   const showAnsweredBadge = preview && post.hasEndorsed && post.type === ThreadType.QUESTION;
   const authorLabelColor = AvatarOutlineAndLabelColors[post.authorLabel];
   const hasAnyAlert = useAlertBannerVisible(post);
-
   const topic = useSelector(selectTopic(post.topicId));
   const topicContext = useSelector(selectTopicContext(post.topicId));
   const getTopicSubsection = useSelector(selectorForUnitSubsection);
@@ -130,14 +129,17 @@ function PostHeader({
               linkToProfile
             />
             {topicContext && topic && (
-            <div className="mr-3 font-size-14 font-style-normal font-family-inter font-weight-500">
-              <span className="text-gray-500">{intl.formatMessage(messages.relatedTo)}{' '}</span>
+            <div className="mr-3 font-size-14 font-style-normal font-family-inter font-weight-400 d-flex">
+              <span className="text-gray-400">{`${intl.formatMessage(messages.relatedTo)} `}</span>
               <Hyperlink
                 destination={topicContext.unitLink}
                 target="_top"
               >
-                {`${getTopicCategoryName(topic)} / ${topic.name}`}
-
+                <div className="mw-md ml-1 d-flex flex-row">
+                  <span className="container-mw-md text-truncate">{getTopicCategoryName(topic)}</span>
+                  <span className="mx-1">/</span>
+                  <span className="container-mw-md text-truncate">{topic.name}</span>
+                </div>
               </Hyperlink>
             </div>
             )}

--- a/src/discussions/posts/post/PostHeader.jsx
+++ b/src/discussions/posts/post/PostHeader.jsx
@@ -5,12 +5,16 @@ import classNames from 'classnames';
 import { useSelector } from 'react-redux';
 
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { Avatar, Badge, Icon } from '@edx/paragon';
+import {
+  Avatar, Badge, Hyperlink, Icon,
+} from '@edx/paragon';
 
 import { Issue, Question } from '../../../components/icons';
 import { AvatarOutlineAndLabelColors, ThreadType } from '../../../data/constants';
+import { selectorForUnitSubsection, selectTopicContext } from '../../../data/selectors';
 import { ActionsDropdown, AuthorLabel } from '../../common';
 import { useAlertBannerVisible } from '../../data/hooks';
+import { selectTopic } from '../../topics/data/selectors';
 import { selectAuthorAvatars } from '../data/selectors';
 import messages from './messages';
 import { postShape } from './proptypes';
@@ -92,6 +96,14 @@ function PostHeader({
   const authorLabelColor = AvatarOutlineAndLabelColors[post.authorLabel];
   const hasAnyAlert = useAlertBannerVisible(post);
 
+  const topic = useSelector(selectTopic(post.topicId));
+  const topicContext = useSelector(selectTopicContext(post.topicId));
+  const getTopicSubsection = useSelector(selectorForUnitSubsection);
+
+  const getTopicCategoryName = topicData => (
+    topicData.usageKey ? getTopicSubsection(topicData.usageKey)?.displayName : topicData.categoryId
+  );
+
   return (
     <div className={classNames('d-flex flex-fill mw-100', { 'mt-2': hasAnyAlert && !preview })}>
       <div className="flex-shrink-0">
@@ -110,12 +122,26 @@ function PostHeader({
               </div>
             )
             : <h4 className="mb-0" style={{ lineHeight: '28px' }} aria-level="1" tabIndex="-1" accessKey="h">{post.title}</h4>}
-          <AuthorLabel
-            author={post.author || intl.formatMessage(messages.anonymous)}
-            authorLabel={post.authorLabel}
-            labelColor={authorLabelColor && `text-${authorLabelColor}`}
-            linkToProfile
-          />
+          <div className="align-items-center d-flex flex-row">
+            <AuthorLabel
+              author={post.author || intl.formatMessage(messages.anonymous)}
+              authorLabel={post.authorLabel}
+              labelColor={authorLabelColor && `text-${authorLabelColor}`}
+              linkToProfile
+            />
+            {topicContext && topic && (
+            <div className="mr-3 font-size-14 font-style-normal font-family-inter font-weight-500">
+              <span className="text-gray-500">{intl.formatMessage(messages.relatedTo)}{' '}</span>
+              <Hyperlink
+                destination={topicContext.unitLink}
+                target="_top"
+              >
+                {`${getTopicCategoryName(topic)} / ${topic.name}`}
+
+              </Hyperlink>
+            </div>
+            )}
+          </div>
         </div>
       </div>
       {!preview

--- a/src/discussions/posts/post/messages.js
+++ b/src/discussions/posts/post/messages.js
@@ -60,7 +60,7 @@ const messages = defineMessages({
   },
   relatedTo: {
     id: 'discussions.post.relatedTo',
-    defaultMessage: 'Related to',
+    defaultMessage: 'in',
     description: 'Message followed the category and topic of post linking to in-course context',
   },
   deletePostTitle: {


### PR DESCRIPTION
### [INF-528](https://2u-internal.atlassian.net/browse/INF-528)

> Topic info moved next to the username, for posts in content-specific discussion topics
> Long topic names are truncated appropriately.

**Before Fix:**
![Unknown](https://user-images.githubusercontent.com/73840786/199215328-30a1ae29-6bf2-43a2-a750-a45641057e0a.png)


**After Fix:**


<img width="1192" alt="Screenshot 2022-11-10 at 5 15 33 PM" src="https://user-images.githubusercontent.com/73840786/201089250-7d021cec-01d2-425b-816a-649c87ec4422.png">



