### PR TITLE
fix: loading icon and filter menu shows when api call is in progress

### DIFF
--- a/src/discussions/posts/data/slices.js
+++ b/src/discussions/posts/data/slices.js
@@ -57,7 +57,6 @@ const threadsSlice = createSlice({
       if (state.author !== payload.author) {
         state.pages = [];
         state.author = payload.author;
-        state.totalThreads = null;
       }
       state.status = RequestStatus.IN_PROGRESS;
     },
@@ -161,9 +160,11 @@ const threadsSlice = createSlice({
     },
     updateThreadFailed: (state) => {
       state.postStatus = RequestStatus.FAILED;
+      state.totalThreads = 0;
     },
     updateThreadDenied: (state) => {
       state.postStatus = RequestStatus.DENIED;
+      state.totalThreads = 0;
     },
     deleteThreadRequest: (state) => {
       state.postStatus = RequestStatus.IN_PROGRESS;


### PR DESCRIPTION
[INF-683](https://2u-internal.atlassian.net/browse/INF-683)

**Description**
Loading icon and filter menu shows when api call is in progress in My posts tab.

Before

![My posts tab](https://user-images.githubusercontent.com/73840786/208665210-7c2e8392-0704-4fdb-bab0-7123939be0b4.gif)

After
![chrome-capture-2022-11-20](https://user-images.githubusercontent.com/73840786/208665965-4c4a2c5d-2ab6-4f38-bbbd-d99c097d4969.gif)

