### PR TITLE
style: design changes for post summary card

### DIFF
--- a/src/discussions/posts/post/PostFooter.jsx
+++ b/src/discussions/posts/post/PostFooter.jsx
@@ -93,14 +93,14 @@ function PostFooter({
               </span>
             </OverlayTrigger>
             <span
-              className="text-light-700 mx-1.5 font-weight-500"
+              className="text-gray-700 mx-1.5 font-weight-500"
               style={{ fontSize: '16px' }}
             >
               ·
             </span>
           </>
         )}
-        <span title={post.createdAt} className="text-gray-500">
+        <span title={post.createdAt} className="text-gray-700">
           {timeago.format(post.createdAt, 'time-locale')}
         </span>
         {!preview && post.closed

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Badge, Icon } from '@edx/paragon';
+import { CheckCircle } from '@edx/paragon/icons';
 
 import { PushPin } from '../../../components/icons';
 import { AvatarOutlineAndLabelColors, Routes, ThreadType } from '../../../data/constants';
@@ -54,7 +55,7 @@ function PostLink({
         }
         to={linkUrl}
         onClick={() => isSelected(post.id)}
-        style={{ lineHeight: '21px' }}
+        style={{ lineHeight: '22px' }}
         aria-current={isSelected(post.id) ? 'page' : undefined}
         role="option"
         tabIndex={(isSelected(post.id) || idx === 0) ? 0 : -1}
@@ -82,11 +83,19 @@ function PostLink({
                   {post.title}
                 </div>
 
+                <div
+                  className="text-truncate text-gray-700 font-weight-normal font-size-14 font-style-normal font-family-inter mx-1.5"
+                  style={{ maxHeight: '1.5rem' }}
+                >
+                  {isPostPreviewAvailable(post.previewBody)
+                    ? post.previewBody
+                    : intl.formatMessage(messages.postWithoutPreview)}
+                </div>
+
                 {showAnsweredBadge && (
-                <Badge variant="success" className="font-weight-500 ml-auto badge-padding">
-                  {intl.formatMessage(messages.answered)}
-                  <span className="sr-only">{' '}answered</span>
-                </Badge>
+                  <Icon src={CheckCircle} className="text-success font-weight-500 ml-auto badge-padding" data-testid="check-icon">
+                    <span className="sr-only">{' '}answered</span>
+                  </Icon>
                 )}
 
                 {canSeeReportedBadge && (
@@ -113,17 +122,7 @@ function PostLink({
               authorLabel={post.authorLabel}
               labelColor={authorLabelColor && `text-${authorLabelColor}`}
             />
-            <div
-              className="text-truncate text-primary-500 font-weight-normal font-size-14 font-style-normal font-family-inter"
-              style={{ maxHeight: '1.5rem' }}
-            >
-              {isPostPreviewAvailable(post.previewBody)
-                ? post.previewBody
-                : intl.formatMessage(messages.postWithoutPreview)}
-            </div>
-            <div className="mt-1">
-              <PostFooter post={post} preview intl={intl} showNewCountLabel={read} />
-            </div>
+            <PostFooter post={post} preview intl={intl} showNewCountLabel={read} />
           </div>
         </div>
         {!showDivider && post.pinned && <div className="pt-1 bg-light-500 border-top border-light-700" />}


### PR DESCRIPTION
Related Ticket: https://2u-internal.atlassian.net/browse/INF-634

Figma: https://www.figma.com/file/LVFnO9oRHYiamoicZuXDAC/Discussions?node-id=7024%3A307217&t=7aAuK3OFCcZNOo6i-0

Before:
<img width="486" alt="Screen Shot 2022-11-16 at 6 45 01 PM" src="https://user-images.githubusercontent.com/67791278/202196825-112de473-7efd-4b02-9d27-e9bac0425d78.png">
After:
<img width="484" alt="Screen Shot 2022-11-16 at 6 46 01 PM" src="https://user-images.githubusercontent.com/67791278/202197064-5a06abc0-30bf-452c-ab97-1cdd196745b0.png">

<img width="465" alt="Screen Shot 2022-11-16 at 6 47 21 PM" src="https://user-images.githubusercontent.com/67791278/202197338-bbe90793-4feb-4123-b590-5e5e5b3f1bb9.png">
