### PR TITLE
fix: incontext modal alignment changes

### DIFF
--- a/src/discussions/common/ActionsDropdown.jsx
+++ b/src/discussions/common/ActionsDropdown.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { useSelector } from 'react-redux';
@@ -16,6 +16,7 @@ import { selectBlackoutDate } from '../data/selectors';
 import messages from '../messages';
 import { postShape } from '../posts/post/proptypes';
 import { inBlackoutDateRange, useActions } from '../utils';
+import { DiscussionContext } from './context';
 
 function ActionsDropdown({
   intl,
@@ -26,6 +27,7 @@ function ActionsDropdown({
   const [isOpen, open, close] = useToggle(false);
   const [target, setTarget] = useState(null);
   const actions = useActions(commentOrPost);
+  const { inContext } = useContext(DiscussionContext);
   const handleActions = (action) => {
     const actionFunction = actionHandlers[action];
     if (actionFunction) {
@@ -54,7 +56,7 @@ function ActionsDropdown({
         onClose={close}
         positionRef={target}
         isOpen={isOpen}
-        placement="auto-start"
+        placement={inContext ? 'left' : 'auto-start'}
       >
         <div
           className="bg-white p-1 shadow d-flex flex-column"

--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -105,7 +105,7 @@ function PostEditor({
   const { allowAnonymous, allowAnonymousToPeers } = useSelector(selectAnonymousPostingConfig);
   const { reasonCodesEnabled, editReasons } = useSelector(selectModerationSettings);
   const userIsStaff = useSelector(selectUserIsStaff);
-  const { category } = useContext(DiscussionContext);
+  const { category, inContext } = useContext(DiscussionContext);
 
   const canDisplayEditReason = (reasonCodesEnabled && editExisting
     && (userHasModerationPrivileges || userIsGroupTa || userIsStaff)
@@ -286,6 +286,7 @@ function PostEditor({
                 onBlur={handleBlur}
                 aria-describedby="topicAreaInput"
                 floatingLabel={intl.formatMessage(messages.topicArea)}
+                disabled={inContext}
               >
                 {nonCoursewareTopics.map(topic => (
                   <option

--- a/src/discussions/posts/post/ClosePostReasonModal.jsx
+++ b/src/discussions/posts/post/ClosePostReasonModal.jsx
@@ -50,8 +50,7 @@ function ClosePostReasonModal({
       isOpen={isOpen}
       onClose={onCancel}
       hasCloseButton={false}
-      isFullscreenOnMobile
-      isFullscreenScroll
+      zIndex={5000}
     >
       <ModalDialog.Header>
         <ModalDialog.Title>

--- a/src/index.scss
+++ b/src/index.scss
@@ -251,6 +251,6 @@ header {
 
 @media only screen and (max-width: 767px) {
   body:not(.tox-force-desktop) .tox .tox-dialog {
-    align-self: flex-end;
+    align-self: center;
   }
 }


### PR DESCRIPTION
### [INF-480](https://2u-internal.atlassian.net/browse/INF-480)

- Display the action menu dropdown on the left side in the in-context sidebar
- Display the image upload modal in the screen center on the post-creation/edit
- Display close reason modal as mobile size in the in-context sidebar 
- Disable topic select dropdown when use is in-context sidebar. It can only create/edit a post related to the opened topic. 

### Before
https://www.loom.com/share/06b3e7c044934fd7aeb09c6112a99819

### After
https://www.loom.com/share/47c4794ef83a45eb86029e6720360f63