### PR TITLE
fix: incontext crashing

### DIFF
--- a/src/discussions/data/hooks.js
+++ b/src/discussions/data/hooks.js
@@ -71,14 +71,14 @@ export const useSidebarVisible = () => {
   return !hideSidebar;
 };
 
-export function useCourseDiscussionData(courseId, enableInContextSidebar) {
+export function useCourseDiscussionData(courseId) {
   const dispatch = useDispatch();
   const { authenticatedUser } = useContext(AppContext);
 
   useEffect(() => {
     async function fetchBaseData() {
       await dispatch(fetchCourseConfig(courseId));
-      if (!enableInContextSidebar) { await dispatch(fetchCourseBlocks(courseId, authenticatedUser.username)); }
+      await dispatch(fetchCourseBlocks(courseId, authenticatedUser.username));
     }
 
     fetchBaseData();

--- a/src/discussions/discussions-home/DiscussionsHome.jsx
+++ b/src/discussions/discussions-home/DiscussionsHome.jsx
@@ -50,7 +50,7 @@ export default function DiscussionsHome() {
     courseId, postId, topicId, category, learnerUsername,
   } = params;
 
-  useCourseDiscussionData(courseId, enableInContextSidebar);
+  useCourseDiscussionData(courseId);
   useRedirectToThread(courseId, enableInContextSidebar);
 
   /*  Display the content area if we are currently viewing/editing a post or creating one.


### PR DESCRIPTION
### Description

Incontext discussion was crashing because blocks data was not available

#### How Has This Been Tested?

Open discussion side bar in any unit. Now it will show threads 

#### Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [x] Is there adequate test coverage for your changes?

