### PR TITLE
fix: moved spinner to center and reply menu icon to right side

### DIFF
--- a/src/discussions/comments/comment/Reply.jsx
+++ b/src/discussions/comments/comment/Reply.jsx
@@ -113,13 +113,15 @@ function Reply({
         >
           <div className="d-flex flex-row justify-content-between align-items-center mb-0.5">
             <AuthorLabel author={reply.author} authorLabel={reply.authorLabel} labelColor={colorClass && `text-${colorClass}`} linkToProfile />
-            <ActionsDropdown
-              commentOrPost={{
-                ...reply,
-                postType,
-              }}
-              actionHandlers={actionHandlers}
-            />
+            <div className="ml-auto d-flex">
+              <ActionsDropdown
+                commentOrPost={{
+                  ...reply,
+                  postType,
+                }}
+                actionHandlers={actionHandlers}
+              />
+            </div>
           </div>
           {isEditing
             ? <CommentEditor comment={reply} onCloseEditor={() => setEditing(false)} />

--- a/src/discussions/posts/PostsList.jsx
+++ b/src/discussions/posts/PostsList.jsx
@@ -90,7 +90,7 @@ function PostsList({
       {postInstances(unpinnedPosts)}
       {posts?.length === 0 && loadingStatus === RequestStatus.SUCCESSFUL && <NoResults />}
       {loadingStatus === RequestStatus.IN_PROGRESS ? (
-        <div className="d-flex justify-content-center p-4">
+        <div className="d-flex justify-content-center p-4 mx-auto my-auto">
           <Spinner animation="border" variant="primary" size="lg" />
         </div>
       ) : (


### PR DESCRIPTION
[INF-403](https://2u-internal.atlassian.net/browse/INF-403)

- Moved Spinner to Center in Post summary List
- Reply menu Icon button is moved to top right corner of reply box

**Before**
<img width="1171" alt="Screenshot 2022-12-28 at 4 08 29 PM" src="https://user-images.githubusercontent.com/73840786/209803004-0802b231-2194-488b-9c0b-5cc8bf72903b.png">

![CPT2212281614-447x743](https://user-images.githubusercontent.com/73840786/209804213-8c10a4b2-bcfe-4149-9aaf-de0b9a3947d7.gif)


**After**
<img width="1173" alt="Screenshot 2022-12-28 at 4 04 08 PM" src="https://user-images.githubusercontent.com/73840786/209803026-58d08b67-f2c6-4d67-b200-ff65595ee17a.png">

![CPT2212281619-1553x755](https://user-images.githubusercontent.com/73840786/209804408-3986121f-b724-4707-8f3a-07dcd44206e2.gif)

