### PR TITLE
feat: removed feedback bar in discussions sidebar

### DIFF
--- a/src/discussions/discussions-home/DiscussionsHome.jsx
+++ b/src/discussions/discussions-home/DiscussionsHome.jsx
@@ -93,7 +93,7 @@ export default function DiscussionsHome() {
             {!enableInContextSidebar && <Route path={Routes.DISCUSSIONS.PATH} component={NavigationBar} />}
             <PostActionsBar />
           </div>
-          {isFeedbackBannerVisible && <InformationBanner />}
+          {isFeedbackBannerVisible && !enableInContextSidebar && <InformationBanner />}
           <BlackoutInformationBanner />
         </div>
         {provider === DiscussionProvider.LEGACY && (


### PR DESCRIPTION
### Description

We received feedback that users are accidentally closing the feedback bar instead of closing the sidebar and vice versa. This is probably because the buttons to close each of them is close to each other.

#### Changes description:
As a short-term solution, we have stopped showing the feedback bar in the discussions sidebar. 
We are exploring feedback collection mechanisms in the long term.


#### Screenshots/sandbox (optional):

**Before**

<img width="520" alt="Screenshot 2023-02-14 at 3 59 06 PM" src="https://user-images.githubusercontent.com/73840786/218716325-f26490d8-4892-422c-a359-99117064521b.png">

**After**

<img width="526" alt="Screenshot 2023-02-14 at 3 58 37 PM" src="https://user-images.githubusercontent.com/73840786/218716375-bf3b5649-59e2-4d30-a4d4-b206842fe1c8.png">

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.