### PR TITLE
fix: post edit reason will not be sent in case of global staff own post

### DIFF
--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -138,7 +138,7 @@ function PostEditor({
     follow: isEmpty(post?.following) ? true : post?.following,
     anonymous: allowAnonymous ? false : undefined,
     anonymousToPeers: allowAnonymousToPeers ? false : undefined,
-    editReasonCode: post?.lastEdit?.reasonCode || (userIsStaff ? 'violates-guidelines' : ''),
+    editReasonCode: post?.lastEdit?.reasonCode || (userIsStaff && canDisplayEditReason ? 'violates-guidelines' : undefined),
     cohort: post?.cohort || 'default',
   };
 


### PR DESCRIPTION
- edit reason was sent in API in any case if the logged-in user is global staff, now it will only be sent when the requirement to send reason code is met. 
<img width="1196" alt="Screen Shot 2022-12-20 at 8 04 44 PM" src="https://user-images.githubusercontent.com/67791278/208698318-0c40719e-dd6e-4318-a124-1105057e5f29.png">


edited global staff post