### PR TITLE
fix: long post titles does not  shift menu position.

### DIFF
--- a/src/discussions/posts/post/PostHeader.jsx
+++ b/src/discussions/posts/post/PostHeader.jsx
@@ -120,7 +120,7 @@ function PostHeader({
       </div>
       {!preview
         && (
-          <div className="ml-auto d-flex align-items-center">
+          <div className="ml-auto d-flex">
             <ActionsDropdown commentOrPost={post} actionHandlers={actionHandlers} />
           </div>
         )}


### PR DESCRIPTION
[INF-578](https://2u-internal.atlassian.net/browse/INF-578)
Long post titles were shifting the menu position downwards. The menu position is fixed and does not move downwards, regardless of post title length.

**Before**
![beforee](https://user-images.githubusercontent.com/73840786/203997180-3da39b9b-7317-49e2-b016-675a1108f212.png)

**After**
<img width="766" alt="Screenshot 2022-11-25 at 6 38 28 PM" src="https://user-images.githubusercontent.com/73840786/203997351-49a96c22-c10f-4169-8ddc-03e635937a24.png">
