### PR TITLE
feat: hide the comments sort feature

### DIFF
--- a/src/discussions/post-comments/PostCommentsView.jsx
+++ b/src/discussions/post-comments/PostCommentsView.jsx
@@ -40,6 +40,7 @@ function PostCommentsView({ intl }) {
   const {
     courseId, learnerUsername, category, topicId, page, enableInContextSidebar,
   } = useContext(DiscussionContext);
+  const enableCommentsSort = false;
 
   useEffect(() => {
     if (!thread) { submitDispatch(fetchThread(postId, courseId, true)); }
@@ -109,7 +110,7 @@ function PostCommentsView({ intl }) {
           />
         )}
       </div>
-      {!!commentsCount && commentsStatus === RequestStatus.SUCCESSFUL && <CommentsSort />}
+      {!!commentsCount && commentsStatus === RequestStatus.SUCCESSFUL && enableCommentsSort && <CommentsSort />}
       {thread.type === ThreadType.DISCUSSION && (
         <CommentsView
           postId={postId}

--- a/src/discussions/post-comments/PostCommentsView.test.jsx
+++ b/src/discussions/post-comments/PostCommentsView.test.jsx
@@ -19,8 +19,8 @@ import DiscussionContent from '../discussions-home/DiscussionContent';
 import { getThreadsApiUrl } from '../posts/data/api';
 import { fetchThreads } from '../posts/data/thunks';
 import { getCommentsApiUrl } from './data/api';
-import { removeComment } from './data/thunks';
 
+// import { removeComment } from './data/thunks';
 import '../posts/data/__factories__';
 import './data/__factories__';
 
@@ -35,7 +35,7 @@ const reverseOrder = false;
 let store;
 let axiosMock;
 let testLocation;
-let container;
+// let container;
 
 function mockAxiosReturnPagedComments() {
   [null, false, true].forEach(endorsed => {
@@ -106,7 +106,8 @@ function renderComponent(postId) {
       </AppProvider>
     </IntlProvider>,
   );
-  container = wrapper.container;
+  // container = wrapper.container;
+  return wrapper;
 }
 
 describe('ThreadView', () => {
@@ -699,67 +700,67 @@ describe('ThreadView', () => {
     });
   });
 
-  describe('for comments sort', () => {
-    it('should show sort dropdown if there are endorse or unendorsed comments', async () => {
-      renderComponent(discussionPostId);
+  // describe('for comments sort', () => {
+  //   it('should show sort dropdown if there are endorse or unendorsed comments', async () => {
+  //     renderComponent(discussionPostId);
 
-      const comment = await waitFor(() => screen.findByTestId('comment-comment-1'));
-      const sortWrapper = container.querySelector('.comments-sort');
-      const sortDropDown = within(sortWrapper).getByRole('button', { name: /Oldest first/i });
+  //     const comment = await waitFor(() => screen.findByTestId('comment-comment-1'));
+  //     const sortWrapper = container.querySelector('.comments-sort');
+  //     const sortDropDown = within(sortWrapper).getByRole('button', { name: /Oldest first/i });
 
-      expect(comment).toBeInTheDocument();
-      expect(sortDropDown).toBeInTheDocument();
-    });
+  //     expect(comment).toBeInTheDocument();
+  //     expect(sortDropDown).toBeInTheDocument();
+  //   });
 
-    it('should not show sort dropdown if there is no response', async () => {
-      const commentId = 'comment-1';
-      renderComponent(discussionPostId);
+  //   it('should not show sort dropdown if there is no response', async () => {
+  //     const commentId = 'comment-1';
+  //     renderComponent(discussionPostId);
 
-      await waitFor(() => screen.findByTestId('comment-comment-1'));
-      axiosMock.onDelete(`${commentsApiUrl}${commentId}/`).reply(201);
-      await executeThunk(removeComment(commentId, discussionPostId), store.dispatch, store.getState);
+  //     await waitFor(() => screen.findByTestId('comment-comment-1'));
+  //     axiosMock.onDelete(`${commentsApiUrl}${commentId}/`).reply(201);
+  //     await executeThunk(removeComment(commentId, discussionPostId), store.dispatch, store.getState);
 
-      expect(await waitFor(() => screen.findByText('No responses', { exact: true }))).toBeInTheDocument();
-      expect(container.querySelector('.comments-sort')).not.toBeInTheDocument();
-    });
+  //     expect(await waitFor(() => screen.findByText('No responses', { exact: true }))).toBeInTheDocument();
+  //     expect(container.querySelector('.comments-sort')).not.toBeInTheDocument();
+  //   });
 
-    it('should have only two options', async () => {
-      renderComponent(discussionPostId);
+  //   it('should have only two options', async () => {
+  //     renderComponent(discussionPostId);
 
-      await waitFor(() => screen.findByTestId('comment-comment-1'));
-      await act(async () => { fireEvent.click(screen.getByRole('button', { name: /Oldest first/i })); });
-      const dropdown = await waitFor(() => screen.findByTestId('comment-sort-dropdown-modal-popup'));
+  //     await waitFor(() => screen.findByTestId('comment-comment-1'));
+  //     await act(async () => { fireEvent.click(screen.getByRole('button', { name: /Oldest first/i })); });
+  //     const dropdown = await waitFor(() => screen.findByTestId('comment-sort-dropdown-modal-popup'));
 
-      expect(dropdown).toBeInTheDocument();
-      expect(await within(dropdown).getAllByRole('button')).toHaveLength(2);
-    });
+  //     expect(dropdown).toBeInTheDocument();
+  //     expect(await within(dropdown).getAllByRole('button')).toHaveLength(2);
+  //   });
 
-    it('should be selected Oldest first and auto focus', async () => {
-      renderComponent(discussionPostId);
+  //   it('should be selected Oldest first and auto focus', async () => {
+  //     renderComponent(discussionPostId);
 
-      await waitFor(() => screen.findByTestId('comment-comment-1'));
-      await act(async () => { fireEvent.click(screen.getByRole('button', { name: /Oldest first/i })); });
-      const dropdown = await waitFor(() => screen.findByTestId('comment-sort-dropdown-modal-popup'));
+  //     await waitFor(() => screen.findByTestId('comment-comment-1'));
+  //     await act(async () => { fireEvent.click(screen.getByRole('button', { name: /Oldest first/i })); });
+  //     const dropdown = await waitFor(() => screen.findByTestId('comment-sort-dropdown-modal-popup'));
 
-      expect(dropdown).toBeInTheDocument();
-      expect(within(dropdown).getByRole('button', { name: /Oldest first/i })).toBeInTheDocument();
-      expect(within(dropdown).getByRole('button', { name: /Oldest first/i })).toHaveFocus();
-      expect(within(dropdown).getByRole('button', { name: /Newest first/i })).not.toHaveFocus();
-    });
+  //     expect(dropdown).toBeInTheDocument();
+  //     expect(within(dropdown).getByRole('button', { name: /Oldest first/i })).toBeInTheDocument();
+  //     expect(within(dropdown).getByRole('button', { name: /Oldest first/i })).toHaveFocus();
+  //     expect(within(dropdown).getByRole('button', { name: /Newest first/i })).not.toHaveFocus();
+  //   });
 
-    test('successfully handles sort state update', async () => {
-      renderComponent(discussionPostId);
+  //   it('successfully handles sort state update', async () => {
+  //     renderComponent(discussionPostId);
 
-      expect(store.getState().comments.sortOrder).toBeFalsy();
+  //     expect(store.getState().comments.sortOrder).toBeFalsy();
 
-      await waitFor(() => screen.findByTestId('comment-comment-1'));
-      await act(async () => { fireEvent.click(screen.getByRole('button', { name: /Oldest first/i })); });
-      const dropdown = await waitFor(() => screen.findByTestId('comment-sort-dropdown-modal-popup'));
-      await act(async () => {
-        fireEvent.click(within(dropdown).getByRole('button', { name: /Newest first/i }));
-      });
+  //     await waitFor(() => screen.findByTestId('comment-comment-1'));
+  //     await act(async () => { fireEvent.click(screen.getByRole('button', { name: /Oldest first/i })); });
+  //     const dropdown = await waitFor(() => screen.findByTestId('comment-sort-dropdown-modal-popup'));
+  //     await act(async () => {
+  //       fireEvent.click(within(dropdown).getByRole('button', { name: /Newest first/i }));
+  //     });
 
-      expect(store.getState().comments.sortOrder).toBeTruthy();
-    });
-  });
+  //     expect(store.getState().comments.sortOrder).toBeTruthy();
+  //   });
+  // });
 });

--- a/src/discussions/post-comments/PostCommentsView.test.jsx
+++ b/src/discussions/post-comments/PostCommentsView.test.jsx
@@ -20,7 +20,6 @@ import { getThreadsApiUrl } from '../posts/data/api';
 import { fetchThreads } from '../posts/data/thunks';
 import { getCommentsApiUrl } from './data/api';
 
-// import { removeComment } from './data/thunks';
 import '../posts/data/__factories__';
 import './data/__factories__';
 
@@ -35,7 +34,6 @@ const reverseOrder = false;
 let store;
 let axiosMock;
 let testLocation;
-// let container;
 
 function mockAxiosReturnPagedComments() {
   [null, false, true].forEach(endorsed => {
@@ -106,7 +104,6 @@ function renderComponent(postId) {
       </AppProvider>
     </IntlProvider>,
   );
-  // container = wrapper.container;
   return wrapper;
 }
 
@@ -699,68 +696,4 @@ describe('ThreadView', () => {
       expect(screen.queryByRole('dialog', { name: /Delete/i, exact: false })).toBeInTheDocument();
     });
   });
-
-  // describe('for comments sort', () => {
-  //   it('should show sort dropdown if there are endorse or unendorsed comments', async () => {
-  //     renderComponent(discussionPostId);
-
-  //     const comment = await waitFor(() => screen.findByTestId('comment-comment-1'));
-  //     const sortWrapper = container.querySelector('.comments-sort');
-  //     const sortDropDown = within(sortWrapper).getByRole('button', { name: /Oldest first/i });
-
-  //     expect(comment).toBeInTheDocument();
-  //     expect(sortDropDown).toBeInTheDocument();
-  //   });
-
-  //   it('should not show sort dropdown if there is no response', async () => {
-  //     const commentId = 'comment-1';
-  //     renderComponent(discussionPostId);
-
-  //     await waitFor(() => screen.findByTestId('comment-comment-1'));
-  //     axiosMock.onDelete(`${commentsApiUrl}${commentId}/`).reply(201);
-  //     await executeThunk(removeComment(commentId, discussionPostId), store.dispatch, store.getState);
-
-  //     expect(await waitFor(() => screen.findByText('No responses', { exact: true }))).toBeInTheDocument();
-  //     expect(container.querySelector('.comments-sort')).not.toBeInTheDocument();
-  //   });
-
-  //   it('should have only two options', async () => {
-  //     renderComponent(discussionPostId);
-
-  //     await waitFor(() => screen.findByTestId('comment-comment-1'));
-  //     await act(async () => { fireEvent.click(screen.getByRole('button', { name: /Oldest first/i })); });
-  //     const dropdown = await waitFor(() => screen.findByTestId('comment-sort-dropdown-modal-popup'));
-
-  //     expect(dropdown).toBeInTheDocument();
-  //     expect(await within(dropdown).getAllByRole('button')).toHaveLength(2);
-  //   });
-
-  //   it('should be selected Oldest first and auto focus', async () => {
-  //     renderComponent(discussionPostId);
-
-  //     await waitFor(() => screen.findByTestId('comment-comment-1'));
-  //     await act(async () => { fireEvent.click(screen.getByRole('button', { name: /Oldest first/i })); });
-  //     const dropdown = await waitFor(() => screen.findByTestId('comment-sort-dropdown-modal-popup'));
-
-  //     expect(dropdown).toBeInTheDocument();
-  //     expect(within(dropdown).getByRole('button', { name: /Oldest first/i })).toBeInTheDocument();
-  //     expect(within(dropdown).getByRole('button', { name: /Oldest first/i })).toHaveFocus();
-  //     expect(within(dropdown).getByRole('button', { name: /Newest first/i })).not.toHaveFocus();
-  //   });
-
-  //   it('successfully handles sort state update', async () => {
-  //     renderComponent(discussionPostId);
-
-  //     expect(store.getState().comments.sortOrder).toBeFalsy();
-
-  //     await waitFor(() => screen.findByTestId('comment-comment-1'));
-  //     await act(async () => { fireEvent.click(screen.getByRole('button', { name: /Oldest first/i })); });
-  //     const dropdown = await waitFor(() => screen.findByTestId('comment-sort-dropdown-modal-popup'));
-  //     await act(async () => {
-  //       fireEvent.click(within(dropdown).getByRole('button', { name: /Newest first/i }));
-  //     });
-
-  //     expect(store.getState().comments.sortOrder).toBeTruthy();
-  //   });
-  // });
 });


### PR DESCRIPTION
**[INF-783](https://2u-internal.atlassian.net/browse/INF-783)**
### Description
To create the comment sort feature noticeable by users, our team is working on a product tour. This PR is temporarily hiding the comment sort feature. This feature will be enabled after the product tour implementation.

#### How Has This Been Tested?

1. Go to Discussion MEF 
2. Select the Post tab
3. Select a post that has at least one comment
4. Comment sort dropdown will be visible

#### Screenshots/sandbox (optional):
**Before**
<img width="1440" alt="Screenshot 2023-02-17 at 3 05 53 PM" src="https://user-images.githubusercontent.com/79941147/219614532-b3eea20c-3ec5-4046-8d8d-b1501f6e80c6.png">

**After**
<img width="1440" alt="Screenshot 2023-02-17 at 3 04 49 PM" src="https://user-images.githubusercontent.com/79941147/219614593-b09de432-57b1-4d14-9e45-5a03ad364751.png">


#### Merge Checklist
* [❌ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [✅ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist
* [ ❌] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [😊 ] 🎉 🙌 Celebrate! Thanks for your contribution.