### PR TITLE
style: z-index fixes for UI elements in user dropdown and editor toolbar

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -117,9 +117,6 @@ $fa-font-path: "~font-awesome/fonts";
 }
 
 header {
-  .user-dropdown {
-    z-index: 1;
-  }
   .logo {
     margin-right: 1rem;
     img {
@@ -261,4 +258,7 @@ header {
   body:not(.tox-force-desktop) .tox .tox-dialog {
     align-self: center;
   }
+}
+.tox .tox-editor-header {
+  z-index: 0 !important;
 }


### PR DESCRIPTION
After Fix:

The toolbar is not going over the sticky top also the user menu drop-down stays above the sticky header now.

https://user-images.githubusercontent.com/67791278/209301165-1bce0518-aabb-43ee-9966-1d1b65831694.mov

