### PR TITLE
test: added  test cases for v3 Topics and units list page

### DIFF
--- a/src/discussions/in-context-topics/TopicsView.test.jsx
+++ b/src/discussions/in-context-topics/TopicsView.test.jsx
@@ -30,10 +30,10 @@ const topicsApiUrl = `${getCourseTopicsApiUrl()}`;
 let store;
 let axiosMock;
 let lastLocation;
-let component;
 let container;
+
 function renderComponent() {
-  component = render(
+  const wrapper = render(
     <IntlProvider locale="en">
       <AppProvider store={store}>
         <DiscussionContext.Provider value={{ courseId, category }}>
@@ -55,8 +55,7 @@ function renderComponent() {
       </AppProvider>
     </IntlProvider>,
   );
-  container = component.container;
-  return container;
+  container = wrapper.container;
 }
 
 describe('InContext Topics View', () => {
@@ -146,7 +145,7 @@ describe('InContext Topics View', () => {
     expect(sectionGroups.length).toBe(2);
     expect(topicsList.children[5]).toStrictEqual(topicsList.querySelector('.divider'));
   });
-
+  // need updation
   it('A section group should have only a title and required subsections.', async () => {
     await setupMockResponse();
     renderComponent();
@@ -156,7 +155,7 @@ describe('InContext Topics View', () => {
       const subsectionGroups = await within(sectionGroups[index]).getAllByTestId('subsection-group');
 
       expect(within(sectionGroups[index]).queryByText(topic.displayName)).toBeInTheDocument();
-      expect(statsList).toHaveLength(0);
+      expect(statsList).toHaveLength(subsectionGroups.length + 2);
       expect(subsectionGroups).toHaveLength(2);
     });
   });
@@ -170,7 +169,7 @@ describe('InContext Topics View', () => {
     const statsList = await subSection.querySelectorAll('.icon-size');
 
     expect(subSectionTitle).toBeInTheDocument();
-    expect(statsList).toHaveLength(0);
+    expect(statsList).toHaveLength(2);
   });
 
   it('Subsection names should be clickable and redirected to the units lists', async () => {

--- a/src/discussions/in-context-topics/TopicsView.test.jsx
+++ b/src/discussions/in-context-topics/TopicsView.test.jsx
@@ -145,17 +145,18 @@ describe('InContext Topics View', () => {
     expect(sectionGroups.length).toBe(2);
     expect(topicsList.children[5]).toStrictEqual(topicsList.querySelector('.divider'));
   });
-  // need updation
+
   it('A section group should have only a title and required subsections.', async () => {
     await setupMockResponse();
     renderComponent();
     const sectionGroups = await screen.getAllByTestId('section-group');
+
     coursewareTopics.forEach(async (topic, index) => {
-      const statsList = await sectionGroups[index].querySelectorAll('.icon-size');
+      const stats = await sectionGroups[index].querySelectorAll('.icon-size:not([data-testid="subsection-group"].icon-size)');
       const subsectionGroups = await within(sectionGroups[index]).getAllByTestId('subsection-group');
 
       expect(within(sectionGroups[index]).queryByText(topic.displayName)).toBeInTheDocument();
-      expect(statsList).toHaveLength(subsectionGroups.length + 2);
+      expect(stats).toHaveLength(0);
       expect(subsectionGroups).toHaveLength(2);
     });
   });

--- a/src/discussions/in-context-topics/TopicsView.test.jsx
+++ b/src/discussions/in-context-topics/TopicsView.test.jsx
@@ -1,0 +1,227 @@
+import {
+  fireEvent, render, screen, waitFor,
+  within,
+} from '@testing-library/react';
+import MockAdapter from 'axios-mock-adapter';
+import { act } from 'react-dom/test-utils';
+import { IntlProvider } from 'react-intl';
+import { MemoryRouter, Route } from 'react-router';
+import { Factory } from 'rosie';
+
+import { initializeMockApp } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { AppProvider } from '@edx/frontend-platform/react';
+
+import { initializeStore } from '../../store';
+import { executeThunk } from '../../test-utils';
+import { DiscussionContext } from '../common/context';
+import { getCourseTopicsApiUrl } from './data/api';
+import { selectCoursewareTopics, selectNonCoursewareTopics } from './data/selectors';
+import { fetchCourseTopicsV3 } from './data/thunks';
+import TopicPostsView from './TopicPostsView';
+import TopicsView from './TopicsView';
+
+import './data/__factories__';
+
+const courseId = 'course-v1:edX+DemoX+Demo_Course';
+const category = 'section-topic-1';
+
+const topicsApiUrl = `${getCourseTopicsApiUrl()}`;
+let store;
+let axiosMock;
+let lastLocation;
+let component;
+let container;
+function renderComponent() {
+  component = render(
+    <IntlProvider locale="en">
+      <AppProvider store={store}>
+        <DiscussionContext.Provider value={{ courseId, category }}>
+          <MemoryRouter initialEntries={[`/${courseId}/topics/`]}>
+            <Route path="/:courseId/topics/">
+              <TopicsView />
+            </Route>
+            <Route path="/:courseId/category/:category">
+              <TopicPostsView />
+            </Route>
+            <Route
+              render={({ location }) => {
+                lastLocation = location;
+                return null;
+              }}
+            />
+          </MemoryRouter>
+        </DiscussionContext.Provider>
+      </AppProvider>
+    </IntlProvider>,
+  );
+  container = component.container;
+  return container;
+}
+
+describe('Legacy Topics View', () => {
+  let nonCoursewareTopics;
+  let coursewareTopics;
+  beforeEach(() => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 3,
+        username: 'abc123',
+        administrator: true,
+        roles: [],
+      },
+    });
+
+    store = initializeStore({
+      config: { enableInContext: true, provider: 'openedx', hasModerationPrivileges: true },
+    });
+    Factory.resetAll();
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    lastLocation = undefined;
+  });
+
+  async function setupMockResponse() {
+    axiosMock.onGet(`${topicsApiUrl}${courseId}`)
+      .reply(200, (Factory.buildList('topic', 1, null, {
+        topicPrefix: 'noncourseware-topic',
+        enabledInContext: true,
+        topicNamePrefix: 'general-topic',
+        usageKey: '',
+        courseware: false,
+        discussionCount: 1,
+        questionCount: 1,
+      }).concat(Factory.buildList('section', 2, null, { topicPrefix: 'courseware' })))
+        .concat(Factory.buildList('archived-topics', 2, null)));
+    await executeThunk(fetchCourseTopicsV3(courseId), store.dispatch, store.getState);
+
+    const state = store.getState();
+    nonCoursewareTopics = selectNonCoursewareTopics(state);
+    coursewareTopics = selectCoursewareTopics(state);
+  }
+
+  it('A non-courseware topic should be clickable and should have a title', async () => {
+    await setupMockResponse();
+    renderComponent();
+
+    nonCoursewareTopics.forEach(async topic => {
+      const noncoursewareTopic = await screen.findByText(topic.name);
+
+      await act(async () => fireEvent.click(noncoursewareTopic));
+      await waitFor(async () => {
+        expect(screen.queryByText(topic.name)).toBeInTheDocument();
+        expect(lastLocation.pathname.endsWith(`/topics/${topic.id}`)).toBeTruthy();
+      });
+    });
+  });
+
+  it('A non-courseware topic should be on the top of the list', async () => {
+    await setupMockResponse();
+    renderComponent();
+    const topicsList = await screen.getByRole('list');
+    const { firstChild } = topicsList;
+    expect(within(firstChild).queryByText(nonCoursewareTopics[0].name)).toBeInTheDocument();
+    expect(topicsList.children[1]).toBe(topicsList.querySelector('.divider'));
+  });
+
+  it('A non-Courseware topic should have 3 stats and should be hoverable', async () => {
+    await setupMockResponse();
+    renderComponent();
+    const topicsList = await screen.getByRole('list');
+    const { firstChild } = topicsList;
+    const statsList = await firstChild.getElementsByClassName('pgn__icon');
+
+    expect(statsList.length).toBe(3);
+    fireEvent.mouseOver(statsList[0]);
+    expect(screen.queryByText('1 Discussion')).toBeInTheDocument();
+  });
+
+  it('Section groups should be listed in the middle of the topics list.', async () => {
+    await setupMockResponse();
+    renderComponent();
+    const topicsList = await screen.getByRole('list');
+    const sectionGroups = await screen.getAllByTestId('section-group');
+
+    expect(topicsList.children[1]).toStrictEqual(topicsList.querySelector('.divider'));
+    expect(sectionGroups.length).toBe(2);
+    expect(topicsList.children[5]).toStrictEqual(topicsList.querySelector('.divider'));
+  });
+
+  it('A section group should have only a title and required subsections.', async () => {
+    await setupMockResponse();
+    renderComponent();
+    const sectionGroups = await screen.getAllByTestId('section-group');
+    coursewareTopics.forEach(async (topic, index) => {
+      const statsList = await sectionGroups[index].getElementsByClassName('pgn__icon');
+      const subsectionGroups = await within(sectionGroups[index]).getAllByTestId('subsection-group');
+
+      expect(within(sectionGroups[index]).queryByText(topic.displayName)).toBeInTheDocument();
+      expect(statsList).toHaveLength(0);
+      expect(subsectionGroups).toHaveLength(2);
+    });
+  });
+
+  it('The subsection should have a title name, be clickable, and not have the stats', async () => {
+    await setupMockResponse();
+    renderComponent();
+    const subSection = await container.querySelector(`[data-subsection-id=${coursewareTopics[0].children[0].id}]`);
+    const subSectionTitleContainer = await within(subSection).queryByText(coursewareTopics[0].children[0].displayName);
+    const statsList = await subSection.getElementsByClassName('pgn__icon');
+
+    expect(subSectionTitleContainer).toBeInTheDocument();
+    expect(statsList).toHaveLength(0);
+  });
+
+  it('Subsection names should be clickable and redirected to the units lists', async () => {
+    await setupMockResponse();
+    renderComponent();
+
+    const subSection = await container.querySelector(`[data-subsection-id=${coursewareTopics[0].children[0].id}]`);
+    await act(async () => fireEvent.click(subSection));
+    await waitFor(async () => {
+      const backButton = await screen.getByLabelText('Back to topics list');
+      const topicsList = await screen.getByRole('list');
+      const subSectionHeadingContainer = await screen.findByText(coursewareTopics[0].children[0].displayName);
+      const units = await topicsList.getElementsByClassName('discussion-topic');
+
+      expect(backButton).toBeInTheDocument();
+      expect(subSectionHeadingContainer).toBeInTheDocument();
+      expect(units).toHaveLength(4);
+      expect(lastLocation.pathname.endsWith(`/category/${coursewareTopics[0].children[0].id}`)).toBeTruthy();
+    });
+  });
+
+  it('The number of units should be matched with the actual unit length.', async () => {
+    await setupMockResponse();
+    renderComponent();
+    const subSection = await container.querySelector(`[data-subsection-id=${coursewareTopics[0].children[0].id}]`);
+
+    await act(async () => fireEvent.click(subSection));
+    await waitFor(async () => {
+      const units = await container.getElementsByClassName('discussion-topic');
+
+      expect(units).toHaveLength(4);
+    });
+  });
+
+  it('A unit should have a title and stats and should be clickable', async () => {
+    await setupMockResponse();
+    renderComponent();
+    const unit = coursewareTopics[0].children[0].children[0];
+    const subSection = await container.querySelector(`[data-subsection-id=${coursewareTopics[0].children[0].id}]`);
+
+    await act(async () => fireEvent.click(subSection));
+    await waitFor(async () => {
+      const ele = await screen.findByText(unit.name);
+      const unitContainer = await container.querySelector(`[data-topic-id=${unit.id}]`);
+      const statsList = await unitContainer.getElementsByClassName('pgn__icon');
+
+      expect(ele).toBeInTheDocument();
+      expect(statsList).toHaveLength(3);
+
+      await act(async () => fireEvent.click(unitContainer));
+      await waitFor(async () => {
+        expect(lastLocation.pathname.endsWith(`/topics/${unit.id}`)).toBeTruthy();
+      });
+    });
+  });
+});

--- a/src/discussions/in-context-topics/TopicsView.test.jsx
+++ b/src/discussions/in-context-topics/TopicsView.test.jsx
@@ -160,7 +160,7 @@ describe('InContext Topics View', () => {
     });
   });
 
-  it('The subsection should have a title name, be clickable, and not have the stats', async () => {
+  it('The subsection should have a title name, be clickable, and have the stats', async () => {
     await setupMockResponse();
     renderComponent();
     const subsectionObject = coursewareTopics[0].children[0];

--- a/src/discussions/in-context-topics/data/__factories__/inContextTopics.factory.js
+++ b/src/discussions/in-context-topics/data/__factories__/inContextTopics.factory.js
@@ -8,7 +8,7 @@ Factory.define('topic')
   .sequence('name', ['topicNamePrefix'], (idx, topicNamePrefix) => `${topicNamePrefix}-${idx}`)
   .sequence('usage-key', ['usageKey'], (idx, usageKey) => usageKey)
   .sequence('courseware', ['courseware'], (idx, courseware) => courseware)
-
+  .attr('activeFlags', null, true)
   .attr('thread_counts', ['discussionCount', 'questionCount'], (discCount, questCount) => {
     Factory.reset('thread-counts');
     return Factory.build('thread-counts', null, { discussionCount: discCount, questionCount: questCount });

--- a/src/discussions/in-context-topics/data/__factories__/inContextTopics.factory.js
+++ b/src/discussions/in-context-topics/data/__factories__/inContextTopics.factory.js
@@ -27,6 +27,11 @@ Factory.define('sub-section')
   .sequence('student_view_url', ['id', 'courseId'],
     (idx, id) => `${getApiBaseUrl}/xblock/block-v1:${id}`)
   .attr('type', null, 'sequential')
+  .attr('activeFlags', null, true)
+  .attr('thread_counts', ['discussionCount', 'questionCount'], (discCount, questCount) => {
+    Factory.reset('thread-counts');
+    return Factory.build('thread-counts', null, { discussionCount: discCount, questionCount: questCount });
+  })
   .attr('children', ['id', 'display-name', 'courseId'], (id, name, courseId) => {
     Factory.reset('topic');
     return Factory.buildList('topic', 2, null, {
@@ -55,7 +60,13 @@ Factory.define('section')
   .attr('type', null, 'chapter')
   .attr('children', ['id', 'display-name'], (id, name) => {
     Factory.reset('sub-section');
-    return Factory.buildList('sub-section', 2, null, { sectionPrefix: `${name}-`, topicPrefix: 'section', id });
+    return Factory.buildList('sub-section', 2, null, {
+      sectionPrefix: `${name}-`,
+      topicPrefix: 'section',
+      id,
+      discussionCount: 1,
+      questionCount: 1,
+    });
   });
 
 Factory.define('thread-counts')

--- a/src/discussions/in-context-topics/data/__factories__/inContextTopics.factory.js
+++ b/src/discussions/in-context-topics/data/__factories__/inContextTopics.factory.js
@@ -42,7 +42,7 @@ Factory.define('sub-section')
 Factory.define('section')
   .sequence('block_id', (idx) => `${idx}`)
   .option('topicPrefix', null, '')
-  .sequence('id', ['topicPrefix'], (idx, topicPrefix) => `${topicPrefix}-topic-${idx}`)
+  .sequence('id', ['topicPrefix'], (idx, topicPrefix) => `${topicPrefix}-topic-${idx}-v3`)
   .attr('courseware', null, true)
   .sequence('display-name', (idx) => `Introduction ${idx}`)
   .option('courseId', null, 'course-v1:edX+DemoX+Demo_Course')
@@ -53,9 +53,9 @@ Factory.define('section')
   .sequence('student_view_url', ['id', 'courseId'],
     (idx, id, courseId) => `${getApiBaseUrl}/xblock/${courseId.replace('course-v1:', 'block-v1:')}+type@chapter+block@${id}`)
   .attr('type', null, 'chapter')
-  .attr('children', ['display-name'], (name) => {
+  .attr('children', ['id', 'display-name'], (id, name) => {
     Factory.reset('sub-section');
-    return Factory.buildList('sub-section', 2, null, { sectionPrefix: `${name}-`, topicPrefix: 'section' });
+    return Factory.buildList('sub-section', 2, null, { sectionPrefix: `${name}-`, topicPrefix: 'section', id });
   });
 
 Factory.define('thread-counts')

--- a/src/discussions/in-context-topics/data/redux.test.js
+++ b/src/discussions/in-context-topics/data/redux.test.js
@@ -101,7 +101,7 @@ describe('Redux in context topics tests', () => {
       // contain chapter at first level
       coursewareTopics.forEach((chapter, index) => {
         expect(chapter.courseware).toEqual(true);
-        expect(chapter.id).toEqual(`courseware-topic-${index + 1}`);
+        expect(chapter.id).toEqual(`courseware-topic-${index + 1}-v3`);
         expect(chapter.type).toEqual('chapter');
         expect(chapter).toHaveProperty('blockId');
         expect(chapter).toHaveProperty('lmsWebUrl');
@@ -120,7 +120,7 @@ describe('Redux in context topics tests', () => {
           // contain sub section at third level
           section.children.forEach((subSection, subSecIndex) => {
             expect(subSection.enabledInContext).toEqual(true);
-            expect(subSection.id).toEqual(`${section.id}-${subSecIndex + 1}`);
+            expect(subSection.id).toEqual(`courseware-topic-${index + 1}-v3-${subSecIndex + 1}`);
             expect(subSection).toHaveProperty('usageKey');
             expect(subSection).not.toHaveProperty('blockId');
             expect(subSection?.threadCounts?.discussion).toEqual(1);

--- a/src/discussions/in-context-topics/data/selector.test.jsx
+++ b/src/discussions/in-context-topics/data/selector.test.jsx
@@ -88,7 +88,7 @@ describe('In Context Topics Selector test cases', () => {
 
       expect(coursewareTopics).not.toBeUndefined();
       coursewareTopics.forEach((topic, index) => {
-        expect(topic?.id).toEqual(`courseware-topic-${index + 1}`);
+        expect(topic?.id).toEqual(`courseware-topic-${index + 1}-v3`);
       });
     });
   });


### PR DESCRIPTION
INF-723

### Description
https://2u-internal.atlassian.net/browse/INF-723

This PR includes 9 test cases for v3 Topics and units list page.

1.  Course-wide/nonCourseware topics will be listed on top, along with their stats.
     a. A nonCourseware topic should be clickable and should have a title.
     b. A nonCourseware topic should be on the top of the list. Check it using a divider should be only on the bottom.
     c. A nonCourseware topic should have 3 stats and should be hoverable.

2. Afterward, sections and subsections will be listed. No stats will be shown here.

      a. Section groups should be listed in the middle of the topics list. Check it using the divider should be at the top and 
          bottom.
      b. A section group should have only a title and required subsections. e.g 2 subsections and should not have the stats.
      c. The subsection should have a title name, be clickable, and have the stats.

3. Subsection names will be clickable and redirected to the units lists
      a. It should have a navigation button bar with the subsection name which would be clicked. The number of units should 
          be matched with the actual unit length. 

4. The units list will display all units related to a subsection.
      a. The number of units should be matched with the actual unit length. 
      b. A unit should have a title and stats and should be clickable.

#### How Has This Been Tested?

I tested this by running command "npm run test src/discussions/in-context-topics/TopicsView.test.jsx".

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [✅] Is there adequate test coverage for your changes?
