### PR TITLE
fix: Fix for code block formatting on the post preview and published post view

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -254,3 +254,12 @@ header {
     align-self: center;
   }
 }
+
+.post-preview,
+.discussion-comments {
+  blockquote {
+    border-left: 2px solid #ccc;
+    margin-left: 1.5rem;
+    padding-left: 1rem;
+  }
+}


### PR DESCRIPTION
### Description

The problem with "quote" block was found on the MFE Discussion. When we are writing a post - we can immediately see normal view for quote, with padding and left border. But in preview window - quote block appears without border, margin and padding, like a regular text. The same situation with published post
 
<img width="1860" alt="Снимок экрана 2023-02-21 в 17 29 40" src="https://user-images.githubusercontent.com/19806032/220388211-81ca379a-5b34-4ec1-876e-a2b73a8b2e8e.png">

#### How Has This Been Tested?

We made minor changes in css and checked the result in preview mode and published post

<img width="1860" alt="Снимок экрана 2023-02-21 в 17 33 38" src="https://user-images.githubusercontent.com/19806032/220388989-d762fe60-ce20-4e45-9baf-abd0300dafe4.png">

and published post

<img width="1897" alt="Снимок экрана 2023-02-21 в 17 37 07" src="https://user-images.githubusercontent.com/19806032/220390292-739f7a39-c14d-4c8f-90b4-cbd1d8770bc3.png">

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.