### PR TITLE
fix: text update for blackout dates banner

### DIFF
--- a/src/discussions/messages.js
+++ b/src/discussions/messages.js
@@ -185,8 +185,8 @@ const messages = defineMessages({
   },
   blackoutDiscussionInformation: {
     id: 'discussion.blackoutBanner.information',
-    defaultMessage: 'Blackout dates are currently active. Posting in discussions is unavailable at this time.',
-    description: 'Informative text when discussions blackout is active',
+    defaultMessage: 'Posting in discussions is temporarily disabled by the course team',
+    description: 'Informative text when discussion posting is disabled',
   },
   imageWarningMessage: {
     id: 'discussions.editor.image.warning.message',


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/INF-707
Change the blackout info banner to say: `“Posting in discussions is temporarily disabled by the course team”.`
instead of `Blackout dates are currently active. Posting in discussions is unavailable at this time.`