### PR TITLE
fix: add a post/response/comment during active blackout dates fixed for all roles

### DIFF
--- a/src/discussions/comments/comment/Comment.jsx
+++ b/src/discussions/comments/comment/Comment.jsx
@@ -10,12 +10,10 @@ import { Button, useToggle } from '@edx/paragon';
 import HTMLLoader from '../../../components/HTMLLoader';
 import { ContentActions } from '../../../data/constants';
 import { AlertBanner, DeleteConfirmation, EndorsedAlertBanner } from '../../common';
-import {
-  selectBlackoutDate, selectIsCourseAdmin,
-  selectIsCourseStaff, selectUserHasModerationPrivileges, selectUserIsGroupTa, selectUserIsStaff,
-} from '../../data/selectors';
+import { useUserPrivilage } from '../../data/hooks';
+import { selectBlackoutDate } from '../../data/selectors';
 import { fetchThread } from '../../posts/data/thunks';
-import { handleAddPostForRoles, inBlackoutDateRange } from '../../utils';
+import { inBlackoutDateRange } from '../../utils';
 import CommentIcons from '../comment-icons/CommentIcons';
 import { selectCommentCurrentPage, selectCommentHasMorePages, selectCommentResponses } from '../data/selectors';
 import { editComment, fetchCommentResponses, removeComment } from '../data/thunks';
@@ -42,14 +40,7 @@ function Comment({
   const hasMorePages = useSelector(selectCommentHasMorePages(comment.id));
   const currentPage = useSelector(selectCommentCurrentPage(comment.id));
   const blackoutDateRange = useSelector(selectBlackoutDate);
-  const isUserAdmin = useSelector(selectUserIsStaff);
-  const userHasModerationPrivilages = useSelector(selectUserHasModerationPrivileges);
-  const isUserGroupTA = useSelector(selectUserIsGroupTa);
-  const isCourseAdmin = useSelector(selectIsCourseAdmin);
-  const isCourseStaff = useSelector(selectIsCourseStaff);
-
-  const hasPrivilege = handleAddPostForRoles(isUserAdmin, userHasModerationPrivilages,
-    isUserGroupTA, isCourseAdmin, isCourseStaff);
+  const hasPrivilege = useUserPrivilage();
 
   const handleAddComment = () => {
     if ((!(inBlackoutDateRange(blackoutDateRange)))) {

--- a/src/discussions/comments/comment/Comment.jsx
+++ b/src/discussions/comments/comment/Comment.jsx
@@ -10,10 +10,8 @@ import { Button, useToggle } from '@edx/paragon';
 import HTMLLoader from '../../../components/HTMLLoader';
 import { ContentActions } from '../../../data/constants';
 import { AlertBanner, DeleteConfirmation, EndorsedAlertBanner } from '../../common';
-import { useUserPrivilage } from '../../data/hooks';
-import { selectBlackoutDate } from '../../data/selectors';
+import { useUserCanAddThreadInBlackoutDate } from '../../data/hooks';
 import { fetchThread } from '../../posts/data/thunks';
-import { inBlackoutDateRange } from '../../utils';
 import CommentIcons from '../comment-icons/CommentIcons';
 import { selectCommentCurrentPage, selectCommentHasMorePages, selectCommentResponses } from '../data/selectors';
 import { editComment, fetchCommentResponses, removeComment } from '../data/thunks';
@@ -39,18 +37,7 @@ function Comment({
   const [isReplying, setReplying] = useState(false);
   const hasMorePages = useSelector(selectCommentHasMorePages(comment.id));
   const currentPage = useSelector(selectCommentCurrentPage(comment.id));
-  const blackoutDateRange = useSelector(selectBlackoutDate);
-  const hasPrivilege = useUserPrivilage();
-
-  const handleAddComment = () => {
-    if ((!(inBlackoutDateRange(blackoutDateRange)))) {
-      return true;
-    }
-    if (hasPrivilege) {
-      return true;
-    }
-    return false;
-  };
+  const userCanAddThreadInBlackoutDate = useUserCanAddThreadInBlackoutDate();
 
   useEffect(() => {
     // If the comment has a parent comment, it won't have any children, so don't fetch them.
@@ -139,18 +126,18 @@ function Comment({
               />
             ) : (
               <>
-                {(!isClosedPost && handleAddComment())
+                {!isClosedPost && userCanAddThreadInBlackoutDate
                   && (
-                    <Button
-                      className="d-flex flex-grow mt-3 py-2 font-size-14"
-                      variant="outline-primary"
-                      style={{
-                        lineHeight: '20px',
-                      }}
-                      onClick={() => setReplying(true)}
-                    >
-                      {intl.formatMessage(messages.addComment)}
-                    </Button>
+                  <Button
+                    className="d-flex flex-grow mt-3 py-2 font-size-14"
+                    variant="outline-primary"
+                    style={{
+                      lineHeight: '20px',
+                    }}
+                    onClick={() => setReplying(true)}
+                  >
+                    {intl.formatMessage(messages.addComment)}
+                  </Button>
                   )}
               </>
 

--- a/src/discussions/comments/comment/ResponseEditor.jsx
+++ b/src/discussions/comments/comment/ResponseEditor.jsx
@@ -8,11 +8,9 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Button } from '@edx/paragon';
 
 import { DiscussionContext } from '../../common/context';
-import {
-  selectBlackoutDate, selectIsCourseAdmin,
-  selectIsCourseStaff, selectUserHasModerationPrivileges, selectUserIsGroupTa, selectUserIsStaff,
-} from '../../data/selectors';
-import { handleAddPostForRoles, inBlackoutDateRange } from '../../utils';
+import { useUserPrivilage } from '../../data/hooks';
+import { selectBlackoutDate } from '../../data/selectors';
+import { inBlackoutDateRange } from '../../utils';
 import messages from '../messages';
 import CommentEditor from './CommentEditor';
 
@@ -24,18 +22,11 @@ function ResponseEditor({
   const { inContext } = useContext(DiscussionContext);
   const [addingResponse, setAddingResponse] = useState(false);
   const blackoutDateRange = useSelector(selectBlackoutDate);
-  const isUserAdmin = useSelector(selectUserIsStaff);
-  const userHasModerationPrivilages = useSelector(selectUserHasModerationPrivileges);
-  const isUserGroupTA = useSelector(selectUserIsGroupTa);
-  const isCourseAdmin = useSelector(selectIsCourseAdmin);
-  const isCourseStaff = useSelector(selectIsCourseStaff);
+  const hasPrivilege = useUserPrivilage();
 
   useEffect(() => {
     setAddingResponse(false);
   }, [postId]);
-
-  const hasPrivilege = handleAddPostForRoles(isUserAdmin, userHasModerationPrivilages,
-    isUserGroupTA, isCourseAdmin, isCourseStaff);
 
   const handleAddResponse = () => {
     if ((!(inBlackoutDateRange(blackoutDateRange)))) {

--- a/src/discussions/comments/comment/ResponseEditor.jsx
+++ b/src/discussions/comments/comment/ResponseEditor.jsx
@@ -2,15 +2,12 @@ import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import classNames from 'classnames';
-import { useSelector } from 'react-redux';
 
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Button } from '@edx/paragon';
 
 import { DiscussionContext } from '../../common/context';
-import { useUserPrivilage } from '../../data/hooks';
-import { selectBlackoutDate } from '../../data/selectors';
-import { inBlackoutDateRange } from '../../utils';
+import { useUserCanAddThreadInBlackoutDate } from '../../data/hooks';
 import messages from '../messages';
 import CommentEditor from './CommentEditor';
 
@@ -21,22 +18,11 @@ function ResponseEditor({
 }) {
   const { inContext } = useContext(DiscussionContext);
   const [addingResponse, setAddingResponse] = useState(false);
-  const blackoutDateRange = useSelector(selectBlackoutDate);
-  const hasPrivilege = useUserPrivilage();
+  const userCanAddThreadInBlackoutDate = useUserCanAddThreadInBlackoutDate();
 
   useEffect(() => {
     setAddingResponse(false);
   }, [postId]);
-
-  const handleAddResponse = () => {
-    if ((!(inBlackoutDateRange(blackoutDateRange)))) {
-      return true;
-    }
-    if (hasPrivilege) {
-      return true;
-    }
-    return false;
-  };
 
   return addingResponse
     ? (
@@ -48,7 +34,7 @@ function ResponseEditor({
         />
       </div>
     )
-    : handleAddResponse() && (
+    : userCanAddThreadInBlackoutDate && (
       <div className={classNames({ 'mb-4': addWrappingDiv }, 'actions d-flex')}>
         <Button
           variant="primary"

--- a/src/discussions/data/hooks.js
+++ b/src/discussions/data/hooks.js
@@ -17,13 +17,17 @@ import { DiscussionContext } from '../common/context';
 import { clearRedirect } from '../posts/data';
 import { selectTopics } from '../topics/data/selectors';
 import { fetchCourseTopics } from '../topics/data/thunks';
-import { discussionsPath } from '../utils';
+import { discussionsPath, handleAddPostForRoles } from '../utils';
 import {
-  selectAreThreadsFiltered, selectLearnersTabEnabled,
+  selectAreThreadsFiltered,
+  selectIsCourseAdmin,
+  selectIsCourseStaff,
+  selectLearnersTabEnabled,
   selectModerationSettings,
   selectPostThreadCount,
   selectUserHasModerationPrivileges,
   selectUserIsGroupTa,
+  selectUserIsStaff,
 } from './selectors';
 import { fetchCourseConfig } from './thunks';
 
@@ -173,4 +177,17 @@ export const useCurrentDiscussionTopic = () => {
     return topics[0];
   }
   return null;
+};
+
+export const useUserPrivilage = () => {
+  const isUserAdmin = useSelector(selectUserIsStaff);
+  const userHasModerationPrivilages = useSelector(selectUserHasModerationPrivileges);
+  const isUserGroupTA = useSelector(selectUserIsGroupTa);
+  const isCourseAdmin = useSelector(selectIsCourseAdmin);
+  const isCourseStaff = useSelector(selectIsCourseStaff);
+
+  return (
+    handleAddPostForRoles(isUserAdmin, userHasModerationPrivilages,
+      isUserGroupTA, isCourseAdmin, isCourseStaff)
+  );
 };

--- a/src/discussions/data/hooks.js
+++ b/src/discussions/data/hooks.js
@@ -17,9 +17,10 @@ import { DiscussionContext } from '../common/context';
 import { clearRedirect } from '../posts/data';
 import { selectTopics } from '../topics/data/selectors';
 import { fetchCourseTopics } from '../topics/data/thunks';
-import { discussionsPath, handleAddPostForRoles } from '../utils';
+import { discussionsPath, inBlackoutDateRange } from '../utils';
 import {
   selectAreThreadsFiltered,
+  selectBlackoutDate,
   selectIsCourseAdmin,
   selectIsCourseStaff,
   selectLearnersTabEnabled,
@@ -179,15 +180,16 @@ export const useCurrentDiscussionTopic = () => {
   return null;
 };
 
-export const useUserPrivilage = () => {
+export const useUserCanAddThreadInBlackoutDate = () => {
+  const blackoutDateRange = useSelector(selectBlackoutDate);
   const isUserAdmin = useSelector(selectUserIsStaff);
   const userHasModerationPrivilages = useSelector(selectUserHasModerationPrivileges);
   const isUserGroupTA = useSelector(selectUserIsGroupTa);
   const isCourseAdmin = useSelector(selectIsCourseAdmin);
   const isCourseStaff = useSelector(selectIsCourseStaff);
+  const ifInBlackoutDateRange = inBlackoutDateRange(blackoutDateRange);
 
-  return (
-    handleAddPostForRoles(isUserAdmin, userHasModerationPrivilages,
-      isUserGroupTA, isCourseAdmin, isCourseStaff)
+  return (((ifInBlackoutDateRange && (isUserAdmin || userHasModerationPrivilages
+     || isUserGroupTA || isCourseAdmin || isCourseStaff)) || !ifInBlackoutDateRange)
   );
 };

--- a/src/discussions/data/hooks.js
+++ b/src/discussions/data/hooks.js
@@ -187,9 +187,8 @@ export const useUserCanAddThreadInBlackoutDate = () => {
   const isUserGroupTA = useSelector(selectUserIsGroupTa);
   const isCourseAdmin = useSelector(selectIsCourseAdmin);
   const isCourseStaff = useSelector(selectIsCourseStaff);
-  const ifInBlackoutDateRange = inBlackoutDateRange(blackoutDateRange);
+  const isInBlackoutDateRange = inBlackoutDateRange(blackoutDateRange);
 
-  return (((ifInBlackoutDateRange && (isUserAdmin || userHasModerationPrivilages
-     || isUserGroupTA || isCourseAdmin || isCourseStaff)) || !ifInBlackoutDateRange)
-  );
+  return (!(isInBlackoutDateRange)
+          || (isUserAdmin || userHasModerationPrivilages || isUserGroupTA || isCourseAdmin || isCourseStaff));
 };

--- a/src/discussions/data/selectors.js
+++ b/src/discussions/data/selectors.js
@@ -24,6 +24,10 @@ export const selectBlackoutDate = state => state.config.blackouts;
 
 export const selectGroupAtSubsection = state => state.config.groupAtSubsection;
 
+export const selectIsCourseAdmin = state => state.config.isCourseAdmin;
+
+export const selectIsCourseStaff = state => state.config.isCourseStaff;
+
 export const selectModerationSettings = state => ({
   postCloseReasons: state.config.postCloseReasons,
   editReasons: state.config.editReasons,

--- a/src/discussions/data/slices.js
+++ b/src/discussions/data/slices.js
@@ -14,6 +14,8 @@ const configSlice = createSlice({
     groupAtSubsection: false,
     hasModerationPrivileges: false,
     isGroupTa: false,
+    isCourseAdmin: false,
+    isCourseStaff: false,
     isUserAdmin: false,
     learnersTabEnabled: false,
     settings: {

--- a/src/discussions/posts/post-actions-bar/PostActionsBar.jsx
+++ b/src/discussions/posts/post-actions-bar/PostActionsBar.jsx
@@ -12,9 +12,9 @@ import { Close } from '@edx/paragon/icons';
 
 import Search from '../../../components/Search';
 import { RequestStatus } from '../../../data/constants';
-import { useUserPrivilage } from '../../data/hooks';
-import { selectBlackoutDate, selectconfigLoadingStatus } from '../../data/selectors';
-import { inBlackoutDateRange, postMessageToParent } from '../../utils';
+import { useUserCanAddThreadInBlackoutDate } from '../../data/hooks';
+import { selectconfigLoadingStatus } from '../../data/selectors';
+import { postMessageToParent } from '../../utils';
 import { showPostEditor } from '../data';
 import messages from './messages';
 
@@ -26,21 +26,10 @@ function PostActionsBar({
 }) {
   const dispatch = useDispatch();
   const loadingStatus = useSelector(selectconfigLoadingStatus);
-  const blackoutDateRange = useSelector(selectBlackoutDate);
-  const hasPrivilege = useUserPrivilage();
+  const userCanAddThreadInBlackoutDate = useUserCanAddThreadInBlackoutDate();
 
   const handleCloseInContext = () => {
     postMessageToParent('learning.events.sidebar.close');
-  };
-
-  const handleAddPost = () => {
-    if (loadingStatus === RequestStatus.SUCCESSFUL && (!(inBlackoutDateRange(blackoutDateRange)))) {
-      return true;
-    }
-    if (hasPrivilege) {
-      return true;
-    }
-    return false;
   };
 
   return (
@@ -51,7 +40,7 @@ function PostActionsBar({
           {intl.formatMessage(messages.title)}
         </h4>
       )}
-      {handleAddPost()
+      {loadingStatus === RequestStatus.SUCCESSFUL && userCanAddThreadInBlackoutDate
       && (
         <>
           {!inContext && <div className="border-right border-light-400 mx-3" />}

--- a/src/discussions/posts/post-actions-bar/PostActionsBar.jsx
+++ b/src/discussions/posts/post-actions-bar/PostActionsBar.jsx
@@ -12,13 +12,9 @@ import { Close } from '@edx/paragon/icons';
 
 import Search from '../../../components/Search';
 import { RequestStatus } from '../../../data/constants';
-import {
-  selectBlackoutDate, selectconfigLoadingStatus,
-  selectIsCourseAdmin, selectIsCourseStaff,
-  selectUserHasModerationPrivileges, selectUserIsGroupTa,
-  selectUserIsStaff,
-} from '../../data/selectors';
-import { handleAddPostForRoles, inBlackoutDateRange, postMessageToParent } from '../../utils';
+import { useUserPrivilage } from '../../data/hooks';
+import { selectBlackoutDate, selectconfigLoadingStatus } from '../../data/selectors';
+import { inBlackoutDateRange, postMessageToParent } from '../../utils';
 import { showPostEditor } from '../data';
 import messages from './messages';
 
@@ -31,18 +27,11 @@ function PostActionsBar({
   const dispatch = useDispatch();
   const loadingStatus = useSelector(selectconfigLoadingStatus);
   const blackoutDateRange = useSelector(selectBlackoutDate);
-  const isUserAdmin = useSelector(selectUserIsStaff);
-  const userHasModerationPrivilages = useSelector(selectUserHasModerationPrivileges);
-  const isUserGroupTA = useSelector(selectUserIsGroupTa);
-  const isCourseAdmin = useSelector(selectIsCourseAdmin);
-  const isCourseStaff = useSelector(selectIsCourseStaff);
+  const hasPrivilege = useUserPrivilage();
 
   const handleCloseInContext = () => {
     postMessageToParent('learning.events.sidebar.close');
   };
-
-  const hasPrivilege = handleAddPostForRoles(isUserAdmin, userHasModerationPrivilages,
-    isUserGroupTA, isCourseAdmin, isCourseStaff);
 
   const handleAddPost = () => {
     if (loadingStatus === RequestStatus.SUCCESSFUL && (!(inBlackoutDateRange(blackoutDateRange)))) {

--- a/src/discussions/utils.js
+++ b/src/discussions/utils.js
@@ -281,3 +281,11 @@ export function inBlackoutDateRange(blackoutDateRanges) {
     (blackoutDateRange) => dateInDateRange(now, new Date(blackoutDateRange.start), new Date(blackoutDateRange.end)),
   );
 }
+
+export function handleAddPostForRoles(isUserAdmin, userHasModerationPrivilages, isUserGroupTA,
+  isCourseAdmin, isCourseStaff) {
+  if (isUserAdmin || userHasModerationPrivilages || isUserGroupTA || isCourseAdmin || isCourseStaff) {
+    return true;
+  }
+  return false;
+}

--- a/src/discussions/utils.js
+++ b/src/discussions/utils.js
@@ -281,11 +281,3 @@ export function inBlackoutDateRange(blackoutDateRanges) {
     (blackoutDateRange) => dateInDateRange(now, new Date(blackoutDateRange.start), new Date(blackoutDateRange.end)),
   );
 }
-
-export function handleAddPostForRoles(isUserAdmin, userHasModerationPrivilages, isUserGroupTA,
-  isCourseAdmin, isCourseStaff) {
-  if (isUserAdmin || userHasModerationPrivilages || isUserGroupTA || isCourseAdmin || isCourseStaff) {
-    return true;
-  }
-  return false;
-}


### PR DESCRIPTION
[INF-628](https://2u-internal.atlassian.net/browse/INF-628)
Add a post/response/comment during active blackout dates fixed for all roles in discussions MFE
**Before**
For discussions MFE when blackout dates were active, buttons for adding a post, response, or comment were not visible for some roles.
**After**
For discussions MFE when blackout dates are active, buttons for adding a post, response, or comment are visible for roles as seen below.

- Global staff
- Course staff 
- Course admin
- Disc. admin
- Disc. moderator
- Disc. TA 
- Disc. Group TA

