### PR TITLE
fix: fix cohort field on content filter event.

### DIFF
--- a/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
+++ b/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
@@ -89,7 +89,7 @@ function PostFilterBar({
       statusFilter: currentStatus,
       threadTypeFilter: currentType,
       sortFilter: currentSorting,
-      cohortFilter: cohorts,
+      cohortFilter: selectedCohort,
       triggeredBy: name,
     };
     if (name === 'type') {


### PR DESCRIPTION
Fix cohortFilter field in content filter event.

We were sending all cohorts present for course. This PR fixes this issue, by replacing it with the current selected cohort.