### PR TITLE
 Removed extra space besides authorLabel

### DIFF
--- a/src/discussions/common/AuthorLabel.jsx
+++ b/src/discussions/common/AuthorLabel.jsx
@@ -65,7 +65,7 @@ function AuthorLabel({
       )}
       {authorLabelMessage && (
         <span
-          className={classNames('mr-3 font-size-14 font-style-normal font-family-inter font-weight-500', {
+          className={classNames('mr-1 font-size-14 font-style-normal font-family-inter font-weight-500', {
             'text-primary-500': !authorLabelMessage,
           })}
           style={{ marginLeft: '2px' }}


### PR DESCRIPTION
[INF-528](https://2u-internal.atlassian.net/browse/INF-528)

-  Removed extra space besides authorLabel

**Before fix**
<img width="733" alt="Screenshot 2022-11-14 at 6 12 17 PM" src="https://user-images.githubusercontent.com/73840786/201894314-16619baa-bc3a-4ceb-8abd-886275464601.png">

**After fix**
<img width="1169" alt="Screenshot 2022-11-15 at 3 10 42 PM" src="https://user-images.githubusercontent.com/73840786/201894332-35e6f129-2d14-44ec-9e69-0c927d2c2a1f.png">
