### PR TITLE
feat: add tracking event for content filtering in discussion MFE

### DIFF
--- a/src/discussions/posts/data/slices.js
+++ b/src/discussions/posts/data/slices.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-param-reassign,import/prefer-default-export */
 import { createSlice } from '@reduxjs/toolkit';
 
+import { sendTrackEvent } from '@edx/frontend-platform/analytics';
+
 import {
   PostsStatusFilter, RequestStatus, ThreadOrdering, ThreadType,
 } from '../../../data/constants';
@@ -20,6 +22,19 @@ const mergeThreadsInTopics = (dataFromState, dataFromPayload) => {
     return acc;
   }, {});
 };
+
+function trackFilterContentEvent(filters, sort, eventTrigger) {
+  sendTrackEvent(
+    'edx.forum.filter.content',
+    {
+      statusFilter: filters.status,
+      threadTypeFilter: filters.postType,
+      sort,
+      cohortFilter: filters.cohortFilter,
+      triggeredBy: eventTrigger,
+    },
+  );
+}
 
 const threadsSlice = createSlice({
   name: 'thread',
@@ -182,14 +197,17 @@ const threadsSlice = createSlice({
     },
     setStatusFilter: (state, { payload }) => {
       state.filters.status = payload;
+      trackFilterContentEvent(state.filters, state.sortedBy, 'Status Filter');
       state.pages = [];
     },
     setPostsTypeFilter: (state, { payload }) => {
       state.filters.postType = payload;
+      trackFilterContentEvent(state.filters, state.sortedBy, 'Type Filter');
       state.pages = [];
     },
     setCohortFilter: (state, { payload }) => {
       state.filters.cohort = payload;
+      trackFilterContentEvent(state.filters, state.sortedBy, 'Cohort Filter');
       state.pages = [];
     },
     setSearchQuery: (state, { payload }) => {


### PR DESCRIPTION
### [INF-488](https://2u-internal.atlassian.net/browse/INF-488)

### Description

Add event for content filtering and sorting in discussions MFE. The event will be triggered every time a sort / filter is applied on content.
Event name will be `edx.forum.filter.content`