### PR TITLE
fix: post sharing URL

### DIFF
--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -77,9 +77,10 @@ const Post = ({ handleAddResponseButton }) => {
     }
   }, [closed, postId, reasonCodesEnabled, showClosePostModal]);
 
-  const handlePostCopyLink = useCallback(() => navigator.clipboard.writeText(
-    `${window.location.origin}/${courseId}/posts/${postId}`,
-  ), [window.location.origin, postId, courseId]);
+  const handlePostCopyLink = useCallback(() => {
+    const postURL = new URL(`${getConfig().PUBLIC_PATH}${courseId}/posts/${postId}`, window.location.origin);
+    navigator.clipboard.writeText(postURL.href);
+  }, [window.location.origin, postId, courseId]);
 
   const handlePostPin = useCallback(() => dispatch(
     updateExistingThread(postId, { pinned: !pinned }),


### PR DESCRIPTION
### Description

When MFE uses path-based deployment (common domain for all MFEs divided by path) - the copied link leads to 404 error.

~Using the page's full URL is the easiest way to fix the problem.~

~The difference in the behavior compared to the state before the fix:~

~Before the fix:~
~The copied link always leads to the "All Posts" tab of the MFE.~

~After the fix:~
~The copied link will lead to the page where it was copied. The post can be viewed in different places (e.g. "All Posts", "Topics" tabs of the MFE) so the link will lead to the post in the corresponding tab.~

#### UPD:
- refactored the fix to always construct a URL to the post page
- used the `BASE_URL` and `PUBLIC_PATH` env variables to get the discussions MFE root URL. It should work with both subdirectory and subdomain-based deployments. 
- WIP status until finishing the subdirectory deployment testing. Subdomain deployment tested on devstack (the `PUBLIC_PATH` is `'/'`)
- clipboard work is really hard to cover by test (coverage will decrease a bit)
- LMS recently started to use the discussions sidebar which has the same button "Copy Link", but it uses its own env variable `DISCUSSIONS_MFE_BASE_URL`, and will not be affected by this change (thanks @muhammadadeeltajamul for mentioning the case)

<img width="1731" alt="Screenshot 2023-02-17 at 17 29 48" src="https://user-images.githubusercontent.com/47273130/219697113-4828a008-9097-47db-8d07-2e4e21f401b8.png">

#### UPD2:
- tested subdomain-based instance on Devstack - works as expected
- tested subdirectory-based instance (on the stage environment) - works great too


### Would be great:
- to have @muhammadadeeltajamul as a reviewer as he has made previous changes to the feature (#280) and could point out cases I didn't find (if any) or disadvantages of the fix. I've also thought about using the env variable for the base URL (or even the public path env var which I [saw in the grade book MFE](https://github.com/openedx/frontend-app-gradebook/pull/202/files#diff-da8567d3c962abaa9698255bfdb1c44e936ef3b3674ad5fab44c61abe3fbdc7dR4)) but it will require more effort and I'm not sure it worth it.

#### How Has This Been Tested?

Tested on master-based Devstack manually with both `localhost:2002/` and `localhost:2002/discussions` base URLs

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.