### PR TITLE
fix: fixed post coment actions menu accessibilty for keyboard

### DIFF
--- a/src/discussions/post-comments/comments/comment/Comment.jsx
+++ b/src/discussions/post-comments/comments/comment/Comment.jsx
@@ -119,7 +119,7 @@ function Comment({
           />
         )}
         <EndorsedAlertBanner postType={postType} content={comment} />
-        <div className="d-flex flex-column post-card-comment px-4 pt-3.5 pb-10px" aria-level={5}>
+        <div className="d-flex flex-column post-card-comment px-4 pt-3.5 pb-10px" tabIndex="0">
           <HoverCard
             commentOrPost={comment}
             actionHandlers={actionHandlers}

--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -90,8 +90,9 @@ function Post({
   return (
     <div
       className="d-flex flex-column w-100 mw-100 post-card-comment"
-      aria-level={5}
       data-testid={`post-${post.id}`}
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+      tabIndex="0"
     >
       <Confirmation
         isOpen={isDeleting}

--- a/src/index.scss
+++ b/src/index.scss
@@ -433,7 +433,7 @@ header {
   pointer-events: none;
 }
 
-.on-focus:focus-visible {
+.on-focus:focus-within {
   outline: 2px solid black;
 }
 
@@ -442,6 +442,8 @@ header {
 }
 
 .post-card-comment {
+  outline: none;
+
   &:not(:hover),
   &:not(:focus) {
     .hover-card {
@@ -450,7 +452,7 @@ header {
   }
 
   &:hover,
-  &:focus {
+  &:focus-within {
     .hover-card {
       display: flex;
     }


### PR DESCRIPTION
[INF-799](https://2u-internal.atlassian.net/browse/INF-799)
### Description

The actions menu that appears on hover on post/comment, is not accessible via the keyboard which is fixed.

#### Screenshots
**Before**

![image-20230227-161345](https://user-images.githubusercontent.com/73840786/221651441-fa47cc09-585c-4dff-bca6-4b4b58ed21cb.png)


**After**

[4ae641d6-be51-4aef-b7dd-137b275dabba.webm](https://user-images.githubusercontent.com/73840786/221651683-612cef08-e450-4094-b19a-31d7bf8286c2.webm)
