### PR TITLE
test: added testcases of redux, selector and api

### DIFF
--- a/src/discussions/learners/LearnersView.test.jsx
+++ b/src/discussions/learners/LearnersView.test.jsx
@@ -64,9 +64,9 @@ describe('LearnersView', () => {
     axiosMock.onGet(`${coursesApiUrl}${courseId}/activity_stats/`)
       .reply(() => [200, learnersData]);
     const learnersProfile = Factory.build('learnersProfile', {}, {
-      username: ['leaner-1', 'leaner-2', 'leaner-3'],
+      username: ['learner-1', 'learner-2', 'learner-3'],
     });
-    axiosMock.onGet(`${userProfileApiUrl}?username=leaner-1,leaner-2,leaner-3`)
+    axiosMock.onGet(`${userProfileApiUrl}?username=learner-1,learner-2,learner-3`)
       .reply(() => [200, learnersProfile.profiles]);
     await executeThunk(fetchLearners(courseId), store.dispatch, store.getState);
   });

--- a/src/discussions/learners/data/__factories__/learners.factory.js
+++ b/src/discussions/learners/data/__factories__/learners.factory.js
@@ -2,7 +2,7 @@ import { Factory } from 'rosie';
 
 Factory.define('learner')
   .sequence('id')
-  .attr('username', ['id'], (id) => `leaner-${id}`)
+  .attr('username', ['id'], (id) => `learner-${id}`)
   .option('activeFlags', null, null)
   .attr('active_flags', ['activeFlags'], (activeFlags) => activeFlags)
   .attrs({
@@ -23,14 +23,8 @@ Factory.define('learnersResult')
     ['courseId', 'count', 'page', 'pageSize'],
     (courseId, count, page, pageSize) => {
       const numPages = Math.ceil(count / pageSize);
-      const next = page < numPages
-        ? `http://test.site/api/discussion/v1/courses/course-v1:edX+DemoX+Demo_Course/activity_stats?page=${page + 1
-        }`
-        : null;
-      const prev = page > 1
-        ? `http://test.site/api/discussion/v1/courses/course-v1:edX+DemoX+Demo_Course/activity_stats?page=${page - 1
-        }`
-        : null;
+      const next = page < numPages ? page + 1 : null;
+      const prev = page > 1 ? page - 1 : null;
       return {
         next,
         prev,
@@ -65,7 +59,7 @@ Factory.define('learnersResult')
   );
 
 Factory.define('learnersProfile')
-  .option('usernames', null, ['leaner-1', 'leaner-2', 'leaner-3'])
+  .option('usernames', null, ['learner-1', 'learner-2', 'learner-3'])
   .attr('profiles', ['usernames'], (usernames) => {
     const profiles = usernames.map((user) => ({
       account_privacy: 'private',

--- a/src/discussions/learners/data/api.js
+++ b/src/discussions/learners/data/api.js
@@ -10,6 +10,8 @@ ensureConfig([
 
 export const getCoursesApiUrl = () => `${getConfig().LMS_BASE_URL}/api/discussion/v1/courses/`;
 export const getUserProfileApiUrl = () => `${getConfig().LMS_BASE_URL}/api/user/v1/accounts`;
+export const learnerPostsApiUrl = (courseId) => `${getCoursesApiUrl()}${courseId}/learner/`;
+export const learnersApiUrl = (courseId) => `${getCoursesApiUrl()}${courseId}/activity_stats/`;
 
 /**
  * Fetches all the learners in the given course.
@@ -18,8 +20,7 @@ export const getUserProfileApiUrl = () => `${getConfig().LMS_BASE_URL}/api/user/
  * @returns {Promise<{}>}
  */
 export async function getLearners(courseId, params) {
-  const url = `${getCoursesApiUrl()}${courseId}/activity_stats/`;
-  const { data } = await getAuthenticatedHttpClient().get(url, { params });
+  const { data } = await getAuthenticatedHttpClient().get(learnersApiUrl(courseId), { params });
   return data;
 }
 
@@ -65,8 +66,6 @@ export async function getUserPosts(courseId, {
   countFlagged,
   cohort,
 } = {}) {
-  const learnerPostsApiUrl = `${getCoursesApiUrl()}${courseId}/learner/`;
-
   const params = snakeCaseObject({
     page,
     pageSize,
@@ -81,6 +80,6 @@ export async function getUserPosts(courseId, {
   });
 
   const { data } = await getAuthenticatedHttpClient()
-    .get(learnerPostsApiUrl, { params });
+    .get(learnerPostsApiUrl(courseId), { params });
   return data;
 }

--- a/src/discussions/learners/data/api.test.jsx
+++ b/src/discussions/learners/data/api.test.jsx
@@ -85,12 +85,13 @@ describe('Learner api test cases', () => {
     { status: 'statusUnanswered', search: 'Title', cohort: 'post' },
     { status: 'statusReported', search: 'Title', cohort: 'post' },
     { status: 'statusUnresponded', search: 'Title', cohort: 'post' },
-  ])('Successfully fetch user posts based on multiple filters', async ({ status, search, cohort }) => {
-    const threads = await setupPostsMockResponse(courseId, 200, { status, search, cohort });
+  ])('Successfully fetch user posts based on \'$status\', \'$search\' , and \'$cohort\'  filters',
+    async ({ status, search, cohort }) => {
+      const threads = await setupPostsMockResponse(courseId, 200, { status, search, cohort });
 
-    expect(threads.status).toEqual('successful');
-    expect(Object.values(threads.threadsById)).toHaveLength(2);
-  });
+      expect(threads.status).toEqual('successful');
+      expect(Object.values(threads.threadsById)).toHaveLength(2);
+    });
 
   it('failed to fetch learners', async () => {
     const learners = await setupLearnerMockResponse(courseId2, 200);

--- a/src/discussions/learners/data/api.test.jsx
+++ b/src/discussions/learners/data/api.test.jsx
@@ -1,0 +1,115 @@
+import MockAdapter from 'axios-mock-adapter';
+import { Factory } from 'rosie';
+
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { initializeMockApp } from '@edx/frontend-platform/testing';
+
+import { initializeStore } from '../../../store';
+import { executeThunk } from '../../../test-utils';
+import { getCoursesApiUrl, getUserProfileApiUrl } from './api';
+import { fetchLearners, fetchUserPosts } from './thunks';
+
+import './__factories__';
+
+const courseId = 'course-v1:edX+DemoX+Demo_Course';
+const courseId2 = 'course-v1:edX+TestX+Test_Course2';
+const coursesApiUrl = getCoursesApiUrl();
+const userProfileApiUrl = getUserProfileApiUrl();
+
+let axiosMock;
+let store;
+const username = 'abc123';
+const learnerCount = 3;
+
+describe('Learner api test cases', () => {
+  beforeEach(async () => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 3,
+        username,
+        administrator: true,
+        roles: [],
+      },
+    });
+    Factory.resetAll();
+    store = initializeStore();
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+  });
+
+  afterEach(() => {
+    axiosMock.reset();
+  });
+
+  async function setupLearnerMockResponse(learnerCourseId, statusCode) {
+    const learnersData = Factory.build('learnersResult', {}, {
+      count: learnerCount,
+      pageSize: 6,
+    });
+    axiosMock.onGet(`${coursesApiUrl}${learnerCourseId}/activity_stats/`)
+      .reply(() => [statusCode, learnersData]);
+
+    const learnersProfile = Factory.build('learnersProfile', {}, {
+      username: ['learner-1', 'learner-2', 'learner-3'],
+    });
+    axiosMock.onGet(`${userProfileApiUrl}?username=learner-1,learner-2,learner-3`)
+      .reply(() => [statusCode, learnersProfile.profiles]);
+
+    await executeThunk(fetchLearners(courseId), store.dispatch, store.getState);
+    return store.getState().learners;
+  }
+
+  async function setupPostsMockResponse(learnerCourseId, statusCode) {
+    const learnerPosts = Factory.build('learnerPosts', {}, {
+      abuseFlaggedCount: 1,
+    });
+    const apiUrl = `${coursesApiUrl}${learnerCourseId}/learner/`;
+
+    axiosMock.onGet(apiUrl, { username, count_flagged: true })
+      .reply(() => [statusCode, learnerPosts]);
+
+    await executeThunk(fetchUserPosts(courseId), store.dispatch, store.getState);
+    return store.getState().threads;
+  }
+
+  test('Successfully get API response for the learner\'s list and learners posts', async () => {
+    const learners = await setupLearnerMockResponse(courseId, 200);
+    const threads = await setupPostsMockResponse(courseId, 200);
+
+    expect(learners.status).toEqual('successful');
+    expect(learners.learnerProfiles).not.toBeUndefined();
+    expect(threads.status).toEqual('successful');
+    expect(threads.threadsById).not.toBeUndefined();
+  });
+
+  test('Successfully store learners and learnerPosts API data in redux', async () => {
+    const learners = await setupLearnerMockResponse(courseId, 200);
+    const threads = await setupPostsMockResponse(courseId, 200);
+
+    expect(Object.values(threads.threadsById)).toHaveLength(2);
+    expect(Object.values(learners.learnerProfiles)).toHaveLength(3);
+  });
+
+  it('failed to fetch learners', async () => {
+    const learners = await setupLearnerMockResponse(courseId2, 200);
+
+    expect(learners.status).toEqual('failed');
+  });
+
+  it('denied to fetch learners', async () => {
+    const learners = await setupLearnerMockResponse(courseId, 403);
+
+    expect(learners.status).toEqual('denied');
+  });
+
+  it('failed to fetch learnerPosts', async () => {
+    const threads = await setupPostsMockResponse(courseId2, 200);
+
+    expect(threads.status).toEqual('failed');
+  });
+
+  it('denied to fetch learnerPosts', async () => {
+    const threads = await setupPostsMockResponse(courseId, 403);
+
+    expect(threads.status).toEqual('denied');
+  });
+});

--- a/src/discussions/learners/data/redux.test.jsx
+++ b/src/discussions/learners/data/redux.test.jsx
@@ -5,25 +5,22 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { initializeMockApp } from '@edx/frontend-platform/testing';
 
 import { initializeStore } from '../../../store';
-import { executeThunk, setupLearnerMockResponse } from '../../../test-utils';
+import { executeThunk } from '../../../test-utils';
+import { setupLearnerMockResponse } from '../test-utils';
 import { setPostFilter, setSortedBy, setUsernameSearch } from './slices';
 import { fetchLearners } from './thunks';
 
 import './__factories__';
 
-const courseId = 'course-v1:edX+DemoX+Demo_Course';
-
 let axiosMock;
 let store;
-const username = 'abc123';
-const learnerCount = 6;
 
 describe('Learner redux test cases', () => {
   beforeEach(async () => {
     initializeMockApp({
       authenticatedUser: {
         userId: 3,
-        username,
+        username: 'abc123',
         administrator: true,
         roles: [],
       },
@@ -38,7 +35,10 @@ describe('Learner redux test cases', () => {
   });
 
   test('Successfully load initial states in redux', async () => {
-    executeThunk(fetchLearners(courseId, { usernameSearch: 'learner-1' }), store.dispatch, store.getState);
+    executeThunk(
+      fetchLearners('course-v1:edX+DemoX+Demo_Course', { usernameSearch: 'learner-1' }),
+      store.dispatch, store.getState,
+    );
     const { learners } = store.getState();
 
     expect(learners.status).toEqual('in-progress');
@@ -57,7 +57,7 @@ describe('Learner redux test cases', () => {
 
   test('Successfully store a learner posts stats data as pages object in redux',
     async () => {
-      const learners = await setupLearnerMockResponse(courseId, 200, axiosMock, store, learnerCount, courseId);
+      const learners = await setupLearnerMockResponse();
       const page = learners.pages[0];
       const statsObject = page[0];
 
@@ -69,7 +69,7 @@ describe('Learner redux test cases', () => {
 
   test('Successfully store the nextPage, totalPages, totalLearners, and sortedBy data in redux',
     async () => {
-      const learners = await setupLearnerMockResponse(courseId, 200, axiosMock, store, learnerCount, courseId);
+      const learners = await setupLearnerMockResponse();
 
       expect(learners.nextPage).toEqual(2);
       expect(learners.totalPages).toEqual(2);
@@ -78,7 +78,7 @@ describe('Learner redux test cases', () => {
     });
 
   test('Successfully updated the learner\'s sort data in redux', async () => {
-    const learners = await setupLearnerMockResponse(courseId, 200, axiosMock, store, learnerCount, courseId);
+    const learners = await setupLearnerMockResponse();
 
     expect(learners.sortedBy).toEqual('activity');
     expect(learners.pages[0]).toHaveLength(3);
@@ -91,7 +91,7 @@ describe('Learner redux test cases', () => {
   });
 
   test('Successfully updated the post-filter data in redux', async () => {
-    const learners = await setupLearnerMockResponse(courseId, 200, axiosMock, store, learnerCount, courseId);
+    const learners = await setupLearnerMockResponse();
     const filter = {
       ...learners.postFilter,
       postType: 'discussion',
@@ -108,7 +108,7 @@ describe('Learner redux test cases', () => {
 
   test('Successfully update the learner\'s search query in redux when searching for a learner',
     async () => {
-      const learners = await setupLearnerMockResponse(courseId, 200, axiosMock, store, learnerCount, courseId);
+      const learners = await setupLearnerMockResponse();
 
       expect(learners.usernameSearch).toBeNull();
 

--- a/src/discussions/learners/data/redux.test.jsx
+++ b/src/discussions/learners/data/redux.test.jsx
@@ -1,0 +1,141 @@
+import MockAdapter from 'axios-mock-adapter';
+import { Factory } from 'rosie';
+
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { initializeMockApp } from '@edx/frontend-platform/testing';
+
+import { initializeStore } from '../../../store';
+import { executeThunk } from '../../../test-utils';
+import { getCoursesApiUrl, getUserProfileApiUrl } from './api';
+import { setPostFilter, setSortedBy, setUsernameSearch } from './slices';
+import { fetchLearners } from './thunks';
+
+import './__factories__';
+
+const courseId = 'course-v1:edX+DemoX+Demo_Course';
+const coursesApiUrl = getCoursesApiUrl();
+const userProfileApiUrl = getUserProfileApiUrl();
+
+let axiosMock;
+let store;
+const username = 'abc123';
+const learnerCount = 6;
+
+describe('Learner redux test cases', () => {
+  beforeEach(async () => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 3,
+        username,
+        administrator: true,
+        roles: [],
+      },
+    });
+    Factory.resetAll();
+    store = initializeStore();
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+  });
+
+  afterEach(() => {
+    axiosMock.reset();
+  });
+
+  async function setupLearnerMockResponse() {
+    const learnersData = Factory.build('learnersResult', {}, {
+      count: learnerCount,
+      pageSize: 3,
+    });
+    axiosMock.onGet(`${coursesApiUrl}${courseId}/activity_stats/`)
+      .reply(() => [200, learnersData]);
+
+    const learnersProfile = Factory.build('learnersProfile', {}, {
+      username: ['learner-1', 'learner-2', 'learner-3'],
+    });
+    axiosMock.onGet(`${userProfileApiUrl}?username=learner-1,learner-2,learner-3`)
+      .reply(() => [200, learnersProfile.profiles]);
+
+    await executeThunk(fetchLearners(courseId), store.dispatch, store.getState);
+    return store.getState().learners;
+  }
+
+  test('Successfully load initial states in redux', async () => {
+    executeThunk(fetchLearners(courseId), store.dispatch, store.getState);
+    const state = store.getState();
+
+    expect(state.learners.status).toEqual('in-progress');
+    expect(state.learners.learnerProfiles).toEqual({});
+    expect(state.learners.pages).toHaveLength(0);
+    expect(state.learners.nextPage).toBeNull();
+    expect(state.learners.totalPages).toBeNull();
+    expect(state.learners.totalLearners).toBeNull();
+    expect(state.learners.sortedBy).toEqual('activity');
+    expect(state.learners.usernameSearch).toBeNull();
+    expect(state.learners.postFilter.postType).toEqual('all');
+    expect(state.learners.postFilter.status).toEqual('statusAll');
+    expect(state.learners.postFilter.orderBy).toEqual('lastActivityAt');
+    expect(state.learners.postFilter.cohort).toEqual('');
+  });
+
+  test('Successfully store a learner posts stats data as pages object in redux',
+    async () => {
+      const learners = await setupLearnerMockResponse();
+      const pages = learners.pages[0];
+      const stats = pages[0];
+
+      expect(pages).toHaveLength(3);
+      expect(stats.responses).toEqual(3);
+      expect(stats.threads).toEqual(1);
+      expect(stats.replies).toEqual(0);
+    });
+
+  test('Successfully store the nextPage, totalPages, totalLearners, and sortedBy data in redux',
+    async () => {
+      const learners = await setupLearnerMockResponse();
+
+      expect(learners.nextPage).toEqual(2);
+      expect(learners.totalPages).toEqual(2);
+      expect(learners.totalLearners).toEqual(6);
+      expect(learners.sortedBy).toEqual('activity');
+    });
+
+  test('Successfully updated the learner\'s sort data in redux', async () => {
+    const learners = await setupLearnerMockResponse();
+
+    expect(learners.sortedBy).toEqual('activity');
+    expect(learners.pages[0]).toHaveLength(3);
+
+    await store.dispatch(setSortedBy('recency'));
+    const updatedLearners = store.getState().learners;
+
+    expect(updatedLearners.sortedBy).toEqual('recency');
+    expect(updatedLearners.pages).toHaveLength(0);
+  });
+
+  test('Successfully updated the post-filter data in redux', async () => {
+    const learners = await setupLearnerMockResponse();
+    const filter = {
+      ...learners.postFilter,
+      postType: 'discussion',
+    };
+
+    expect(learners.postFilter.postType).toEqual('all');
+
+    await store.dispatch(setPostFilter(filter));
+    const updatedLearners = store.getState().learners;
+
+    expect(updatedLearners.postFilter.postType).toEqual('discussion');
+    expect(updatedLearners.pages).toHaveLength(0);
+  });
+
+  test('Successfully update the learner\'s search query in redux when searching for a learner',
+    async () => {
+      const learners = await setupLearnerMockResponse();
+
+      expect(learners.usernameSearch).toBeNull();
+
+      await store.dispatch(setUsernameSearch('learner-2'));
+      const updatedLearners = store.getState().learners;
+
+      expect(updatedLearners.usernameSearch).toEqual('learner-2');
+    });
+});

--- a/src/discussions/learners/data/selector.test.jsx
+++ b/src/discussions/learners/data/selector.test.jsx
@@ -6,7 +6,7 @@ import { initializeMockApp } from '@edx/frontend-platform/testing';
 
 import { initializeStore } from '../../../store';
 import { executeThunk } from '../../../test-utils';
-import { getCoursesApiUrl, getUserProfileApiUrl } from './api';
+import { getUserProfileApiUrl, learnersApiUrl } from './api';
 import {
   learnersLoadingStatus,
   selectLearnerNextPage,
@@ -18,7 +18,6 @@ import { fetchLearners } from './thunks';
 import './__factories__';
 
 const courseId = 'course-v1:edX+DemoX+Demo_Course';
-const coursesApiUrl = getCoursesApiUrl();
 const userProfileApiUrl = getUserProfileApiUrl();
 
 let axiosMock;
@@ -41,18 +40,16 @@ describe('Learner selectors test cases', () => {
     store = initializeStore();
     axiosMock = new MockAdapter(getAuthenticatedHttpClient());
 
-    const learnersData = Factory.build('learnersResult', {}, {
-      count: learnerCount,
-      pageSize: 3,
-    });
-    axiosMock.onGet(`${coursesApiUrl}${courseId}/activity_stats/`)
-      .reply(() => [200, learnersData]);
+    axiosMock.onGet(learnersApiUrl(courseId))
+      .reply(() => [200, Factory.build('learnersResult', {}, {
+        count: learnerCount,
+        pageSize: 3,
+      })]);
 
-    const learnersProfile = Factory.build('learnersProfile', {}, {
-      username: ['learner-1', 'learner-2', 'learner-3'],
-    });
     axiosMock.onGet(`${userProfileApiUrl}?username=learner-1,learner-2,learner-3`)
-      .reply(() => [200, learnersProfile.profiles]);
+      .reply(() => [200, Factory.build('learnersProfile', {}, {
+        username: ['learner-1', 'learner-2', 'learner-3'],
+      }).profiles]);
 
     await executeThunk(fetchLearners(courseId), store.dispatch, store.getState);
     state = store.getState();

--- a/src/discussions/learners/data/selector.test.jsx
+++ b/src/discussions/learners/data/selector.test.jsx
@@ -1,0 +1,84 @@
+import MockAdapter from 'axios-mock-adapter';
+import { Factory } from 'rosie';
+
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { initializeMockApp } from '@edx/frontend-platform/testing';
+
+import { initializeStore } from '../../../store';
+import { executeThunk } from '../../../test-utils';
+import { getCoursesApiUrl, getUserProfileApiUrl } from './api';
+import {
+  learnersLoadingStatus,
+  selectLearnerNextPage,
+  selectLearnerSorting,
+  selectUsernameSearch,
+} from './selectors';
+import { fetchLearners } from './thunks';
+
+import './__factories__';
+
+const courseId = 'course-v1:edX+DemoX+Demo_Course';
+const coursesApiUrl = getCoursesApiUrl();
+const userProfileApiUrl = getUserProfileApiUrl();
+
+let axiosMock;
+let store;
+const username = 'abc123';
+const learnerCount = 6;
+let state;
+
+describe('Learner selectors test cases', () => {
+  beforeEach(async () => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 3,
+        username,
+        administrator: true,
+        roles: [],
+      },
+    });
+    Factory.resetAll();
+    store = initializeStore();
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+
+    const learnersData = Factory.build('learnersResult', {}, {
+      count: learnerCount,
+      pageSize: 3,
+    });
+    axiosMock.onGet(`${coursesApiUrl}${courseId}/activity_stats/`)
+      .reply(() => [200, learnersData]);
+
+    const learnersProfile = Factory.build('learnersProfile', {}, {
+      username: ['learner-1', 'learner-2', 'learner-3'],
+    });
+    axiosMock.onGet(`${userProfileApiUrl}?username=learner-1,learner-2,learner-3`)
+      .reply(() => [200, learnersProfile.profiles]);
+
+    await executeThunk(fetchLearners(courseId), store.dispatch, store.getState);
+    state = store.getState();
+  });
+
+  afterEach(() => {
+    axiosMock.reset();
+  });
+
+  test('learnersLoadingStatus should return learners list loading status.', async () => {
+    const status = learnersLoadingStatus()(state);
+    expect(status).toEqual('successful');
+  });
+
+  test('selectUsernameSearch should return a learner search query.', async () => {
+    const userNameSearch = selectUsernameSearch()(state);
+    expect(userNameSearch).toBeNull();
+  });
+
+  test('selectLearnerSorting should return learner sortedBy.', async () => {
+    const learnerSorting = selectLearnerSorting()(state);
+    expect(learnerSorting).toEqual('activity');
+  });
+
+  test('selectLearnerNextPage should return learners next page.', async () => {
+    const learnerNextPage = selectLearnerNextPage()(state);
+    expect(learnerNextPage).toEqual(2);
+  });
+});

--- a/src/discussions/learners/test-utils.js
+++ b/src/discussions/learners/test-utils.js
@@ -1,0 +1,52 @@
+import MockAdapter from 'axios-mock-adapter';
+import { Factory } from 'rosie';
+
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+import { initializeStore } from '../../store';
+import { executeThunk } from '../../test-utils';
+import { getUserProfileApiUrl, learnerPostsApiUrl, learnersApiUrl } from './data/api';
+import { fetchLearners, fetchUserPosts } from './data/thunks';
+
+const courseId = 'course-v1:edX+DemoX+Demo_Course';
+
+export async function setupLearnerMockResponse({
+  learnerCourseId = courseId,
+  statusCode = 200,
+  learnerCount = 6,
+} = {}) {
+  const store = initializeStore();
+  const axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+
+  axiosMock.onGet(learnersApiUrl(learnerCourseId))
+    .reply(() => [statusCode, Factory.build('learnersResult', {}, {
+      count: learnerCount,
+      pageSize: 3,
+    })]);
+
+  axiosMock.onGet(`${getUserProfileApiUrl()}?username=learner-1,learner-2,learner-3`)
+    .reply(() => [statusCode, Factory.build('learnersProfile', {}, {
+      username: ['learner-1', 'learner-2', 'learner-3'],
+    }).profiles]);
+
+  await executeThunk(fetchLearners(courseId), store.dispatch, store.getState);
+  return store.getState().learners;
+}
+
+export async function setupPostsMockResponse({
+  learnerCourseId = courseId,
+  statusCode = 200,
+  username = 'abc123',
+  filters = { status: 'all' },
+} = {}) {
+  const store = initializeStore();
+  const axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+
+  axiosMock.onGet(learnerPostsApiUrl(learnerCourseId), { username, count_flagged: true })
+    .reply(() => [statusCode, Factory.build('learnerPosts', {}, {
+      abuseFlaggedCount: 1,
+    })]);
+
+  await executeThunk(fetchUserPosts(courseId, { filters }), store.dispatch, store.getState);
+  return store.getState().threads;
+}

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -1,5 +1,40 @@
 /* eslint-disable import/prefer-default-export */
+import { Factory } from 'rosie';
+
+import {
+  getUserProfileApiUrl,
+  learnerPostsApiUrl,
+  learnersApiUrl,
+} from './discussions/learners/data/api';
+import { fetchLearners, fetchUserPosts } from './discussions/learners/data/thunks';
+
 export const executeThunk = async (thunk, dispatch, getState) => {
   await thunk(dispatch, getState);
   await new Promise(setImmediate);
 };
+
+export async function setupLearnerMockResponse(learnerCourseId, statusCode, axiosMock, store, learnerCount, courseId) {
+  axiosMock.onGet(learnersApiUrl(learnerCourseId))
+    .reply(() => [statusCode, Factory.build('learnersResult', {}, {
+      count: learnerCount,
+      pageSize: 3,
+    })]);
+
+  axiosMock.onGet(`${getUserProfileApiUrl()}?username=learner-1,learner-2,learner-3`)
+    .reply(() => [statusCode, Factory.build('learnersProfile', {}, {
+      username: ['learner-1', 'learner-2', 'learner-3'],
+    }).profiles]);
+
+  await executeThunk(fetchLearners(courseId), store.dispatch, store.getState);
+  return store.getState().learners;
+}
+
+export async function setupPostsMockResponse(learnerCourseId, statusCode, filters = { status: 'all' }, axiosMock, store, courseId, username) {
+  axiosMock.onGet(learnerPostsApiUrl(learnerCourseId), { username, count_flagged: true })
+    .reply(() => [statusCode, Factory.build('learnerPosts', {}, {
+      abuseFlaggedCount: 1,
+    })]);
+
+  await executeThunk(fetchUserPosts(courseId, { filters }), store.dispatch, store.getState);
+  return store.getState().threads;
+}

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -1,40 +1,6 @@
 /* eslint-disable import/prefer-default-export */
-import { Factory } from 'rosie';
-
-import {
-  getUserProfileApiUrl,
-  learnerPostsApiUrl,
-  learnersApiUrl,
-} from './discussions/learners/data/api';
-import { fetchLearners, fetchUserPosts } from './discussions/learners/data/thunks';
 
 export const executeThunk = async (thunk, dispatch, getState) => {
   await thunk(dispatch, getState);
   await new Promise(setImmediate);
 };
-
-export async function setupLearnerMockResponse(learnerCourseId, statusCode, axiosMock, store, learnerCount, courseId) {
-  axiosMock.onGet(learnersApiUrl(learnerCourseId))
-    .reply(() => [statusCode, Factory.build('learnersResult', {}, {
-      count: learnerCount,
-      pageSize: 3,
-    })]);
-
-  axiosMock.onGet(`${getUserProfileApiUrl()}?username=learner-1,learner-2,learner-3`)
-    .reply(() => [statusCode, Factory.build('learnersProfile', {}, {
-      username: ['learner-1', 'learner-2', 'learner-3'],
-    }).profiles]);
-
-  await executeThunk(fetchLearners(courseId), store.dispatch, store.getState);
-  return store.getState().learners;
-}
-
-export async function setupPostsMockResponse(learnerCourseId, statusCode, filters = { status: 'all' }, axiosMock, store, courseId, username) {
-  axiosMock.onGet(learnerPostsApiUrl(learnerCourseId), { username, count_flagged: true })
-    .reply(() => [statusCode, Factory.build('learnerPosts', {}, {
-      abuseFlaggedCount: 1,
-    })]);
-
-  await executeThunk(fetchUserPosts(courseId, { filters }), store.dispatch, store.getState);
-  return store.getState().threads;
-}


### PR DESCRIPTION
**[INF-793](https://2u-internal.atlassian.net/browse/INF-793)**
### Description
Add test cases for redux store manipulation, API responses, selector, and important Util functions.

1. API responses
       a. Successfully get API response for the learner's list(learners profile) and learners posts(threads)
       b. Successfully store learners and learnerPosts API data in redux
       c. Failed to fetch learners
       d. Failed to fetch learner posts
       e. denied to fetch learners
       f. denied to fetch learner posts

2. Learners redux store 
      a. Successfully load initial states in redux
      b. Successfully store a learner posts stats data as pages object in redux
      c. Successfully store the nextPage, totalPages, totalLearners, and sortedBy data in redux
      d. Successfully update the learner's sort data in redux when selecting a different sort other than the default
      e. Successfully update the post-filter data in redux when selecting a different post-filter other than the default
      f. Successfully update the learner's search query in redux when searching for a learner

3. Selectors
      a. learnersLoadingStatusshould return learners list loading status
      b. selectUsernameSearch should return a learner search query 
      c. selectLearnerSorting should return learner sortedBy
      d. selectLearnerNextPage should return learners next page

#### How Has This Been Tested?

I tested this by running the npm command "npm run test"

#### Merge Checklist

* [ ✅] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.