### PR TITLE
fix: update post delete function to async

### DIFF
--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -48,8 +48,8 @@ function Post({
     }
   };
 
-  const handleDeleteConfirmation = () => {
-    dispatch(removeThread(post.id));
+  const handleDeleteConfirmation = async () => {
+    await dispatch(removeThread(post.id));
     history.push({
       pathname: '.',
       search: enableInContextSidebar && '?inContextSidebar',


### PR DESCRIPTION
### [INF-717](https://2u-internal.atlassian.net/browse/INF-717)

The delete post function was creating delay to update the UI because redirection is happing before the redux state update. So change the function to async and wait to update the redux state. After the state update, redirect to the required page.

**Bug Demo**
https://www.loom.com/share/e4ac107578e64bfa9e02d4ddcdfe3d22