### PR TITLE
fix: editedBy and closedBy banner will be visible to global staff

### DIFF
--- a/src/discussions/common/AlertBanner.jsx
+++ b/src/discussions/common/AlertBanner.jsx
@@ -10,7 +10,9 @@ import { Report } from '@edx/paragon/icons';
 
 import { commentShape } from '../comments/comment/proptypes';
 import messages from '../comments/messages';
-import { selectModerationSettings, selectUserHasModerationPrivileges, selectUserIsGroupTa } from '../data/selectors';
+import {
+  selectModerationSettings, selectUserHasModerationPrivileges, selectUserIsGroupTa, selectUserIsStaff,
+} from '../data/selectors';
 import { postShape } from '../posts/post/proptypes';
 import AuthorLabel from './AuthorLabel';
 
@@ -20,9 +22,10 @@ function AlertBanner({
 }) {
   const userHasModerationPrivileges = useSelector(selectUserHasModerationPrivileges);
   const userIsGroupTa = useSelector(selectUserIsGroupTa);
+  const isAdmin = useSelector(selectUserIsStaff);
   const { reasonCodesEnabled } = useSelector(selectModerationSettings);
   const userIsContentAuthor = getAuthenticatedUser().username === content.author;
-  const canSeeLastEditOrClosedAlert = (userHasModerationPrivileges || userIsContentAuthor || userIsGroupTa);
+  const canSeeLastEditOrClosedAlert = (userHasModerationPrivileges || userIsGroupTa || isAdmin || userIsContentAuthor);
   const canSeeReportedBanner = content?.abuseFlagged;
 
   return (

--- a/src/discussions/common/AlertBanner.jsx
+++ b/src/discussions/common/AlertBanner.jsx
@@ -22,11 +22,13 @@ function AlertBanner({
 }) {
   const userHasModerationPrivileges = useSelector(selectUserHasModerationPrivileges);
   const userIsGroupTa = useSelector(selectUserIsGroupTa);
-  const isAdmin = useSelector(selectUserIsStaff);
+  const userIsGlobalStaff = useSelector(selectUserIsStaff);
   const { reasonCodesEnabled } = useSelector(selectModerationSettings);
   const userIsContentAuthor = getAuthenticatedUser().username === content.author;
-  const canSeeLastEditOrClosedAlert = (userHasModerationPrivileges || userIsGroupTa || isAdmin || userIsContentAuthor);
   const canSeeReportedBanner = content?.abuseFlagged;
+  const canSeeLastEditOrClosedAlert = (userHasModerationPrivileges || userIsGroupTa
+    || userIsGlobalStaff || userIsContentAuthor
+  );
 
   return (
     <>


### PR DESCRIPTION
### [INF-718](https://2u-internal.atlassian.net/browse/INF-718)

Now global staff is privileged to these actions.
1. Can see “closed by” info banner on other’s posts - Yes
2. Can see “closed by” info banner on own posts - Yes
3. Can see “edited by” info banner on other’s content - Yes
4. Can see “edited by” info banner on own content - Yes

### After changes:
**Note: edx is a global staff**
<img width="1440" alt="Screenshot 2023-01-17 at 2 46 20 PM" src="https://user-images.githubusercontent.com/79941147/212865081-0b8d62d0-8104-4c6e-89cd-3a37ea6285f4.png">
<img width="1440" alt="Screenshot 2023-01-17 at 2 46 42 PM" src="https://user-images.githubusercontent.com/79941147/212865102-e4b231b8-588d-4693-84ab-b63437c3175e.png">
