### PR TITLE
style:  in-context discussions style updates

### DIFF
--- a/src/components/PostPreviewPane.jsx
+++ b/src/components/PostPreviewPane.jsx
@@ -33,13 +33,12 @@ function PostPreviewPane({
         </div>
       )}
       <div className="d-flex justify-content-end">
-        {!showPreviewPane
-        && (
+        {!showPreviewPane && (
           <Button
             variant="link"
             size="sm"
             onClick={() => setShowPreviewPane(true)}
-            className={`text-primary-500 p-0 ${editExisting && 'mb-4.5'}`}
+            className={`text-primary-500 font-style p-0 ${editExisting && 'mb-4.5'}`}
             style={{ lineHeight: '26px' }}
           >
             {intl.formatMessage(messages.showPreviewButton)}

--- a/src/discussions/comments/CommentsView.jsx
+++ b/src/discussions/comments/CommentsView.jsx
@@ -3,7 +3,6 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 
-import classNames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
@@ -234,12 +233,13 @@ function CommentsView({ intl }) {
             <div className="px-4 py-1.5 bg-white">
               <Button
                 variant="plain"
-                className="px-0 font-weight-light text-primary-500"
+                className="px-0 py-0 my-1.5 border-0 font-weight-normal fontStyle text-primary-500"
                 iconBefore={ArrowBack}
                 onClick={() => history.push(discussionsPath(PostsPages[page], {
                   courseId, learnerUsername, category, topicId,
                 })(location))}
                 size="sm"
+                style={{ lineHeight: '24px' }}
               >
                 {intl.formatMessage(messages.backAlt)}
               </Button>
@@ -261,10 +261,7 @@ function CommentsView({ intl }) {
         )
       )}
       <div
-        className={classNames('discussion-comments d-flex flex-column card border-0', {
-          'post-card-margin post-card-padding': !enableInContextSidebar,
-          'post-card-padding rounded-0 border-0 mb-4': enableInContextSidebar,
-        })}
+        className="discussion-comments d-flex flex-column card border-0 post-card-margin post-card-padding"
       >
         <Post post={thread} handleAddResponseButton={() => setAddingResponse(true)} />
         {!thread.closed && (

--- a/src/discussions/comments/CommentsView.jsx
+++ b/src/discussions/comments/CommentsView.jsx
@@ -87,10 +87,9 @@ function DiscussionCommentsView({
 
   const handleDefinition = (message, commentsLength) => (
     <div
-      className="mx-4 my-14px text-gray-700 font-style-normal font-family-inter"
+      className="mx-4 my-14px text-gray-700 font-style"
       role="heading"
       aria-level="2"
-      style={{ lineHeight: '24px' }}
     >
       {intl.formatMessage(message, { num: commentsLength })}
     </div>
@@ -113,11 +112,7 @@ function DiscussionCommentsView({
           onClick={handleLoadMoreResponses}
           variant="link"
           block="true"
-          className="px-4 mt-3 py-0 mb-2 font-style-normal font-family-inter font-weight-500 font-size-14"
-          style={{
-            lineHeight: '24px',
-            border: '0px',
-          }}
+          className="px-4 mt-3 border-0 line-height-24 py-0 mb-2 font-style font-weight-500 font-size-14"
           data-testid="load-more-comments"
         >
           {intl.formatMessage(messages.loadMoreResponses)}
@@ -153,11 +148,8 @@ function DiscussionCommentsView({
                     <Button
                       variant="plain"
                       block="true"
-                      className="card mb-4 px-0 py-10px mt-2 font-style font-weight-500 font-size-14 text-primary-500"
-                      style={{
-                        lineHeight: '24px',
-                        border: '0px',
-                      }}
+                      className="card mb-4 px-0 border-0 py-10px mt-2 font-style font-weight-500
+                      line-height-24 font-size-14 text-primary-500"
                       onClick={() => setAddingResponse(true)}
                       data-testid="add-response"
                     >
@@ -233,13 +225,12 @@ function CommentsView({ intl }) {
             <div className="px-4 py-1.5 bg-white">
               <Button
                 variant="plain"
-                className="px-0 py-0 my-1.5 border-0 font-weight-normal font-style  text-primary-500"
+                className="px-0 line-height-24 py-0 my-1.5 border-0 font-weight-normal font-style text-primary-500"
                 iconBefore={ArrowBack}
                 onClick={() => history.push(discussionsPath(PostsPages[page], {
                   courseId, learnerUsername, category, topicId,
                 })(location))}
                 size="sm"
-                style={{ lineHeight: '24px' }}
               >
                 {intl.formatMessage(messages.backAlt)}
               </Button>

--- a/src/discussions/comments/CommentsView.jsx
+++ b/src/discussions/comments/CommentsView.jsx
@@ -154,7 +154,7 @@ function DiscussionCommentsView({
                     <Button
                       variant="plain"
                       block="true"
-                      className="card mb-4 px-0 py-10px mt-2 font-style-normal font-family-inter font-weight-500 font-size-14 text-primary-500"
+                      className="card mb-4 px-0 py-10px mt-2 fontStyle font-weight-500 font-size-14 text-primary-500"
                       style={{
                         lineHeight: '24px',
                         border: '0px',

--- a/src/discussions/comments/CommentsView.jsx
+++ b/src/discussions/comments/CommentsView.jsx
@@ -153,7 +153,7 @@ function DiscussionCommentsView({
                     <Button
                       variant="plain"
                       block="true"
-                      className="card mb-4 px-0 py-10px mt-2 fontStyle font-weight-500 font-size-14 text-primary-500"
+                      className="card mb-4 px-0 py-10px mt-2 font-style font-weight-500 font-size-14 text-primary-500"
                       style={{
                         lineHeight: '24px',
                         border: '0px',
@@ -233,7 +233,7 @@ function CommentsView({ intl }) {
             <div className="px-4 py-1.5 bg-white">
               <Button
                 variant="plain"
-                className="px-0 py-0 my-1.5 border-0 font-weight-normal fontStyle text-primary-500"
+                className="px-0 py-0 my-1.5 border-0 font-weight-normal font-style  text-primary-500"
                 iconBefore={ArrowBack}
                 onClick={() => history.push(discussionsPath(PostsPages[page], {
                   courseId, learnerUsername, category, topicId,

--- a/src/discussions/comments/comment/Comment.jsx
+++ b/src/discussions/comments/comment/Comment.jsx
@@ -152,7 +152,7 @@ function Comment({
             )
             : (
               <HTMLLoader
-                cssClassName="comment-body html-loader text-break mt-14px font-style-normal font-family-inter text-primary-500"
+                cssClassName="comment-body html-loader text-break mt-14px font-style text-primary-500"
                 componentId="comment"
                 htmlNode={comment.renderedBody}
                 testId={comment.id}
@@ -182,7 +182,7 @@ function Comment({
               onClick={handleLoadMoreComments}
               variant="link"
               block="true"
-              className="font-size-14 font-style-normal font-family-inter pt-10px border-0 font-weight-500 pb-0"
+              className="font-size-14 font-style pt-10px border-0 font-weight-500 pb-0"
               data-testid="load-more-comments-responses"
               style={{
                 lineHeight: '20px',
@@ -208,12 +208,9 @@ function Comment({
                 {!isClosedPost && userCanAddThreadInBlackoutDate && (inlineReplies.length >= 5)
                   && (
                     <Button
-                      className="d-flex flex-grow mt-2 font-size-14 font-style-normal font-family-inter font-weight-500 text-primary-500"
+                      className="d-flex flex-grow mt-2 font-size-14 font-style font-weight-500 text-primary-500"
                       variant="plain"
-                      style={{
-                        lineHeight: '24px',
-                        height: '36px',
-                      }}
+                      style={{ height: '36px' }}
                       onClick={() => setReplying(true)}
                     >
                       {intl.formatMessage(messages.addComment)}

--- a/src/discussions/comments/comment/Reply.jsx
+++ b/src/discussions/comments/comment/Reply.jsx
@@ -120,7 +120,7 @@ function Reply({
               postCreatedAt={reply.createdAt}
               postOrComment
             />
-            <div className="ml-auto d-flex" style={{ lineHeight: '24px' }}>
+            <div className="ml-auto d-flex">
               <ActionsDropdown
                 commentOrPost={{
                   ...reply,
@@ -137,7 +137,7 @@ function Reply({
               <HTMLLoader
                 componentId="reply"
                 htmlNode={reply.renderedBody}
-                cssClassName="html-loader text-break font-style-normal pb-1 font-family-inter text-primary-500"
+                cssClassName="html-loader text-break font-style text-primary-500"
                 testId={reply.id}
               />
             )}

--- a/src/discussions/common/AlertBanner.jsx
+++ b/src/discussions/common/AlertBanner.jsx
@@ -41,13 +41,13 @@ function AlertBanner({
         <>
           {content.lastEdit?.reason && (
             <Alert variant="info" className="px-3 shadow-none mb-1 py-10px bg-light-200">
-              <div className="d-flex align-items-center flex-wrap text-gray-700 font-family-inter">
+              <div className="d-flex align-items-center flex-wrap text-gray-700 font-style">
                 {intl.formatMessage(messages.editedBy)}
                 <span className="ml-1 mr-3">
                   <AuthorLabel author={content.lastEdit.editorUsername} linkToProfile postOrComment />
                 </span>
                 <span
-                  className="mx-1.5 font-family-inter font-size-8 font-style-normal text-light-700"
+                  className="mx-1.5 font-size-8 font-style text-light-700"
                   style={{ lineHeight: '15px' }}
                 >
                   {intl.formatMessage(messages.fullStop)}
@@ -58,13 +58,13 @@ function AlertBanner({
           )}
           {content.closed && (
             <Alert variant="info" className="px-3 shadow-none mb-1 py-10px bg-light-200">
-              <div className="d-flex align-items-center flex-wrap text-gray-700 font-family-inter">
+              <div className="d-flex align-items-center flex-wrap text-gray-700 font-style">
                 {intl.formatMessage(messages.closedBy)}
                 <span className="ml-1 ">
                   <AuthorLabel author={content.closedBy} linkToProfile postOrComment />
                 </span>
                 <span
-                  className="mx-1.5 font-family-inter font-size-8 font-style-normal text-light-700"
+                  className="mx-1.5 font-size-8 font-style text-light-700"
                   style={{ lineHeight: '15px' }}
                 >
                   {intl.formatMessage(messages.fullStop)}

--- a/src/discussions/common/AuthorLabel.jsx
+++ b/src/discussions/common/AuthorLabel.jsx
@@ -51,10 +51,10 @@ function AuthorLabel({
     && linkToProfile && author && author !== intl.formatMessage(messages.anonymous);
 
   const labelContents = (
-    <div className={className} style={{ lineHeight: '24px' }}>
+    <div className={className}>
       {!alert && (
         <span
-          className={classNames('mr-1.5 font-size-14 font-style-normal font-family-inter font-weight-500', {
+          className={classNames('mr-1.5 font-size-14 font-style font-weight-500', {
             'text-gray-700': isRetiredUser,
             'text-primary-500': !authorLabelMessage && !isRetiredUser,
           })}
@@ -91,7 +91,7 @@ function AuthorLabel({
       </OverlayTrigger>
       {authorLabelMessage && (
         <span
-          className={classNames('mr-1.5 font-size-14 font-style-normal font-family-inter font-weight-500', {
+          className={classNames('mr-1.5 font-size-14 font-style font-weight-500', {
             'text-primary-500': showTextPrimary,
             'text-gray-700': isRetiredUser,
           })}

--- a/src/discussions/common/HoverCard.jsx
+++ b/src/discussions/common/HoverCard.jsx
@@ -40,7 +40,7 @@ function HoverCard({
         <div className="d-flex">
           <Button
             variant="tertiary"
-            className={classNames('px-2.5 py-2 border-0 font-style-normal font-family-inter text-gray-700 font-size-12',
+            className={classNames('px-2.5 py-2 border-0 fontStyle text-gray-700 font-size-12',
               { 'w-100': enableInContextSidebar })}
             onClick={() => handleResponseCommentButton()}
             disabled={isClosedPost}

--- a/src/discussions/common/HoverCard.jsx
+++ b/src/discussions/common/HoverCard.jsx
@@ -40,7 +40,7 @@ function HoverCard({
         <div className="d-flex">
           <Button
             variant="tertiary"
-            className={classNames('px-2.5 py-2 border-0 fontStyle text-gray-700 font-size-12',
+            className={classNames('px-2.5 py-2 border-0 font-style text-gray-700 font-size-12',
               { 'w-100': enableInContextSidebar })}
             onClick={() => handleResponseCommentButton()}
             disabled={isClosedPost}

--- a/src/discussions/discussions-home/DiscussionsHome.jsx
+++ b/src/discussions/discussions-home/DiscussionsHome.jsx
@@ -87,7 +87,7 @@ export default function DiscussionsHome() {
         >
           <div
             className={classNames('d-flex flex-row justify-content-between navbar fixed-top', {
-              'pl-4 pr-2.5 py-1.5': enableInContextSidebar,
+              'pl-4 pr-3 py-0': enableInContextSidebar,
             })}
           >
             {!enableInContextSidebar && <Route path={Routes.DISCUSSIONS.PATH} component={NavigationBar} />}
@@ -120,7 +120,7 @@ export default function DiscussionsHome() {
                 path={[Routes.POSTS.PATH, Routes.POSTS.ALL_POSTS, Routes.LEARNERS.POSTS]}
                 render={routeProps => <EmptyPosts {...routeProps} subTitleMessage={messages.emptyAllPosts} />}
               />
-              {isRedirectToLearners && <Route path={Routes.LEARNERS.PATH} component={EmptyLearners} /> }
+              {isRedirectToLearners && <Route path={Routes.LEARNERS.PATH} component={EmptyLearners} />}
             </Switch>
           )}
         </div>

--- a/src/discussions/learners/LearnerPostsView.jsx
+++ b/src/discussions/learners/LearnerPostsView.jsx
@@ -88,7 +88,7 @@ function LearnerPostsView({ intl }) {
           onClick={() => history.push(discussionsPath(Routes.LEARNERS.PATH, { courseId })(location))}
           alt={intl.formatMessage(messages.back)}
         />
-        <div className="text-primary-500 font-style-normal font-family-inter font-weight-bold py-2.5">
+        <div className="text-primary-500 font-style font-weight-bold py-2.5">
           {intl.formatMessage(messages.activityForLearner, { username: capitalize(username) })}
         </div>
         <div style={{ padding: '18px' }} />

--- a/src/discussions/learners/learner/LearnerCard.jsx
+++ b/src/discussions/learners/learner/LearnerCard.jsx
@@ -40,7 +40,7 @@ function LearnerCard({
           <div className="d-flex flex-column justify-content-start mw-100 flex-fill">
             <div className="d-flex align-items-center flex-fill">
               <div
-                className="text-truncate font-weight-500 font-size-14 text-primary-500 font-style-normal font-family-inter"
+                className="text-truncate font-weight-500 font-size-14 text-primary-500 font-style"
               >
                 {learner.username}
               </div>

--- a/src/discussions/posts/post-actions-bar/PostActionsBar.jsx
+++ b/src/discussions/posts/post-actions-bar/PostActionsBar.jsx
@@ -51,13 +51,10 @@ function PostActionsBar({
           {!enableInContextSidebar && <div className="border-right border-light-400 mx-3" />}
           <Button
             variant={enableInContextSidebar ? 'plain' : 'brand'}
-            className={classNames('my-0 font-style', { 'px-3 py-10px border-0': enableInContextSidebar })}
+            className={classNames('my-0 font-style border-0 line-height-24',
+              { 'px-3 py-10px border-0': enableInContextSidebar })}
             onClick={() => dispatch(showPostEditor())}
             size={enableInContextSidebar ? 'md' : 'sm'}
-            style={{
-              lineHeight: '24px',
-              border: '0px',
-            }}
           >
             {intl.formatMessage(messages.addAPost)}
           </Button>

--- a/src/discussions/posts/post-actions-bar/PostActionsBar.jsx
+++ b/src/discussions/posts/post-actions-bar/PostActionsBar.jsx
@@ -42,33 +42,41 @@ function PostActionsBar({
           : <Search />
       )}
       {enableInContextSidebar && (
-        <h4 className="d-flex flex-grow-1 font-weight-bold my-0 py-0 align-self-center">
+        <h4 className="d-flex flex-grow-1 font-weight-bold fontStyle my-0 py-10px align-self-center">
           {intl.formatMessage(messages.title)}
         </h4>
       )}
       {loadingStatus === RequestStatus.SUCCESSFUL && userCanAddThreadInBlackoutDate
-      && (
-        <>
-          {!enableInContextSidebar && <div className="border-right border-light-400 mx-3" />}
-          <Button
-            variant={enableInContextSidebar ? 'plain' : 'brand'}
-            className={classNames('my-0', { 'p-0': enableInContextSidebar })}
-            onClick={() => dispatch(showPostEditor())}
-            size={enableInContextSidebar ? 'md' : 'sm'}
-          >
-            {intl.formatMessage(messages.addAPost)}
-          </Button>
-        </>
-      )}
+        && (
+          <>
+            {!enableInContextSidebar && <div className="border-right border-light-400 mx-3" />}
+            <Button
+              variant={enableInContextSidebar ? 'plain' : 'brand'}
+              className={classNames('my-0 fontStyle', { 'px-3 py-10px border-0': enableInContextSidebar })}
+              onClick={() => dispatch(showPostEditor())}
+              size={enableInContextSidebar ? 'md' : 'sm'}
+              style={{
+                lineHeight: '24px',
+                border: '0px',
+              }}
+            >
+              {intl.formatMessage(messages.addAPost)}
+            </Button>
+          </>
+        )}
       {enableInContextSidebar && (
         <>
-          <div className="border-right border-light-300 mr-2 ml-3.5 my-2" />
-          <IconButton
-            src={Close}
-            iconAs={Icon}
-            onClick={handleCloseInContext}
-            alt={intl.formatMessage(messages.close)}
-          />
+          <div className="border-right border-light-300 mr-3 ml-1.5 my-10px" />
+          <div className="justify-content-center mt-2.5 mx-3px">
+            <IconButton
+              src={Close}
+              iconAs={Icon}
+              onClick={handleCloseInContext}
+              alt={intl.formatMessage(messages.close)}
+              iconClassNames="spinner-dimentions"
+              className="spinner-dimentions"
+            />
+          </div>
         </>
       )}
     </div>

--- a/src/discussions/posts/post-actions-bar/PostActionsBar.jsx
+++ b/src/discussions/posts/post-actions-bar/PostActionsBar.jsx
@@ -42,28 +42,27 @@ function PostActionsBar({
           : <Search />
       )}
       {enableInContextSidebar && (
-        <h4 className="d-flex flex-grow-1 font-weight-bold fontStyle my-0 py-10px align-self-center">
+        <h4 className="d-flex flex-grow-1 font-weight-bold font-style my-0 py-10px align-self-center">
           {intl.formatMessage(messages.title)}
         </h4>
       )}
-      {loadingStatus === RequestStatus.SUCCESSFUL && userCanAddThreadInBlackoutDate
-        && (
-          <>
-            {!enableInContextSidebar && <div className="border-right border-light-400 mx-3" />}
-            <Button
-              variant={enableInContextSidebar ? 'plain' : 'brand'}
-              className={classNames('my-0 fontStyle', { 'px-3 py-10px border-0': enableInContextSidebar })}
-              onClick={() => dispatch(showPostEditor())}
-              size={enableInContextSidebar ? 'md' : 'sm'}
-              style={{
-                lineHeight: '24px',
-                border: '0px',
-              }}
-            >
-              {intl.formatMessage(messages.addAPost)}
-            </Button>
-          </>
-        )}
+      {loadingStatus === RequestStatus.SUCCESSFUL && userCanAddThreadInBlackoutDate && (
+        <>
+          {!enableInContextSidebar && <div className="border-right border-light-400 mx-3" />}
+          <Button
+            variant={enableInContextSidebar ? 'plain' : 'brand'}
+            className={classNames('my-0 font-style', { 'px-3 py-10px border-0': enableInContextSidebar })}
+            onClick={() => dispatch(showPostEditor())}
+            size={enableInContextSidebar ? 'md' : 'sm'}
+            style={{
+              lineHeight: '24px',
+              border: '0px',
+            }}
+          >
+            {intl.formatMessage(messages.addAPost)}
+          </Button>
+        </>
+      )}
       {enableInContextSidebar && (
         <>
           <div className="border-right border-light-300 mr-3 ml-1.5 my-10px" />

--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -257,29 +257,30 @@ function PostEditor({
       initialValues={initialValues}
       validationSchema={validationSchema}
       onSubmit={submitForm}
-    >{({
-      values,
-      errors,
-      touched,
-      handleSubmit,
-      handleBlur,
-      handleChange,
-      resetForm,
-    }) => (
-      <Form className="m-4 card p-4 post-form" onSubmit={handleSubmit}>
-        <h4 className="mb-4 font-style font-size-16" style={{ lineHeight: '16px' }}>
-          {editExisting
-            ? intl.formatMessage(messages.editPostHeading) : intl.formatMessage(messages.addPostHeading)}
-        </h4>
-        <Form.RadioSet
-          name="postType"
-          className="d-flex flex-row flex-wrap"
-          value={values.postType}
-          onChange={handleChange}
-          onBlur={handleBlur}
-          aria-label={intl.formatMessage(messages.postTitle)}
-        >
-          <div className="d-flex float-left" style={{ width: '100%' }}>
+    >{
+      ({
+        values,
+        errors,
+        touched,
+        handleSubmit,
+        handleBlur,
+        handleChange,
+        resetForm,
+      }) => (
+        <Form className="m-4 card p-4 post-form" onSubmit={handleSubmit}>
+          <h4 className="mb-4 font-style font-size-16" style={{ lineHeight: '16px' }}>
+            {editExisting
+              ? intl.formatMessage(messages.editPostHeading)
+              : intl.formatMessage(messages.addPostHeading)}
+          </h4>
+          <Form.RadioSet
+            name="postType"
+            className="d-flex flex-row flex-wrap"
+            value={values.postType}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            aria-label={intl.formatMessage(messages.postTitle)}
+          >
             <DiscussionPostType
               value="discussion"
               selected={values.postType === 'discussion'}
@@ -292,210 +293,210 @@ function PostEditor({
               type={intl.formatMessage(messages.questionType)}
               icon={<Help />}
             />
-          </div>
-        </Form.RadioSet>
-        <div className="d-flex flex-row my-4.5 justify-content-between">
-          <Form.Group className="w-100 m-0">
-            <Form.Control
-              className="m-0"
-              name="topic"
-              as="select"
-              value={values.topic}
-              onChange={handleChange}
-              onBlur={handleBlur}
-              aria-describedby="topicAreaInput"
-              floatingLabel={intl.formatMessage(messages.topicArea)}
-              disabled={enableInContextSidebar}
-            >
-              {nonCoursewareTopics.map(topic => (
-                <option
-                  key={topic.id}
-                  value={topic.id}
-                >{topic.name || intl.formatMessage(messages.unnamedSubTopics)}
-                </option>
-              ))}
-              {enableInContext ? (
-                <>
-                  {coursewareTopics?.map(section => (
-                    section?.children?.map(subsection => (
-                      <optgroup
-                        label={handleInContextSelectLabel(section, subsection)}
-                        key={subsection.id}
-                      >
-                        {subsection?.children?.map(unit => (
-                          <option key={unit.id} value={unit.id}>
-                            {unit.name || intl.formatMessage(messages.unnamedSubTopics)}
+          </Form.RadioSet>
+          <div className="d-flex flex-row my-4.5 justify-content-between">
+            <Form.Group className="w-100 m-0">
+              <Form.Control
+                className="m-0"
+                name="topic"
+                as="select"
+                value={values.topic}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                aria-describedby="topicAreaInput"
+                floatingLabel={intl.formatMessage(messages.topicArea)}
+                disabled={enableInContextSidebar}
+              >
+                {nonCoursewareTopics.map(topic => (
+                  <option
+                    key={topic.id}
+                    value={topic.id}
+                  >{topic.name || intl.formatMessage(messages.unnamedSubTopics)}
+                  </option>
+                ))}
+                {enableInContext ? (
+                  <>
+                    {coursewareTopics?.map(section => (
+                      section?.children?.map(subsection => (
+                        <optgroup
+                          label={handleInContextSelectLabel(section, subsection)}
+                          key={subsection.id}
+                        >
+                          {subsection?.children?.map(unit => (
+                            <option key={unit.id} value={unit.id}>
+                              {unit.name || intl.formatMessage(messages.unnamedSubTopics)}
+                            </option>
+                          ))}
+                        </optgroup>
+                      ))
+                    ))}
+                    {(userIsStaff || userIsGroupTa || userHasModerationPrivileges) && (
+                      <optgroup label={intl.formatMessage(messages.archivedTopics)}>
+                        {archivedTopics.map(topic => (
+                          <option key={topic.id} value={topic.id}>
+                            {topic.name || intl.formatMessage(messages.unnamedSubTopics)}
                           </option>
                         ))}
                       </optgroup>
-                    ))
-                  ))}
-                  {(userIsStaff || userIsGroupTa || userHasModerationPrivileges) && (
-                    <optgroup label={intl.formatMessage(messages.archivedTopics)}>
-                      {archivedTopics.map(topic => (
-                        <option key={topic.id} value={topic.id}>
-                          {topic.name || intl.formatMessage(messages.unnamedSubTopics)}
+                    )}
+                  </>
+                ) : (
+                  coursewareTopics.map(categoryObj => (
+                    <optgroup
+                      label={categoryObj.name || intl.formatMessage(messages.unnamedTopics)}
+                      key={categoryObj.id}
+                    >
+                      {categoryObj.topics.map(subtopic => (
+                        <option key={subtopic.id} value={subtopic.id}>
+                          {subtopic.name || intl.formatMessage(messages.unnamedSubTopics)}
                         </option>
                       ))}
                     </optgroup>
-                  )}
-                </>
-              ) : (
-                coursewareTopics.map(categoryObj => (
-                  <optgroup
-                    label={categoryObj.name || intl.formatMessage(messages.unnamedTopics)}
-                    key={categoryObj.id}
-                  >
-                    {categoryObj.topics.map(subtopic => (
-                      <option key={subtopic.id} value={subtopic.id}>
-                        {subtopic.name || intl.formatMessage(messages.unnamedSubTopics)}
-                      </option>
-                    ))}
-                  </optgroup>
-                ))
-              )}
-            </Form.Control>
-          </Form.Group>
-          {canSelectCohort(values.topic) && (
-            <Form.Group className="w-100 ml-3 mb-0">
-              <Form.Control
-                className="m-0"
-                name="cohort"
-                as="select"
-                value={values.cohort}
-                onChange={handleChange}
-                onBlur={handleBlur}
-                aria-describedby="cohortAreaInput"
-                floatingLabel={intl.formatMessage(messages.cohortVisibility)}
-              >
-                <option value="default">{intl.formatMessage(messages.cohortVisibilityAllLearners)}</option>
-                {cohorts.map(cohort => (
-                  <option key={cohort.id} value={cohort.id}>{cohort.name}</option>
-                ))}
+                  ))
+                )}
               </Form.Control>
             </Form.Group>
-          )}
-        </div>
+            {canSelectCohort(values.topic) && (
+              <Form.Group className="w-100 ml-3 mb-0">
+                <Form.Control
+                  className="m-0"
+                  name="cohort"
+                  as="select"
+                  value={values.cohort}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  aria-describedby="cohortAreaInput"
+                  floatingLabel={intl.formatMessage(messages.cohortVisibility)}
+                >
+                  <option value="default">{intl.formatMessage(messages.cohortVisibilityAllLearners)}</option>
+                  {cohorts.map(cohort => (
+                    <option key={cohort.id} value={cohort.id}>{cohort.name}</option>
+                  ))}
+                </Form.Control>
+              </Form.Group>
+            )}
+          </div>
 
-        <div className="d-flex flex-row mb-4.5 justify-content-between">
-          <Form.Group
-            className="w-100 m-0"
-            isInvalid={isFormikFieldInvalid('title', {
-              errors,
-              touched,
-            })}
-          >
-            <Form.Control
-              className="m-0"
-              name="title"
-              type="text"
-              onChange={handleChange}
-              onBlur={handleBlur}
-              aria-describedby="titleInput"
-              floatingLabel={intl.formatMessage(messages.postTitle)}
-              value={values.title}
-            />
-            <FormikErrorFeedback name="title" />
-          </Form.Group>
-          {canDisplayEditReason && (
+          <div className="d-flex flex-row mb-4.5 justify-content-between">
             <Form.Group
-              className="w-100 ml-4 mb-0"
-              isInvalid={isFormikFieldInvalid('editReasonCode', {
+              className="w-100 m-0"
+              isInvalid={isFormikFieldInvalid('title', {
                 errors,
                 touched,
               })}
             >
               <Form.Control
-                name="editReasonCode"
                 className="m-0"
-                as="select"
-                value={values.editReasonCode}
+                name="title"
+                type="text"
                 onChange={handleChange}
                 onBlur={handleBlur}
-                aria-describedby="editReasonCodeInput"
-                floatingLabel={intl.formatMessage(messages.editReasonCode)}
-              >
-                <option key="empty" value="">---</option>
-                {editReasons.map(({ code, label }) => (
-                  <option key={code} value={code}>{label}</option>
-                ))}
-              </Form.Control>
-              <FormikErrorFeedback name="editReasonCode" />
+                aria-describedby="titleInput"
+                floatingLabel={intl.formatMessage(messages.postTitle)}
+                value={values.title}
+              />
+              <FormikErrorFeedback name="title" />
             </Form.Group>
-          )}
-        </div>
-        <div className="mb-3">
-          <TinyMCEEditor
-            onInit={
-              /* istanbul ignore next: TinyMCE is mocked so this cannot be easily tested */
-              (_, editor) => {
-                editorRef.current = editor;
-              }
-            }
-            id={postEditorId}
-            value={values.comment}
-            onEditorChange={formikCompatibleHandler(handleChange, 'comment')}
-            onBlur={formikCompatibleHandler(handleBlur, 'comment')}
-          />
-          <FormikErrorFeedback name="comment" />
-        </div>
-
-        <PostPreviewPane htmlNode={values.comment} isPost editExisting={editExisting} />
-
-        <div className="d-flex flex-row mt-n4 w-75 text-primary font-style">
-          {!editExisting && (
-            <>
-              <Form.Group>
-                <Form.Checkbox
-                  name="follow"
-                  checked={values.follow}
+            {canDisplayEditReason && (
+              <Form.Group
+                className="w-100 ml-4 mb-0"
+                isInvalid={isFormikFieldInvalid('editReasonCode', {
+                  errors,
+                  touched,
+                })}
+              >
+                <Form.Control
+                  name="editReasonCode"
+                  className="m-0"
+                  as="select"
+                  value={values.editReasonCode}
                   onChange={handleChange}
                   onBlur={handleBlur}
-                  className="mr-4.5"
+                  aria-describedby="editReasonCodeInput"
+                  floatingLabel={intl.formatMessage(messages.editReasonCode)}
                 >
-                  <span className="font-size-14">
-                    {intl.formatMessage(messages.followPost)}
-                  </span>
-                </Form.Checkbox>
+                  <option key="empty" value="">---</option>
+                  {editReasons.map(({ code, label }) => (
+                    <option key={code} value={code}>{label}</option>
+                  ))}
+                </Form.Control>
+                <FormikErrorFeedback name="editReasonCode" />
               </Form.Group>
-              {allowAnonymousToPeers && (
+            )}
+          </div>
+          <div className="mb-3">
+            <TinyMCEEditor
+              onInit={
+                /* istanbul ignore next: TinyMCE is mocked so this cannot be easily tested */
+                (_, editor) => {
+                  editorRef.current = editor;
+                }
+              }
+              id={postEditorId}
+              value={values.comment}
+              onEditorChange={formikCompatibleHandler(handleChange, 'comment')}
+              onBlur={formikCompatibleHandler(handleBlur, 'comment')}
+            />
+            <FormikErrorFeedback name="comment" />
+          </div>
+
+          <PostPreviewPane htmlNode={values.comment} isPost editExisting={editExisting} />
+
+          <div className="d-flex flex-row mt-n4 w-75 text-primary font-style">
+            {!editExisting && (
+              <>
                 <Form.Group>
                   <Form.Checkbox
-                    name="anonymousToPeers"
-                    checked={values.anonymousToPeers}
+                    name="follow"
+                    checked={values.follow}
                     onChange={handleChange}
                     onBlur={handleBlur}
+                    className="mr-4.5"
                   >
                     <span className="font-size-14">
-                      {intl.formatMessage(messages.anonymousToPeersPost)}
+                      {intl.formatMessage(messages.followPost)}
                     </span>
                   </Form.Checkbox>
                 </Form.Group>
-              )}
-            </>
-          )}
-        </div>
+                {allowAnonymousToPeers && (
+                  <Form.Group>
+                    <Form.Checkbox
+                      name="anonymousToPeers"
+                      checked={values.anonymousToPeers}
+                      onChange={handleChange}
+                      onBlur={handleBlur}
+                    >
+                      <span className="font-size-14">
+                        {intl.formatMessage(messages.anonymousToPeersPost)}
+                      </span>
+                    </Form.Checkbox>
+                  </Form.Group>
+                )}
+              </>
+            )}
+          </div>
 
-        <div className="d-flex justify-content-end">
-          <Button
-            variant="outline-primary"
-            onClick={() => hideEditor(resetForm)}
-          >
-            {intl.formatMessage(messages.cancel)}
-          </Button>
-          <StatefulButton
-            labels={{
-              default: intl.formatMessage(messages.submit),
-              pending: intl.formatMessage(messages.submitting),
-            }}
-            state={submitting ? 'pending' : 'default'}
-            className="ml-2"
-            variant="primary"
-            onClick={handleSubmit}
-          />
-        </div>
-      </Form>
-    )}
+          <div className="d-flex justify-content-end">
+            <Button
+              variant="outline-primary"
+              onClick={() => hideEditor(resetForm)}
+            >
+              {intl.formatMessage(messages.cancel)}
+            </Button>
+            <StatefulButton
+              labels={{
+                default: intl.formatMessage(messages.submit),
+                pending: intl.formatMessage(messages.submitting),
+              }}
+              state={submitting ? 'pending' : 'default'}
+              className="ml-2"
+              variant="primary"
+              onClick={handleSubmit}
+            />
+          </div>
+        </Form>
+      )
+      }
     </Formik>
   );
 }

--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -54,9 +54,9 @@ function DiscussionPostType({
   value,
   type,
   selected,
-  description,
   icon,
 }) {
+  const { enableInContextSidebar } = useContext(DiscussionContext);
   // Need to use regular label since Form.Label doesn't support overriding htmlFor
   return (
     <label htmlFor={`post-type-${value}`} className="d-flex p-0 my-0 mr-3">
@@ -66,12 +66,11 @@ function DiscussionPostType({
           'border-primary': selected,
           'border-light-400': !selected,
         })}
-        style={{ cursor: 'pointer', width: '14.25rem' }}
+        style={{ cursor: 'pointer', width: `${enableInContextSidebar ? '10.021rem' : '14.25rem'}` }}
       >
-        <Card.Section className="py-3 px-10px d-flex flex-column align-items-center">
+        <Card.Section className="px-4 py-3 d-flex flex-column align-items-center">
           <span className="text-primary-300 mb-0.5">{icon}</span>
-          <span className="text-gray-700 mb-0.5">{type}</span>
-          <span className="x-small text-gray-500">{description}</span>
+          <span className="text-gray-700">{type}</span>
         </Card.Section>
       </Card>
     </label>
@@ -82,7 +81,6 @@ DiscussionPostType.propTypes = {
   value: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   selected: PropTypes.bool.isRequired,
-  description: PropTypes.string.isRequired,
   icon: PropTypes.element.isRequired,
 };
 
@@ -259,30 +257,29 @@ function PostEditor({
       initialValues={initialValues}
       validationSchema={validationSchema}
       onSubmit={submitForm}
-    >{
-      ({
-        values,
-        errors,
-        touched,
-        handleSubmit,
-        handleBlur,
-        handleChange,
-        resetForm,
-      }) => (
-        <Form className="m-4 card p-4 post-form" onSubmit={handleSubmit}>
-          <h4 className="mb-4" style={{ lineHeight: '16px' }}>
-            {editExisting
-              ? intl.formatMessage(messages.editPostHeading)
-              : intl.formatMessage(messages.addPostHeading)}
-          </h4>
-          <Form.RadioSet
-            name="postType"
-            className="d-flex flex-row flex-wrap"
-            value={values.postType}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            aria-label={intl.formatMessage(messages.postTitle)}
-          >
+    >{({
+      values,
+      errors,
+      touched,
+      handleSubmit,
+      handleBlur,
+      handleChange,
+      resetForm,
+    }) => (
+      <Form className="m-4 card p-4 post-form" onSubmit={handleSubmit}>
+        <h4 className="mb-4 font-style font-size-16" style={{ lineHeight: '16px' }}>
+          {editExisting
+            ? intl.formatMessage(messages.editPostHeading) : intl.formatMessage(messages.addPostHeading)}
+        </h4>
+        <Form.RadioSet
+          name="postType"
+          className="d-flex flex-row flex-wrap"
+          value={values.postType}
+          onChange={handleChange}
+          onBlur={handleBlur}
+          aria-label={intl.formatMessage(messages.postTitle)}
+        >
+          <div className="d-flex float-left" style={{ width: '100%' }}>
             <DiscussionPostType
               value="discussion"
               selected={values.postType === 'discussion'}
@@ -295,172 +292,173 @@ function PostEditor({
               type={intl.formatMessage(messages.questionType)}
               icon={<Help />}
             />
-          </Form.RadioSet>
-          <div className="d-flex flex-row my-4.5 justify-content-between">
-            <Form.Group className="w-100 m-0">
-              <Form.Control
-                className="m-0"
-                name="topic"
-                as="select"
-                value={values.topic}
-                onChange={handleChange}
-                onBlur={handleBlur}
-                aria-describedby="topicAreaInput"
-                floatingLabel={intl.formatMessage(messages.topicArea)}
-                disabled={enableInContextSidebar}
-              >
-                {nonCoursewareTopics.map(topic => (
-                  <option
-                    key={topic.id}
-                    value={topic.id}
-                  >{topic.name || intl.formatMessage(messages.unnamedSubTopics)}
-                  </option>
-                ))}
-                {enableInContext ? (
-                  <>
-                    {coursewareTopics?.map(section => (
-                      section?.children?.map(subsection => (
-                        <optgroup
-                          label={handleInContextSelectLabel(section, subsection)}
-                          key={subsection.id}
-                        >
-                          {subsection?.children?.map(unit => (
-                            <option key={unit.id} value={unit.id}>
-                              {unit.name || intl.formatMessage(messages.unnamedSubTopics)}
-                            </option>
-                          ))}
-                        </optgroup>
-                      ))
-                    ))}
-                    {(userIsStaff || userIsGroupTa || userHasModerationPrivileges) && (
-                      <optgroup label={intl.formatMessage(messages.archivedTopics)}>
-                        {archivedTopics.map(topic => (
-                          <option key={topic.id} value={topic.id}>
-                            {topic.name || intl.formatMessage(messages.unnamedSubTopics)}
+          </div>
+        </Form.RadioSet>
+        <div className="d-flex flex-row my-4.5 justify-content-between">
+          <Form.Group className="w-100 m-0">
+            <Form.Control
+              className="m-0"
+              name="topic"
+              as="select"
+              value={values.topic}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              aria-describedby="topicAreaInput"
+              floatingLabel={intl.formatMessage(messages.topicArea)}
+              disabled={enableInContextSidebar}
+            >
+              {nonCoursewareTopics.map(topic => (
+                <option
+                  key={topic.id}
+                  value={topic.id}
+                >{topic.name || intl.formatMessage(messages.unnamedSubTopics)}
+                </option>
+              ))}
+              {enableInContext ? (
+                <>
+                  {coursewareTopics?.map(section => (
+                    section?.children?.map(subsection => (
+                      <optgroup
+                        label={handleInContextSelectLabel(section, subsection)}
+                        key={subsection.id}
+                      >
+                        {subsection?.children?.map(unit => (
+                          <option key={unit.id} value={unit.id}>
+                            {unit.name || intl.formatMessage(messages.unnamedSubTopics)}
                           </option>
                         ))}
                       </optgroup>
-                    )}
-                  </>
-                ) : (
-                  coursewareTopics.map(categoryObj => (
-                    <optgroup
-                      label={categoryObj.name || intl.formatMessage(messages.unnamedTopics)}
-                      key={categoryObj.id}
-                    >
-                      {categoryObj.topics.map(subtopic => (
-                        <option key={subtopic.id} value={subtopic.id}>
-                          {subtopic.name || intl.formatMessage(messages.unnamedSubTopics)}
+                    ))
+                  ))}
+                  {(userIsStaff || userIsGroupTa || userHasModerationPrivileges) && (
+                    <optgroup label={intl.formatMessage(messages.archivedTopics)}>
+                      {archivedTopics.map(topic => (
+                        <option key={topic.id} value={topic.id}>
+                          {topic.name || intl.formatMessage(messages.unnamedSubTopics)}
                         </option>
                       ))}
                     </optgroup>
-                  ))
-                )}
+                  )}
+                </>
+              ) : (
+                coursewareTopics.map(categoryObj => (
+                  <optgroup
+                    label={categoryObj.name || intl.formatMessage(messages.unnamedTopics)}
+                    key={categoryObj.id}
+                  >
+                    {categoryObj.topics.map(subtopic => (
+                      <option key={subtopic.id} value={subtopic.id}>
+                        {subtopic.name || intl.formatMessage(messages.unnamedSubTopics)}
+                      </option>
+                    ))}
+                  </optgroup>
+                ))
+              )}
+            </Form.Control>
+          </Form.Group>
+          {canSelectCohort(values.topic) && (
+            <Form.Group className="w-100 ml-3 mb-0">
+              <Form.Control
+                className="m-0"
+                name="cohort"
+                as="select"
+                value={values.cohort}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                aria-describedby="cohortAreaInput"
+                floatingLabel={intl.formatMessage(messages.cohortVisibility)}
+              >
+                <option value="default">{intl.formatMessage(messages.cohortVisibilityAllLearners)}</option>
+                {cohorts.map(cohort => (
+                  <option key={cohort.id} value={cohort.id}>{cohort.name}</option>
+                ))}
               </Form.Control>
             </Form.Group>
-            {canSelectCohort(values.topic) && (
-              <Form.Group className="w-100 ml-3 mb-0">
-                <Form.Control
-                  className="m-0"
-                  name="cohort"
-                  as="select"
-                  value={values.cohort}
-                  onChange={handleChange}
-                  onBlur={handleBlur}
-                  aria-describedby="cohortAreaInput"
-                  floatingLabel={intl.formatMessage(messages.cohortVisibility)}
-                >
-                  <option value="default">{intl.formatMessage(messages.cohortVisibilityAllLearners)}</option>
-                  {cohorts.map(cohort => (
-                    <option key={cohort.id} value={cohort.id}>{cohort.name}</option>
-                  ))}
-                </Form.Control>
-              </Form.Group>
-            )}
-          </div>
+          )}
+        </div>
 
-          <div className="d-flex flex-row mb-4.5 justify-content-between">
+        <div className="d-flex flex-row mb-4.5 justify-content-between">
+          <Form.Group
+            className="w-100 m-0"
+            isInvalid={isFormikFieldInvalid('title', {
+              errors,
+              touched,
+            })}
+          >
+            <Form.Control
+              className="m-0"
+              name="title"
+              type="text"
+              onChange={handleChange}
+              onBlur={handleBlur}
+              aria-describedby="titleInput"
+              floatingLabel={intl.formatMessage(messages.postTitle)}
+              value={values.title}
+            />
+            <FormikErrorFeedback name="title" />
+          </Form.Group>
+          {canDisplayEditReason && (
             <Form.Group
-              className="w-100 m-0"
-              isInvalid={isFormikFieldInvalid('title', {
+              className="w-100 ml-4 mb-0"
+              isInvalid={isFormikFieldInvalid('editReasonCode', {
                 errors,
                 touched,
               })}
             >
               <Form.Control
+                name="editReasonCode"
                 className="m-0"
-                name="title"
-                type="text"
+                as="select"
+                value={values.editReasonCode}
                 onChange={handleChange}
                 onBlur={handleBlur}
-                aria-describedby="titleInput"
-                floatingLabel={intl.formatMessage(messages.postTitle)}
-                value={values.title}
-              />
-              <FormikErrorFeedback name="title" />
-            </Form.Group>
-            {canDisplayEditReason && (
-              <Form.Group
-                className="w-100 ml-4 mb-0"
-                isInvalid={isFormikFieldInvalid('editReasonCode', {
-                  errors,
-                  touched,
-                })}
+                aria-describedby="editReasonCodeInput"
+                floatingLabel={intl.formatMessage(messages.editReasonCode)}
               >
-                <Form.Control
-                  name="editReasonCode"
-                  className="m-0"
-                  as="select"
-                  value={values.editReasonCode}
+                <option key="empty" value="">---</option>
+                {editReasons.map(({ code, label }) => (
+                  <option key={code} value={code}>{label}</option>
+                ))}
+              </Form.Control>
+              <FormikErrorFeedback name="editReasonCode" />
+            </Form.Group>
+          )}
+        </div>
+        <div className="mb-3">
+          <TinyMCEEditor
+            onInit={
+              /* istanbul ignore next: TinyMCE is mocked so this cannot be easily tested */
+              (_, editor) => {
+                editorRef.current = editor;
+              }
+            }
+            id={postEditorId}
+            value={values.comment}
+            onEditorChange={formikCompatibleHandler(handleChange, 'comment')}
+            onBlur={formikCompatibleHandler(handleBlur, 'comment')}
+          />
+          <FormikErrorFeedback name="comment" />
+        </div>
+
+        <PostPreviewPane htmlNode={values.comment} isPost editExisting={editExisting} />
+
+        <div className="d-flex flex-row mt-n4 w-75 text-primary font-style">
+          {!editExisting && (
+            <>
+              <Form.Group>
+                <Form.Checkbox
+                  name="follow"
+                  checked={values.follow}
                   onChange={handleChange}
                   onBlur={handleBlur}
-                  aria-describedby="editReasonCodeInput"
-                  floatingLabel={intl.formatMessage(messages.editReasonCode)}
+                  className="mr-4.5"
                 >
-                  <option key="empty" value="">---</option>
-                  {editReasons.map(({ code, label }) => (
-                    <option key={code} value={code}>{label}</option>
-                  ))}
-                </Form.Control>
-                <FormikErrorFeedback name="editReasonCode" />
+                  <span className="font-size-14">
+                    {intl.formatMessage(messages.followPost)}
+                  </span>
+                </Form.Checkbox>
               </Form.Group>
-            )}
-          </div>
-          <div className="mb-3">
-            <TinyMCEEditor
-              onInit={
-                /* istanbul ignore next: TinyMCE is mocked so this cannot be easily tested */
-                (_, editor) => {
-                  editorRef.current = editor;
-                }
-              }
-              id={postEditorId}
-              value={values.comment}
-              onEditorChange={formikCompatibleHandler(handleChange, 'comment')}
-              onBlur={formikCompatibleHandler(handleBlur, 'comment')}
-            />
-            <FormikErrorFeedback name="comment" />
-          </div>
-
-          <PostPreviewPane htmlNode={values.comment} isPost editExisting={editExisting} />
-
-          <div className="d-flex flex-row mt-n4 w-75 text-primary">
-            {!editExisting && (
-              <>
-                <Form.Group>
-                  <Form.Checkbox
-                    name="follow"
-                    checked={values.follow}
-                    onChange={handleChange}
-                    onBlur={handleBlur}
-                    className="mr-4.5"
-                  >
-                    <span className="font-size-14">
-                      {intl.formatMessage(messages.followPost)}
-                    </span>
-                  </Form.Checkbox>
-                </Form.Group>
-                {allowAnonymousToPeers && (
+              {allowAnonymousToPeers && (
                 <Form.Group>
                   <Form.Checkbox
                     name="anonymousToPeers"
@@ -473,32 +471,31 @@ function PostEditor({
                     </span>
                   </Form.Checkbox>
                 </Form.Group>
-                )}
-              </>
-            )}
-          </div>
+              )}
+            </>
+          )}
+        </div>
 
-          <div className="d-flex justify-content-end">
-            <Button
-              variant="outline-primary"
-              onClick={() => hideEditor(resetForm)}
-            >
-              {intl.formatMessage(messages.cancel)}
-            </Button>
-            <StatefulButton
-              labels={{
-                default: intl.formatMessage(messages.submit),
-                pending: intl.formatMessage(messages.submitting),
-              }}
-              state={submitting ? 'pending' : 'default'}
-              className="ml-2"
-              variant="primary"
-              onClick={handleSubmit}
-            />
-          </div>
-        </Form>
-      )
-    }
+        <div className="d-flex justify-content-end">
+          <Button
+            variant="outline-primary"
+            onClick={() => hideEditor(resetForm)}
+          >
+            {intl.formatMessage(messages.cancel)}
+          </Button>
+          <StatefulButton
+            labels={{
+              default: intl.formatMessage(messages.submit),
+              pending: intl.formatMessage(messages.submitting),
+            }}
+            state={submitting ? 'pending' : 'default'}
+            className="ml-2"
+            variant="primary"
+            onClick={handleSubmit}
+          />
+        </div>
+      </Form>
+    )}
     </Formik>
   );
 }

--- a/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
+++ b/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
@@ -76,7 +76,7 @@ function PostFilterBar({
 
   const selectedCohort = useMemo(() => cohorts.find(cohort => (
     toString(cohort.id) === currentFilters.cohort)),
-  [currentFilters.cohort]);
+    [currentFilters.cohort]);
 
   const handleSortFilterChange = (event) => {
     const currentType = currentFilters.postType;
@@ -138,7 +138,7 @@ function PostFilterBar({
       className="filter-bar collapsible-card-lg border-0"
     >
       <Collapsible.Trigger className="collapsible-trigger border-0">
-        <span className="text-primary-700 pr-4">
+        <span className="text-primary-500 pr-4 fontStyle">
           {intl.formatMessage(messages.sortFilterStatus, {
             own: false,
             type: currentFilters.postType,

--- a/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
+++ b/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
@@ -71,11 +71,10 @@ function PostFilterBar({
   const currentFilters = useSelector(selectThreadFilters());
   const { status } = useSelector(state => state.cohorts);
   const cohorts = useSelector(selectCourseCohorts);
-
-  const [isOpen, setOpen] = useState(false);
-
   const selectedCohort = useMemo(() => cohorts.find(cohort => (
-    toString(cohort.id) === currentFilters.cohort)), [currentFilters.cohort]);
+    toString(cohort.id) === currentFilters.cohort)),
+    [currentFilters.cohort]);
+  const [isOpen, setOpen] = useState(false);
 
   const handleSortFilterChange = (event) => {
     const currentType = currentFilters.postType;
@@ -137,7 +136,7 @@ function PostFilterBar({
       className="filter-bar collapsible-card-lg border-0"
     >
       <Collapsible.Trigger className="collapsible-trigger border-0">
-        <span className="text-primary-500 pr-4 fontStyle">
+        <span className="text-primary-500 pr-4 font-style">
           {intl.formatMessage(messages.sortFilterStatus, {
             own: false,
             type: currentFilters.postType,

--- a/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
+++ b/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
@@ -75,8 +75,7 @@ function PostFilterBar({
   const [isOpen, setOpen] = useState(false);
 
   const selectedCohort = useMemo(() => cohorts.find(cohort => (
-    toString(cohort.id) === currentFilters.cohort)),
-    [currentFilters.cohort]);
+    toString(cohort.id) === currentFilters.cohort)), [currentFilters.cohort]);
 
   const handleSortFilterChange = (event) => {
     const currentType = currentFilters.postType;

--- a/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
+++ b/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
@@ -71,10 +71,11 @@ function PostFilterBar({
   const currentFilters = useSelector(selectThreadFilters());
   const { status } = useSelector(state => state.cohorts);
   const cohorts = useSelector(selectCourseCohorts);
+  const [isOpen, setOpen] = useState(false);
+
   const selectedCohort = useMemo(() => cohorts.find(cohort => (
     toString(cohort.id) === currentFilters.cohort)),
-    [currentFilters.cohort]);
-  const [isOpen, setOpen] = useState(false);
+  [currentFilters.cohort]);
 
   const handleSortFilterChange = (event) => {
     const currentType = currentFilters.postType;

--- a/src/discussions/posts/post/LikeButton.jsx
+++ b/src/discussions/posts/post/LikeButton.jsx
@@ -41,7 +41,7 @@ function LikeButton({
           iconClassNames="like-icon-dimentions"
         />
       </OverlayTrigger>
-      <div className="font-family-inter font-style-normal">
+      <div className="font-style">
         {(count && count > 0) ? count : null}
       </div>
 

--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -136,12 +136,12 @@ function Post({
       )}
       <AlertBanner content={post} />
       <PostHeader post={post} />
-      <div className="d-flex mt-14px text-break font-style-normal font-family-inter text-primary-500">
+      <div className="d-flex mt-14px text-break font-style text-primary-500">
         <HTMLLoader htmlNode={post.renderedBody} componentId="post" cssClassName="html-loader" testId={post.id} />
       </div>
       {topicContext && topic && (
         <div
-          className={classNames('mt-14px mb-1 font-style-normal font-family-inter font-size-12',
+          className={classNames('mt-14px mb-1 font-style font-size-12',
             { 'w-100': enableInContextSidebar })}
           style={{ lineHeight: '20px' }}
         >

--- a/src/discussions/posts/post/PostHeader.jsx
+++ b/src/discussions/posts/post/PostHeader.jsx
@@ -108,7 +108,17 @@ function PostHeader({
                   && <Badge variant="success">{intl.formatMessage(messages.answered)}</Badge>}
               </div>
             )
-            : <h5 className="mb-0 font-style-normal font-family-inter text-primary-500" style={{ lineHeight: '21px' }} aria-level="1" tabIndex="-1" accessKey="h">{post.title}</h5>}
+            : (
+              <h5
+                className="mb-0 font-style text-primary-500"
+                style={{ lineHeight: '21px' }}
+                aria-level="1"
+                tabIndex="-1"
+                accessKey="h"
+              >
+                {post.title}
+              </h5>
+            )}
           <AuthorLabel
             author={post.author || intl.formatMessage(messages.anonymous)}
             authorLabel={post.authorLabel}

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -74,7 +74,7 @@ function PostLink({
                 <Truncate lines={1} className="mr-1.5" whiteSpace>
                   <span
                     class={
-                      classNames('font-weight-500 font-size-14 text-primary-500 font-style-normal font-family-inter align-bottom',
+                      classNames('font-weight-500 font-size-14 text-primary-500 font-style align-bottom',
                         { 'font-weight-bolder': !read })
                     }
                   >
@@ -82,7 +82,7 @@ function PostLink({
                   </span>
                   <span class="align-bottom"> </span>
                   <span
-                    class="text-gray-700 font-weight-normal font-size-14 font-style-normal font-family-inter align-bottom"
+                    class="text-gray-700 font-weight-normal font-size-14 font-style align-bottom"
                   >
                     {isPostPreviewAvailable(post.previewBody)
                       ? post.previewBody
@@ -109,7 +109,8 @@ function PostLink({
                 {post.pinned && (
                   <Icon
                     src={PushPin}
-                    className={`post-summary-icons-dimensions text-gray-700 ${canSeeReportedBadge || showAnsweredBadge ? 'ml-2' : 'ml-auto'}`}
+                    className={`post-summary-icons-dimensions text-gray-700
+                    ${canSeeReportedBadge || showAnsweredBadge ? 'ml-2' : 'ml-auto'}`}
                   />
                 )}
               </div>

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -74,9 +74,9 @@ function PostLink({
                 <Truncate lines={1} className="mr-1.5" whiteSpace>
                   <span
                     class={
-                        classNames('font-weight-500 font-size-14 text-primary-500 font-style-normal font-family-inter align-bottom',
-                          { 'font-weight-bolder': !read })
-                      }
+                      classNames('font-weight-500 font-size-14 text-primary-500 font-style-normal font-family-inter align-bottom',
+                        { 'font-weight-bolder': !read })
+                    }
                   >
                     {post.title}
                   </span>
@@ -107,10 +107,10 @@ function PostLink({
                 )}
 
                 {post.pinned && (
-                <Icon
-                  src={PushPin}
-                  className={`post-summary-icons-dimensions text-gray-700 ${canSeeReportedBadge || showAnsweredBadge ? 'ml-2' : 'ml-auto'}`}
-                />
+                  <Icon
+                    src={PushPin}
+                    className={`post-summary-icons-dimensions text-gray-700 ${canSeeReportedBadge || showAnsweredBadge ? 'ml-2' : 'ml-auto'}`}
+                  />
                 )}
               </div>
             </div>

--- a/src/discussions/posts/post/PostSummaryFooter.jsx
+++ b/src/discussions/posts/post/PostSummaryFooter.jsx
@@ -27,7 +27,7 @@ function PostSummaryFooter({
   const userHasModerationPrivileges = useSelector(selectUserHasModerationPrivileges);
   timeago.register('time-locale', timeLocale);
   return (
-    <div className="d-flex align-items-center text-gray-700">
+    <div className="d-flex align-items-center text-gray-700" style={{ height: '24px' }}>
       <div className="d-flex align-items-center mr-4.5">
         <OverlayTrigger
           overlay={(
@@ -53,12 +53,14 @@ function PostSummaryFooter({
         )}
       >
         <Icon src={post.following ? StarFilled : StarOutline} className="post-summary-icons-dimensions mr-0.5">
-          <span className="sr-only">{' '}{intl.formatMessage(post.following ? messages.srOnlyFollowDescription : messages.srOnlyUnFollowDescription)}</span>
+          <span className="sr-only">
+            {' '}{intl.formatMessage(post.following ? messages.srOnlyFollowDescription : messages.srOnlyUnFollowDescription)}
+          </span>
         </Icon>
       </OverlayTrigger>
 
       {preview && post.commentCount > 1 && (
-        <div className="d-flex align-items-center ml-4.5">
+        <div className="d-flex align-items-center ml-4.5 text-gray-700 font-style font-size-12">
           <OverlayTrigger
             overlay={(
               <Tooltip id={`follow-${post.id}-tooltip`}>
@@ -68,7 +70,7 @@ function PostSummaryFooter({
           >
             <Icon
               src={post.unreadCommentCount ? QuestionAnswer : QuestionAnswerOutline}
-              className="post-summary-commentcount-dimensions mr-0.5"
+              className="post-summary-comment-count-dimensions mr-0.5"
             >
               <span className="sr-only">{' '} {intl.formatMessage(messages.activity)}</span>
             </Icon>

--- a/src/discussions/posts/post/PostSummaryFooter.jsx
+++ b/src/discussions/posts/post/PostSummaryFooter.jsx
@@ -40,7 +40,7 @@ function PostSummaryFooter({
             <span className="sr-only">{' '}{intl.formatMessage(post.voted ? messages.likedPost : messages.postLikes)}</span>
           </Icon>
         </OverlayTrigger>
-        <div className="font-family-inter font-style-normal">
+        <div className="font-style">
           {(post.voteCount && post.voteCount > 0) ? post.voteCount : null}
         </div>
       </div>

--- a/src/discussions/posts/post/PostSummaryFooter.jsx
+++ b/src/discussions/posts/post/PostSummaryFooter.jsx
@@ -9,16 +9,10 @@ import {
   Badge, Icon, OverlayTrigger, Tooltip,
 } from '@edx/paragon';
 import {
-  Locked,
+  StarFilled, StarOutline, ThumbUpFilled, ThumbUpOutline,
 } from '@edx/paragon/icons';
 
-import {
-  People,
-  QuestionAnswer,
-  QuestionAnswerOutline,
-  StarFilled,
-  StarOutline, ThumbUpFilled, ThumbUpOutline,
-} from '../../../components/icons';
+import { People, QuestionAnswer, QuestionAnswerOutline } from '../../../components/icons';
 import timeLocale from '../../common/time-locale';
 import { selectUserHasModerationPrivileges } from '../../data/selectors';
 import messages from './messages';
@@ -32,7 +26,6 @@ function PostSummaryFooter({
 }) {
   const userHasModerationPrivileges = useSelector(selectUserHasModerationPrivileges);
   timeago.register('time-locale', timeLocale);
-
   return (
     <div className="d-flex align-items-center text-gray-700">
       <div className="d-flex align-items-center mr-4.5">
@@ -43,7 +36,7 @@ function PostSummaryFooter({
             </Tooltip>
           )}
         >
-          <Icon src={post.voted ? ThumbUpFilled : ThumbUpOutline} className="post-summary-icons-dimensions mr-0.5">
+          <Icon src={post.voted ? ThumbUpFilled : ThumbUpOutline} className="post-summary-like-dimensions mr-0.5">
             <span className="sr-only">{' '}{intl.formatMessage(post.voted ? messages.likedPost : messages.postLikes)}</span>
           </Icon>
         </OverlayTrigger>
@@ -60,7 +53,7 @@ function PostSummaryFooter({
         )}
       >
         <Icon src={post.following ? StarFilled : StarOutline} className="post-summary-icons-dimensions mr-0.5">
-          <span className="sr-only">{' '}{ intl.formatMessage(post.following ? messages.srOnlyFollowDescription : messages.srOnlyUnFollowDescription)}</span>
+          <span className="sr-only">{' '}{intl.formatMessage(post.following ? messages.srOnlyFollowDescription : messages.srOnlyUnFollowDescription)}</span>
         </Icon>
       </OverlayTrigger>
 
@@ -73,7 +66,10 @@ function PostSummaryFooter({
               </Tooltip>
             )}
           >
-            <Icon src={post.unreadCommentCount ? QuestionAnswer : QuestionAnswerOutline} className="post-summary-icons-dimensions mr-0.5">
+            <Icon
+              src={post.unreadCommentCount ? QuestionAnswer : QuestionAnswerOutline}
+              className="post-summary-commentcount-dimensions mr-0.5"
+            >
               <span className="sr-only">{' '} {intl.formatMessage(messages.activity)}</span>
             </Icon>
           </OverlayTrigger>
@@ -108,25 +104,6 @@ function PostSummaryFooter({
         <span title={post.createdAt} className="text-gray-700 post-summary-timestamp">
           {timeago.format(post.createdAt, 'time-locale')}
         </span>
-        {!preview && post.closed
-          && (
-            <OverlayTrigger
-              overlay={(
-                <Tooltip id={`closed-${post.id}-tooltip`}>
-                  {intl.formatMessage(messages.postClosed)}
-                </Tooltip>
-              )}
-            >
-              <Icon
-                src={Locked}
-                style={{
-                  width: '1rem',
-                  height: '1rem',
-                }}
-                className="ml-3 post-summary-icons-dimensions"
-              />
-            </OverlayTrigger>
-          )}
       </div>
     </div>
   );

--- a/src/index.scss
+++ b/src/index.scss
@@ -41,6 +41,10 @@ $fa-font-path: "~font-awesome/fonts";
   outline: #EAE6E5 solid 2px;
 }
 
+.font-size-16 {
+  font-size: 16px;
+}
+
 .font-size-14 {
   font-size: 14px;
 }
@@ -90,7 +94,7 @@ $fa-font-path: "~font-awesome/fonts";
   width: 16px !important;
 }
 
-.post-summary-commentcount-dimensions {
+.post-summary-comment-count-dimensions {
   height: 15.39px;
   width: 15.5px
 }
@@ -469,7 +473,7 @@ header {
   white-space: normal;
 }
 
-.fontStyle {
+.font-style {
   font-family: "Inter";
   font-style: normal;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -287,43 +287,29 @@ header {
       font-size: 18px;
       font-weight: 400;
       line-height: 28px;
-    }
-
-    ;
+    };
 
     span {
       font-weight: 500;
       line-height: 24px;
-    }
-
-    ;
-  }
-
-  ;
+    };
+  };
 
   .container-xl {
     .course-title-lockup {
       font-size: 1.125rem;
-    }
-
-    ;
+    };
 
     .logo {
       margin-top: 2px;
-    }
-
-    ;
-  }
-
-  ;
+    };
+  };
 
   span:first-child {
     font-size: 14px;
     margin-top: 1px !important;
     margin-bottom: -1px !important;
-  }
-
-  ;
+  };
 }
 
 #courseTabsNavigation {
@@ -341,9 +327,7 @@ header {
     .nav-item {
       padding-bottom: 8px;
     }
-  }
-
-  ;
+  };
 }
 
 .min-content-height {

--- a/src/index.scss
+++ b/src/index.scss
@@ -90,6 +90,16 @@ $fa-font-path: "~font-awesome/fonts";
   width: 16px !important;
 }
 
+.post-summary-commentcount-dimensions {
+  height: 15.39px;
+  width: 15.5px
+}
+
+.post-summary-like-dimensions {
+  height: 16px;
+  width: 17px
+}
+
 .post-summary-timestamp {
   font-size: 12px !important;
   line-height: 20px !important;
@@ -197,8 +207,8 @@ $fa-font-path: "~font-awesome/fonts";
 }
 
 .question-icon-size {
-  width: 1.4581rem;
-  height: 1.4581rem;
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 .question-icon-position {

--- a/src/index.scss
+++ b/src/index.scss
@@ -465,3 +465,7 @@ header {
 .in-context-navbar {
   line-height: 44px;
 }
+
+.line-height-24 {
+  line-height: 24px;
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -130,6 +130,11 @@ $fa-font-path: "~font-awesome/fonts";
   margin-left: 2px;
 }
 
+.mx-3px {
+  margin-left: 3px;
+  margin-right: 3px;
+}
+
 .mt-14px {
   margin-top: 14px;
 }
@@ -184,6 +189,11 @@ $fa-font-path: "~font-awesome/fonts";
 .px-10px {
   padding-left: 10px;
   padding-right: 10px;
+}
+
+.py-2px {
+  padding-top: 2px !important;
+  padding-bottom: 2px !important;
 }
 
 .question-icon-size {
@@ -263,29 +273,43 @@ header {
       font-size: 18px;
       font-weight: 400;
       line-height: 28px;
-    };
+    }
+
+    ;
 
     span {
       font-weight: 500;
       line-height: 24px;
-    };
-  };
+    }
+
+    ;
+  }
+
+  ;
 
   .container-xl {
     .course-title-lockup {
       font-size: 1.125rem;
-    };
+    }
+
+    ;
 
     .logo {
       margin-top: 2px;
-    };
-  };
+    }
+
+    ;
+  }
+
+  ;
 
   span:first-child {
     font-size: 14px;
     margin-top: 1px !important;
     margin-bottom: -1px !important;
-  };
+  }
+
+  ;
 }
 
 #courseTabsNavigation {
@@ -303,7 +327,9 @@ header {
     .nav-item {
       padding-bottom: 8px;
     }
-  };
+  }
+
+  ;
 }
 
 .min-content-height {
@@ -431,4 +457,13 @@ header {
 
 .MJX-TEX {
   white-space: normal;
+}
+
+.fontStyle {
+  font-family: "Inter";
+  font-style: normal;
+}
+
+.in-context-navbar {
+  line-height: 44px;
 }


### PR DESCRIPTION
[INF-740](https://2u-internal.atlassian.net/browse/INF-740)
UX did some discoveries and created a new layout to increase content density, because of lots of feedback about it.

Mockups can be found here: [Discussions](https://www.figma.com/file/LVFnO9oRHYiamoicZuXDAC/Discussions?node-id=7332%3A316353&t=QhWkFQjlb50HPqvb-0)

Following are the updates mentioned  and Figma:

- change size of postactionbar in in-context discussions
- change postfilterbar text color and icon size
- change side bar icon sizes according to figma
- change margin for post according to Sigma
- change add a post style according to figma

<img width="521" alt="Screenshot 2023-02-03 at 7 49 43 PM" src="https://user-images.githubusercontent.com/73840786/216634547-fb355af8-e614-417f-a0dd-048e0bcda337.png">

<img width="527" alt="Screenshot 2023-02-03 at 7 50 03 PM" src="https://user-images.githubusercontent.com/73840786/216634561-4d5fda78-5a7c-4185-a286-e7f0e9ff0dca.png">

<img width="530" alt="Screenshot 2023-02-03 at 7 50 13 PM" src="https://user-images.githubusercontent.com/73840786/216634569-70b4159f-5608-4517-8939-a04521df5e0a.png">

<img width="512" alt="Screenshot 2023-02-03 at 7 50 23 PM" src="https://user-images.githubusercontent.com/73840786/216634572-08b5fc8b-9652-4a23-8ea3-fb41aa786209.png">

