### PR TITLE
fix: unnamed category and subcategory strings added

### DIFF
--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -286,13 +286,17 @@ function PostEditor({
                 floatingLabel={intl.formatMessage(messages.topicArea)}
               >
                 {nonCoursewareTopics.map(topic => (
-                  <option key={topic.id} value={topic.id}>{topic.name}</option>
+                  <option
+                    key={topic.id}
+                    value={topic.id}
+                  >{topic.name || intl.formatMessage(messages.unnamedSubTopics)}
+                  </option>
                 ))}
                 {coursewareTopics.map(category => (
-                  <optgroup label={category.name} key={category.id}>
+                  <optgroup label={category.name || intl.formatMessage(messages.unnamedTopics)} key={category.id}>
                     {category.topics.map(subtopic => (
                       <option key={subtopic.id} value={subtopic.id}>
-                        {subtopic.name}
+                        {subtopic.name || intl.formatMessage(messages.unnamedSubTopics)}
                       </option>
                     ))}
                   </optgroup>

--- a/src/discussions/posts/post-editor/messages.js
+++ b/src/discussions/posts/post-editor/messages.js
@@ -121,6 +121,16 @@ const messages = defineMessages({
     defaultMessage: 'Actions menu',
     description: 'Button to see actions for a post or comment',
   },
+  unnamedTopics: {
+    id: 'discussions.topic.noName.label',
+    defaultMessage: 'Unnamed category',
+    description: 'display string for topics with missing names',
+  },
+  unnamedSubTopics: {
+    id: 'discussions.subtopic.noName.label',
+    defaultMessage: 'Unnamed subcategory',
+    description: 'display string for topics with missing names',
+  },
 });
 
 export default messages;

--- a/src/discussions/topics/messages.js
+++ b/src/discussions/topics/messages.js
@@ -61,7 +61,12 @@ const messages = defineMessages({
   },
   unnamedTopicCategories: {
     id: 'discussions.topics.unnamed.label',
-    defaultMessage: 'Unnamed Topic',
+    defaultMessage: 'Unnamed category',
+    description: 'Text to display in place of topic name if topic name is empty',
+  },
+  unnamedTopicSubCategories: {
+    id: 'discussions.subtopics.unnamed.label',
+    defaultMessage: 'Unnamed subcategory',
     description: 'Text to display in place of topic name if topic name is empty',
   },
 });

--- a/src/discussions/topics/topic-group/topic/Topic.jsx
+++ b/src/discussions/topics/topic-group/topic/Topic.jsx
@@ -51,7 +51,7 @@ function Topic({
         <div className="d-flex flex-column flex-fill" style={{ minWidth: 0 }}>
           <div className="d-flex flex-column justify-content-start mw-100 flex-fill">
             <div className="topic-name text-truncate">
-              {topic.name}
+              {topic.name || intl.formatMessage(messages.unnamedTopicSubCategories)}
             </div>
           </div>
           <div className="d-flex align-items-center mt-2.5" style={{ marginBottom: '2px' }}>


### PR DESCRIPTION
INF ticket: https://2u-internal.atlassian.net/browse/INF-629

unnamed categories and subcategories will not be shown as empty place holders and instead will have a string place holders for improving user readability

<img width="1607" alt="Screen Shot 2022-11-10 at 10 46 36 PM" src="https://user-images.githubusercontent.com/67791278/201169017-7e865b35-9e8a-458a-83c8-418be110ce39.png">
