### PR TITLE
fix: deleting a post from sidebar renders entire MFE in the sidebar

### DIFF
--- a/src/discussions/posts/data/slices.js
+++ b/src/discussions/posts/data/slices.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-param-reassign,import/prefer-default-export */
 import { createSlice } from '@reduxjs/toolkit';
+import omitBy from 'lodash/omitBy';
 
 import {
   PostsStatusFilter, RequestStatus, ThreadOrdering, ThreadType,
@@ -175,7 +176,7 @@ const threadsSlice = createSlice({
       state.postStatus = RequestStatus.SUCCESSFUL;
       state.threadsInTopic[topicId] = state.threadsInTopic[topicId].filter(item => item !== threadId);
       state.pages = state.pages.map(page => page?.filter(item => item !== threadId));
-      delete state.threadsById[threadId];
+      state.threadsById = omitBy(state.threadsById, (thread) => thread.id === threadId);
     },
     deleteThreadFailed: (state) => {
       state.postStatus = RequestStatus.FAILED;

--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -30,6 +30,7 @@ function Post({
   const location = useLocation();
   const history = useHistory();
   const dispatch = useDispatch();
+  const { enableInContextSidebar } = useContext(DiscussionContext);
   const { courseId } = useSelector((state) => state.courseTabs);
   const topic = useSelector(selectTopic(post.topicId));
   const getTopicSubsection = useSelector(selectorForUnitSubsection);
@@ -49,7 +50,10 @@ function Post({
 
   const handleDeleteConfirmation = () => {
     dispatch(removeThread(post.id));
-    history.push('.');
+    history.push({
+      pathname: '.',
+      search: enableInContextSidebar && '?inContextSidebar',
+    });
     hideDeleteConfirmation();
   };
 
@@ -58,7 +62,6 @@ function Post({
     hideReportConfirmation();
   };
 
-  const { enableInContextSidebar } = useContext(DiscussionContext);
   const actionHandlers = {
     [ContentActions.EDIT_CONTENT]: () => history.push({
       ...location,


### PR DESCRIPTION
### [INF-717](https://2u-internal.atlassian.net/browse/INF-717)

1. Deleting a post from the sidebar renders the entire MFE in the sidebar because of redirection after the delete a post.
2. `inContextSidebar` search param is compulsory to render the inContext sidebar UI which was missing in the redirection URL.

**Bug Demo**
https://user-images.githubusercontent.com/79941147/211270814-d6ed8567-cc70-4eac-8030-3c6f261a0ba0.mov


**Fix Demo**
https://www.loom.com/share/5cec274508d345a095844d2563f899a2