### PR TITLE
fix: count_flagged param sent only for Privilege users

### DIFF
--- a/src/discussions/learners/LearnerPostsView.jsx
+++ b/src/discussions/learners/LearnerPostsView.jsx
@@ -50,7 +50,7 @@ function LearnerPostsView({ intl }) {
       page: pageNum,
       filters: postFilter,
       orderBy: postFilter.orderBy,
-      countFlagged: userHasModerationPrivileges || userIsStaff,
+      countFlagged: (userHasModerationPrivileges || userIsStaff) || undefined,
     };
 
     dispatch(fetchUserPosts(courseId, params));

--- a/src/discussions/posts/PostsList.jsx
+++ b/src/discussions/posts/PostsList.jsx
@@ -44,7 +44,7 @@ function PostsList({ posts, topics, intl }) {
       filters,
       page: pageNum,
       author: showOwnPosts ? authenticatedUser.username : null,
-      countFlagged: userHasModerationPrivileges || userIsStaff,
+      countFlagged: (userHasModerationPrivileges || userIsStaff) || undefined,
       topicIds,
     };
 


### PR DESCRIPTION
### Hot Fix - breaking learner API for nonprivileged users

- count_flagged param sent as true only for Privilege users in learner API
- count_flagged is not required for nonprivileged users in learner API

### Before
**Privilege user**
<img width="1424" alt="Screenshot 2022-11-24 at 1 23 39 PM" src="https://user-images.githubusercontent.com/79941147/203747058-106973a6-2e88-40b8-b1c5-b3624ae9e2e0.png">

**nonprivileged users**
<img width="1438" alt="Screenshot 2022-11-24 at 2 26 19 PM" src="https://user-images.githubusercontent.com/79941147/203747147-88509c9d-7b7e-4a6e-ac9f-f3383c6a65b4.png">


### After
**Privilege user**
<img width="1440" alt="Screenshot 2022-11-24 at 2 16 58 PM" src="https://user-images.githubusercontent.com/79941147/203746465-94a3896f-f3ce-4daf-9d4c-14974de34eea.png">
**nonprivileged users**
<img width="1440" alt="Screenshot 2022-11-24 at 2 17 18 PM" src="https://user-images.githubusercontent.com/79941147/203746489-4686f9fb-ba2c-45a6-a8ca-3f6ba255a44c.png">
