### PR TITLE
fix: restrict tiny mce from converting url

### DIFF
--- a/src/components/TinyMCEEditor.jsx
+++ b/src/components/TinyMCEEditor.jsx
@@ -119,6 +119,7 @@ export default function TinyMCEEditor(props) {
           content_css: false,
           content_style: contentStyle,
           body_class: 'm-2 text-editor',
+          convert_urls: false,
           relative_urls: false,
           default_link_target: '_blank',
           target_list: false,


### PR DESCRIPTION
### Description

Tiny MCE was appending the base URL to the URLs added using anchor tags:
https://2u-internal.atlassian.net/browse/INF-765

- Make a new post.
- Switch to the HTML editor.
- Type in <a href="[www.example.com](https://www.google.com/url?q=http://www.example.com&sa=D&source=docs&ust=1675836215078258&usg=AOvVaw0ld9Hw3RaVrWyrMIMlSWfJ)">[www.example.com](https://www.google.com/url?q=http://www.example.com&sa=D&source=docs&ust=1675836215078317&usg=AOvVaw1jeGPgeio8e_20XyjmuGUI)</a>
- Click "save" to go back to the rich text editor.
- Click "HTML" again. Your code now says <a href="/course-v1:HarvardX+PH527x+1T2021/category/[www.example.com](https://www.google.com/url?q=http://www.example.com&sa=D&source=docs&ust=1675836215078375&usg=AOvVaw3-KPYlKUWc_MEs4ujpew-P)">[www.example.com](https://www.google.com/url?q=http://www.example.com&sa=D&source=docs&ust=1675836215078415&usg=AOvVaw2Nrmqmot217gm1LQaPCqkj)</a>

After Fix: tiny MCE smart URL conversion is turned off to save users from such issues.
#### How Has This Been Tested?

Please describe in detail how you tested your changes. : following above steps will now not reproduce the issue. also tested for ripple by adding links using the link menu

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.