### PR TITLE
fix: disabled relative link

### DIFF
--- a/src/components/TinyMCEEditor.jsx
+++ b/src/components/TinyMCEEditor.jsx
@@ -119,6 +119,7 @@ export default function TinyMCEEditor(props) {
           content_css: false,
           content_style: contentStyle,
           body_class: 'm-2 text-editor',
+          relative_urls: false,
           default_link_target: '_blank',
           target_list: false,
           images_upload_handler: uploadHandler,


### PR DESCRIPTION
[INF-679](https://2u-internal.atlassian.net/browse/INF-679)

The TinyMCE was converting the same domain URLs to relative links hence when copied from My post it changed the URL to  `post/postId` only and when copied from the All Posts tab to `postId` only and then when redirecting it was picking current URL and appending the relative URL to current hence the faulty URL issue. 

for more context on the related setting change consult this documentation
https://www.tiny.cloud/docs/tinymce/6/url-handling/