### PR TITLE
feat: added warning for images with large dimensions

### DIFF
--- a/src/discussions/messages.js
+++ b/src/discussions/messages.js
@@ -193,6 +193,21 @@ const messages = defineMessages({
     defaultMessage: 'Blackout dates are currently active. Posting in discussions is unavailable at this time.',
     description: 'Informative text when discussions blackout is active',
   },
+  imageWarningMessage: {
+    id: 'discussions.editor.image.warning.message',
+    defaultMessage: 'Images having width or height greater than 999px will not be visible when the post, response or comment is viewed using in-line course discussions',
+    description: 'Modal message to tell image dimensions compatibility issue with legacy',
+  },
+  imageWarningModalTitle: {
+    id: 'discussions.editor.image.warning.title',
+    defaultMessage: 'Warning!',
+    description: 'Modal message title',
+  },
+  imageWarningDismissButton: {
+    id: 'discussions.editor.image.warning.dismiss',
+    defaultMessage: 'Ok',
+    description: 'Modal dismiss button text',
+  },
 });
 
 export default messages;

--- a/src/index.scss
+++ b/src/index.scss
@@ -241,7 +241,10 @@ header {
   display: none;
 }
 
-.zindex-5000{
+.zindex-5000 {
  z-index: 5000;
 }
 
+#paragon-portal-root .pgn__modal-layer {
+  z-index: 1500 !important;
+}


### PR DESCRIPTION
- images with dimensions greater than 999px are not rendering old discussion experience, a heads-up message is added in case the user uploads such an image to suggest updating the image dimensions to avoid inconvenience for users on legacy experience.

![Uploading Screen Shot 2022-11-02 at 8.02.10 PM.png…]()
