### PR TITLE
fix:topic info is fixed from posts in in-context discussions

### DIFF
--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -126,7 +126,7 @@ function Post({
       <div className="d-flex mt-14px text-break font-style text-primary-500">
         <HTMLLoader htmlNode={post.renderedBody} componentId="post" cssClassName="html-loader" testId={post.id} />
       </div>
-      {topicContext && topic && (
+      {topicContext && (
         <div
           className={classNames('mt-14px mb-1 font-style font-size-12',
             { 'w-100': enableInContextSidebar })}
@@ -137,7 +137,7 @@ function Post({
             destination={topicContext.unitLink}
             target="_top"
           >
-            {enableInContextSidebar
+            {(topicContext && !topic)
               ? (
                 <>
                   <span className="w-auto">{topicContext.chapterName}</span>


### PR DESCRIPTION
[INF-760](https://github.com/openedx/frontend-app-discussions/pull/new/inf-760)
### Description

- Topic name was not visible on posts in in-context discussions block. 

#### Changes description
- Topic's visibility was bound to topics but we don't have topics when in-context discussions are enabled, we have only topic context.
- I changed the dependency of topic visibility to topic context only.

#### How Has This Been Tested?

1. Go to the learning MFE tab for a course with enabled in-context discussion.
2. Select discussions tab.
3. Select any post on any unit.
4. You will see the topic at the end of the post content.

#### Screenshots/sandbox (optional):

**Before**

<img width="521" alt="Screenshot 2023-02-14 at 3 06 56 PM" src="https://user-images.githubusercontent.com/73840786/218704704-747943a8-ebcc-405d-a339-18184d5c6b8f.png">

**After**

<img width="513" alt="Screenshot 2023-02-14 at 3 05 54 PM" src="https://user-images.githubusercontent.com/73840786/218704751-5ce56d6a-1dd6-488a-b842-687d70985754.png">

#### Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?