### PR TITLE
fix: reduced padding for topic names

### DIFF
--- a/src/discussions/in-context-topics/topic/SectionBaseGroup.jsx
+++ b/src/discussions/in-context-topics/topic/SectionBaseGroup.jsx
@@ -50,7 +50,7 @@ function SectionBaseGroup({
           aria-current={isSelected(section.id) ? 'page' : undefined}
           tabIndex={(isSelected(subsection.id) || index === 0) ? 0 : -1}
         >
-          <div className="d-flex flex-row py-3.5 px-4">
+          <div className="d-flex flex-row pt-2.5 pb-2 px-4">
             <div className="d-flex flex-column flex-fill" style={{ minWidth: 0 }}>
               <div className="d-flex flex-column justify-content-start mw-100 flex-fill">
                 <div className="topic-name text-truncate">


### PR DESCRIPTION
### Description

Sub-sections will have same visual as of course-wide topics. Removed additional padding

#### How Has This Been Tested?

Open discussions MFE and click on Topics Tab. Subsections will be visible

#### Screenshots:

Before
![inf-763-2_before](https://user-images.githubusercontent.com/77053848/219652626-bae2e9a4-d386-4727-90ed-701954f7ee60.png)

After
![inf-763-2_after](https://user-images.githubusercontent.com/77053848/219652650-605c98af-07dc-4f34-8791-c174f4c16d3a.png)


#### Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [x] Is there adequate test coverage for your changes?
