### PR TITLE
fix: fix mathjax text overflowing

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -428,3 +428,7 @@ header {
   height: 24px;
   width: 24px;
 }
+
+.MJX-TEX {
+  white-space: normal;
+}


### PR DESCRIPTION
[INF-759](https://2u-internal.atlassian.net/browse/INF-759)
Text was overflowing on this for mathjax content.

**Before**
<img width="1191" alt="Screenshot 2023-02-06 at 6 16 34 PM" src="https://user-images.githubusercontent.com/73840786/216981171-3d66e312-f54d-43bd-b22f-e9df034a890a.png">


**After**
<img width="1174" alt="Screenshot 2023-02-06 at 6 16 42 PM" src="https://user-images.githubusercontent.com/73840786/216981184-c9e450cd-0dd2-41a1-967c-a2db5d6203b7.png">
