### PR TITLE
fix: Work around `Truncate` infinite loop

### DIFF
--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -78,15 +78,15 @@ function PostLink({
                 <Truncate lines={1} className="mr-1.5" whiteSpace>
                   <span
                     class={
-                        classNames('font-weight-500 font-size-14 text-primary-500 font-style-normal font-family-inter',
+                        classNames('font-weight-500 font-size-14 text-primary-500 font-style-normal font-family-inter align-bottom',
                           { 'font-weight-bolder': !read })
                       }
                   >
                     {post.title}
                   </span>
-                  <span> </span>
+                  <span class="align-bottom"> </span>
                   <span
-                    class="text-gray-700 font-weight-normal font-size-14 font-style-normal font-family-inter"
+                    class="text-gray-700 font-weight-normal font-size-14 font-style-normal font-family-inter align-bottom"
                   >
                     {isPostPreviewAvailable(post.previewBody)
                       ? post.previewBody


### PR DESCRIPTION
#### Description

This works around [a known issue](https://github.com/openedx/paragon/issues/1797) with `Truncate` that in some situations can lead to an infinite loop and subsequent page hang.

#### To reproduce

1. Set up a devstack on master and fire it up;
2. Clone `frontend-app-discussions` and run it;
3. Create and enable the `discussions.enable_discussions_mfe` waffle flag;
4. Enroll in the Demo course, enter it, and click on Discussions;
5. Create a new post;

After the post is created, the page will hang indefinitely.  Firefox will eventually offer to debug it, and inevitably the code will be stuck inside [this loop](https://github.com/openedx/paragon/blob/8aa2fa66ccfc60857faf580a8dfc8007eaa9efa3/src/Truncate/utils.js#L86-L95). 

This can be reproduced reliably using:

* Ubuntu Linux 22.04.1
* Node 16.17.0
* npm v8.15.0
* Firefox 107.0 (64-bit)
* Chromium 107.0.5304.121 (64-bit)

#### Solution

By vertically aligning the inner `<span />`s to `bottom`, they will then conform to the parent's expected `line-height`, thus providing a way out of that loop.