### PR TITLE
fix: filter result rendering fixed in topics

### DIFF
--- a/src/discussions/posts/PostsList.jsx
+++ b/src/discussions/posts/PostsList.jsx
@@ -22,7 +22,9 @@ import { fetchThreads } from './data/thunks';
 import NoResults from './NoResults';
 import { PostLink } from './post';
 
-function PostsList({ posts, topics, intl }) {
+function PostsList({
+  posts, topics, intl, isTopicTab,
+}) {
   const dispatch = useDispatch();
   const {
     courseId,
@@ -38,7 +40,7 @@ function PostsList({ posts, topics, intl }) {
   const userIsStaff = useSelector(selectUserIsStaff);
   const configStatus = useSelector(selectconfigLoadingStatus);
 
-  const loadThreads = (topicIds, pageNum = undefined) => {
+  const loadThreads = (topicIds, pageNum = undefined, isFilterChanged = false) => {
     const params = {
       orderBy,
       filters,
@@ -46,6 +48,7 @@ function PostsList({ posts, topics, intl }) {
       author: showOwnPosts ? authenticatedUser.username : null,
       countFlagged: (userHasModerationPrivileges || userIsStaff) || undefined,
       topicIds,
+      isFilterChanged,
     };
 
     if (showOwnPosts) {
@@ -59,7 +62,11 @@ function PostsList({ posts, topics, intl }) {
     if (topics !== undefined && configStatus === RequestStatus.SUCCESSFUL) {
       loadThreads(topics);
     }
-  }, [courseId, orderBy, filters, page, JSON.stringify(topics), configStatus]);
+  }, [courseId, filters, orderBy, page, JSON.stringify(topics), configStatus]);
+
+  useEffect(() => {
+    if (isTopicTab) { loadThreads(topics, 1, true); }
+  }, [filters]);
 
   const checkIsSelected = (id) => window.location.pathname.includes(id);
   const pinnedPosts = useMemo(() => filterPosts(posts, 'pinned'), [posts]);
@@ -103,12 +110,14 @@ PostsList.propTypes = {
     id: PropTypes.string.isRequired,
   })),
   topics: PropTypes.arrayOf(PropTypes.string),
+  isTopicTab: PropTypes.bool,
   intl: intlShape.isRequired,
 };
 
 PostsList.defaultProps = {
   posts: [],
   topics: undefined,
+  isTopicTab: false,
 };
 
 export default injectIntl(PostsList);

--- a/src/discussions/posts/PostsView.jsx
+++ b/src/discussions/posts/PostsView.jsx
@@ -21,7 +21,7 @@ function AllPostsList() {
 
 function TopicPostsList({ topicId }) {
   const posts = useSelector(selectTopicThreads([topicId]));
-  return <PostsList posts={posts} topics={[topicId]} />;
+  return <PostsList posts={posts} topics={[topicId]} isTopicTab />;
 }
 
 TopicPostsList.propTypes = {

--- a/src/discussions/posts/data/slices.js
+++ b/src/discussions/posts/data/slices.js
@@ -79,7 +79,13 @@ const threadsSlice = createSlice({
       }
       state.status = RequestStatus.SUCCESSFUL;
       state.threadsById = { ...state.threadsById, ...payload.threadsById };
-      state.threadsInTopic = mergeThreadsInTopics(state.threadsInTopic, payload.threadsInTopic);
+      // filter
+      if (payload.isFilterChanged) {
+        state.threadsInTopic = { ...payload.threadsInTopic };
+      } else {
+        state.threadsInTopic = mergeThreadsInTopics(state.threadsInTopic, payload.threadsInTopic);
+      }
+
       state.avatars = { ...state.avatars, ...payload.avatars };
       state.nextPage = (payload.page < payload.pagination.numPages) ? payload.page + 1 : null;
       state.totalPages = payload.pagination.numPages;

--- a/src/discussions/posts/data/thunks.js
+++ b/src/discussions/posts/data/thunks.js
@@ -102,6 +102,7 @@ export function fetchThreads(courseId, {
   author = null,
   filters = {},
   page = 1,
+  isFilterChanged,
   countFlagged,
 } = {}) {
   const options = {
@@ -141,7 +142,7 @@ export function fetchThreads(courseId, {
       const data = await getThreads(courseId, options);
       const normalisedData = normaliseThreads(camelCaseObject(data), topicIds);
       dispatch(fetchThreadsSuccess({
-        ...normalisedData, page, author, textSearchRewrite: data.text_search_rewrite,
+        ...normalisedData, page, author, textSearchRewrite: data.text_search_rewrite, isFilterChanged,
       }));
     } catch (error) {
       if (getHttpErrorStatus(error) === 403) {


### PR DESCRIPTION
[https://2u-internal.atlassian.net/browse/INF-692](url)

Filters now working fine on all tabs:
<img width="495" alt="Screen Shot 2022-12-06 at 10 03 46 PM" src="https://user-images.githubusercontent.com/67791278/205975992-3db6aab5-a503-42a9-aa34-5ac550e35279.png">
<img width="480" alt="Screen Shot 2022-12-06 at 10 04 00 PM" src="https://user-images.githubusercontent.com/67791278/205976013-e2cdc068-e54a-4bc2-b72d-4299245bf860.png">
Also tested for load more functionality