### PR TITLE
style: 3 level topic hierarchy accomodated when incontext discussions…

### DIFF
--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 
+import classNames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 
@@ -109,7 +110,9 @@ function Post({
         <HTMLLoader htmlNode={post.renderedBody} id="post" />
       </div>
       {topicContext && topic && (
-        <div className={`border px-3 rounded mb-4 border-light-400 align-self-start py-2.5 ${inContext ? 'w-100' : ''}`}>
+        <div className={classNames('border px-3 rounded mb-4 border-light-400 align-self-start py-2.5',
+          { 'w-100': inContext })}
+        >
           <span className="text-gray-500">{intl.formatMessage(messages.relatedTo)}{' '}</span>
           <Hyperlink
             destination={topicContext.unitLink}
@@ -120,7 +123,7 @@ function Post({
                 <>
                   <span className="w-auto">{topicContext.chapterName}</span>
                   <span className="mx-1">/</span>
-                  <span className=" w-auto">{topicContext.verticalName}</span>
+                  <span className="w-auto">{topicContext.verticalName}</span>
                   <span className="mx-1">/</span>
                   <span className="w-auto">{topicContext.unitName}</span>
                 </>

--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import { useDispatch, useSelector } from 'react-redux';
@@ -11,6 +11,7 @@ import HTMLLoader from '../../../components/HTMLLoader';
 import { ContentActions } from '../../../data/constants';
 import { selectorForUnitSubsection, selectTopicContext } from '../../../data/selectors';
 import { AlertBanner, Confirmation } from '../../common';
+import { DiscussionContext } from '../../common/context';
 import { selectModerationSettings } from '../../data/selectors';
 import { selectTopic } from '../../topics/data/selectors';
 import { removeThread, updateExistingThread } from '../data/thunks';
@@ -56,6 +57,7 @@ function Post({
     hideReportConfirmation();
   };
 
+  const { inContext } = useContext(DiscussionContext);
   const actionHandlers = {
     [ContentActions.EDIT_CONTENT]: () => history.push({
       ...location,
@@ -107,13 +109,23 @@ function Post({
         <HTMLLoader htmlNode={post.renderedBody} id="post" />
       </div>
       {topicContext && topic && (
-        <div className="border px-3 rounded mb-4 border-light-400 align-self-start py-2.5">
+        <div className={`border px-3 rounded mb-4 border-light-400 align-self-start py-2.5 ${inContext ? 'w-100' : ''}`}>
           <span className="text-gray-500">{intl.formatMessage(messages.relatedTo)}{' '}</span>
           <Hyperlink
             destination={topicContext.unitLink}
             target="_top"
           >
-            {`${getTopicCategoryName(topic)} / ${topic.name}`}
+            {inContext
+              ? (
+                <>
+                  <span className="w-auto">{topicContext.chapterName}</span>
+                  <span className="mx-1">/</span>
+                  <span className=" w-auto">{topicContext.verticalName}</span>
+                  <span className="mx-1">/</span>
+                  <span className="w-auto">{topicContext.unitName}</span>
+                </>
+              )
+              : `${getTopicCategoryName(topic)} / ${topic.name}`}
           </Hyperlink>
         </div>
       )}


### PR DESCRIPTION
[INF-661](https://2u-internal.atlassian.net/browse/INF-661)

- Topic information needs to be changed according to 3 level hierarchy, once when in-context discussions is enabled.
- Changes are made to accommodate 3 level topic hierarchy.

<img width="482" alt="Screenshot 2022-11-30 at 6 35 19 PM" src="https://user-images.githubusercontent.com/73840786/204825139-358481ad-5acb-4b8f-9c9d-6805c2b0e811.png">

