### PR TITLE
fix: copy link not working in in-context discussion

### DIFF
--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -33,7 +33,7 @@ function Post({
   const history = useHistory();
   const dispatch = useDispatch();
   const { enableInContextSidebar } = useContext(DiscussionContext);
-  const { courseId } = useSelector((state) => state.courseTabs);
+  const courseId = useSelector((state) => state.config.id);
   const topic = useSelector(selectTopic(post.topicId));
   const getTopicSubsection = useSelector(selectorForUnitSubsection);
   const topicContext = useSelector(selectTopicContext(post.topicId));


### PR DESCRIPTION
### Description

Copy Link was not working on discussion sidebar in frontend-app-learning. CourseId was null when post link was copied from discussion sidebar

#### How Has This Been Tested?

Open discussion sidebar in a unit in frontend-app-learning. Select a post and click on "Copy Link" button in post actions.

#### No Visual Change

#### Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [x] Is there adequate test coverage for your changes?
