### PR TITLE
fix: UI style fixed for medium screens

### DIFF
--- a/src/discussions/data/hooks.js
+++ b/src/discussions/data/hooks.js
@@ -97,7 +97,7 @@ export function useRedirectToThread(courseId, inContext) {
 
 export function useIsOnDesktop() {
   const windowSize = useWindowSize();
-  return windowSize.width >= breakpoints.large.minWidth;
+  return windowSize.width >= breakpoints.medium.minWidth;
 }
 
 export function useIsOnXLDesktop() {


### PR DESCRIPTION
### [INF-630](https://2u-internal.atlassian.net/browse/INF-630)

The breakpoints added for the desktop screen are conflicting and showing mobile view when screen sizes are comparatively smaller than regular desktop screens hence the limit for desktop screens is expanded 

screen views with different resolutions are pasted below:

<img width="628" alt="Screen Shot 2022-12-01 at 8 57 23 PM" src="https://user-images.githubusercontent.com/67791278/205100106-5b0b70d9-273e-4c84-b58d-370a184e9a71.png">

<img width="546" alt="Screen Shot 2022-12-01 at 8 57 52 PM" src="https://user-images.githubusercontent.com/67791278/205100117-67dff878-d1e3-4ccc-b86a-48cc19a647f0.png">

<img width="669" alt="Screen Shot 2022-12-01 at 8 57 14 PM" src="https://user-images.githubusercontent.com/67791278/205100096-7648411b-145c-4206-8ced-f544edb50a9e.png">


<img width="1186" alt="Screen Shot 2022-12-01 at 8 57 05 PM" src="https://user-images.githubusercontent.com/67791278/205100067-3c76c714-1efa-46e8-988a-5929f94c478c.png">
