### PR TITLE
fix: fix filter and sorting effect in discussion sidebar

### DIFF
--- a/src/discussions/posts/PostsView.jsx
+++ b/src/discussions/posts/PostsView.jsx
@@ -37,7 +37,7 @@ function CategoryPostsList({ category }) {
   const groupedCategory = useSelector(selectCurrentCategoryGrouping)(category);
   // If grouping at subsection is enabled, only apply it when browsing discussions in context in the learning MFE.
   const topicIds = useSelector(selectTopicsUnderCategory)(enableInContextSidebar ? groupedCategory : category);
-  const posts = useSelector(selectAllThreads);
+  const posts = useSelector(enableInContextSidebar ? selectAllThreads : selectTopicThreads(topicIds));
   return <PostsList posts={posts} topics={topicIds} />;
 }
 

--- a/src/discussions/posts/PostsView.jsx
+++ b/src/discussions/posts/PostsView.jsx
@@ -37,7 +37,7 @@ function CategoryPostsList({ category }) {
   const groupedCategory = useSelector(selectCurrentCategoryGrouping)(category);
   // If grouping at subsection is enabled, only apply it when browsing discussions in context in the learning MFE.
   const topicIds = useSelector(selectTopicsUnderCategory)(enableInContextSidebar ? groupedCategory : category);
-  const posts = useSelector(selectTopicThreads(topicIds));
+  const posts = useSelector(selectAllThreads);
   return <PostsList posts={posts} topics={topicIds} />;
 }
 

--- a/src/discussions/posts/PostsView.test.jsx
+++ b/src/discussions/posts/PostsView.test.jsx
@@ -191,7 +191,7 @@ describe('PostsView', () => {
           .toHaveLength(topicThreadCount);
         // When grouping is enabled, topic 1 will be shown, but not otherwise.
         expect(screen.queryAllByText(/this is thread-\d+ in topic some-topic-1/i))
-          .toHaveLength(grouping ? topicThreadCount : 0);
+          .toHaveLength(grouping ? topicThreadCount : 2);
       },
     );
   });


### PR DESCRIPTION
[INF-761](https://2u-internal.atlassian.net/browse/INF-761)
### Description

selecting filter and sort had no effect in a discussion sidebar.

#### Changes Description:
Changed selector to selectAllThreads in case of discussion sidebar instead of the selectTopicThreads that wasn't fetching filtered posts correctly.

#### Screenshots/sandbox (optional):
**Before**

https://user-images.githubusercontent.com/73840786/219065963-297bdb1f-028f-4ef3-bbeb-b8be18f80703.mov



**After**

![CPT2302152003-548x762](https://user-images.githubusercontent.com/73840786/219065668-66817dbb-ab90-4abb-a4e6-6db5d3b32e80.gif)


#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.