### PR TITLE
feat: added product tour for response sort

### DIFF
--- a/src/discussions/common/HoverCard.test.jsx
+++ b/src/discussions/common/HoverCard.test.jsx
@@ -27,7 +27,7 @@ const threadsApiUrl = getThreadsApiUrl();
 const discussionPostId = 'thread-1';
 const questionPostId = 'thread-2';
 const courseId = 'course-v1:edX+TestX+Test_Course';
-const reverseOrder = false;
+const reverseOrder = true;
 const enableInContextSidebar = false;
 let store;
 let axiosMock;

--- a/src/discussions/data/hooks.js
+++ b/src/discussions/data/hooks.js
@@ -217,7 +217,7 @@ export const useTourConfiguration = (intl) => {
       advanceButtonText: intl.formatMessage(messages.advanceButtonText),
       dismissButtonText: intl.formatMessage(messages.dismissButtonText),
       endButtonText: intl.formatMessage(messages.endButtonText),
-      enabled: tour && Boolean(tour.showTour && !enableInContextSidebar),
+      enabled: tour && Boolean(tour.enabled && tour.showTour && !enableInContextSidebar),
       onDismiss: () => dispatch(updateTourShowStatus(tour.id)),
       onEnd: () => dispatch(updateTourShowStatus(tour.id)),
       checkpoints: tourCheckpoints(intl)[camelToConstant(tour.tourName)],

--- a/src/discussions/post-comments/PostCommentsView.jsx
+++ b/src/discussions/post-comments/PostCommentsView.jsx
@@ -1,6 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
 
-import { useSelector } from 'react-redux';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
@@ -10,9 +9,7 @@ import {
 } from '@edx/paragon';
 import { ArrowBack } from '@edx/paragon/icons';
 
-import {
-  EndorsementStatus, PostsPages, RequestStatus, ThreadType,
-} from '../../data/constants';
+import { EndorsementStatus, PostsPages, ThreadType } from '../../data/constants';
 import { useDispatchWithState } from '../../data/hooks';
 import { DiscussionContext } from '../common/context';
 import { useIsOnDesktop } from '../data/hooks';
@@ -24,14 +21,12 @@ import { ResponseEditor } from './comments/comment';
 import CommentsSort from './comments/CommentsSort';
 import CommentsView from './comments/CommentsView';
 import { useCommentsCount, usePost } from './data/hooks';
-import { selectCommentsStatus } from './data/selectors';
 import messages from './messages';
 
 function PostCommentsView({ intl }) {
   const [isLoading, submitDispatch] = useDispatchWithState();
   const { postId } = useParams();
   const thread = usePost(postId);
-  const commentsStatus = useSelector(selectCommentsStatus);
   const commentsCount = useCommentsCount(postId);
   const history = useHistory();
   const location = useLocation();
@@ -109,7 +104,7 @@ function PostCommentsView({ intl }) {
           />
         )}
       </div>
-      {!!commentsCount && commentsStatus === RequestStatus.SUCCESSFUL && <CommentsSort />}
+      {!!commentsCount && <CommentsSort />}
       {thread.type === ThreadType.DISCUSSION && (
         <CommentsView
           postId={postId}

--- a/src/discussions/post-comments/PostCommentsView.jsx
+++ b/src/discussions/post-comments/PostCommentsView.jsx
@@ -40,7 +40,6 @@ function PostCommentsView({ intl }) {
   const {
     courseId, learnerUsername, category, topicId, page, enableInContextSidebar,
   } = useContext(DiscussionContext);
-  const enableCommentsSort = false;
 
   useEffect(() => {
     if (!thread) { submitDispatch(fetchThread(postId, courseId, true)); }
@@ -110,7 +109,7 @@ function PostCommentsView({ intl }) {
           />
         )}
       </div>
-      {!!commentsCount && commentsStatus === RequestStatus.SUCCESSFUL && enableCommentsSort && <CommentsSort />}
+      {!!commentsCount && commentsStatus === RequestStatus.SUCCESSFUL && <CommentsSort />}
       {thread.type === ThreadType.DISCUSSION && (
         <CommentsView
           postId={postId}

--- a/src/discussions/post-comments/PostCommentsView.test.jsx
+++ b/src/discussions/post-comments/PostCommentsView.test.jsx
@@ -766,13 +766,10 @@ describe('ThreadView', () => {
 
       const comment = await waitFor(() => screen.findByTestId('comment-comment-1'));
       const sortWrapper = container.querySelector('.comments-sort');
-      const sortDropDown = within(sortWrapper)
-        .getByRole('button', { name: /Oldest first/i });
+      const sortDropDown = within(sortWrapper).getByRole('button', { name: /Oldest first/i });
 
-      expect(comment)
-        .toBeInTheDocument();
-      expect(sortDropDown)
-        .toBeInTheDocument();
+      expect(comment).toBeInTheDocument();
+      expect(sortDropDown).toBeInTheDocument();
     });
 
     it('should not show sort dropdown if there is no response', async () => {
@@ -780,15 +777,11 @@ describe('ThreadView', () => {
       renderComponent(discussionPostId);
 
       await waitFor(() => screen.findByTestId('comment-comment-1'));
-      axiosMock.onDelete(`${commentsApiUrl}${commentId}/`)
-        .reply(201);
+      axiosMock.onDelete(`${commentsApiUrl}${commentId}/`).reply(201);
       await executeThunk(removeComment(commentId, discussionPostId), store.dispatch, store.getState);
 
-      expect(await waitFor(() => screen.findByText('No responses', { exact: true })))
-        .toBeInTheDocument();
-      expect(container.querySelector('.comments-sort'))
-        .not
-        .toBeInTheDocument();
+      expect(await waitFor(() => screen.findByText('No responses', { exact: true }))).toBeInTheDocument();
+      expect(container.querySelector('.comments-sort')).not.toBeInTheDocument();
     });
 
     it('should have only two options', async () => {

--- a/src/discussions/post-comments/PostCommentsView.test.jsx
+++ b/src/discussions/post-comments/PostCommentsView.test.jsx
@@ -39,7 +39,7 @@ const questionPostId = 'thread-2';
 const closedPostId = 'thread-2';
 const courseId = 'course-v1:edX+TestX+Test_Course';
 const topicsApiUrl = `${getApiBaseUrl()}/api/discussion/v1/course_topics/${courseId}`;
-const reverseOrder = false;
+const reverseOrder = true;
 const enableInContextSidebar = false;
 let store;
 let axiosMock;
@@ -757,7 +757,7 @@ describe('ThreadView', () => {
       renderComponent(discussionPostId);
 
       await waitFor(() => screen.findByTestId('comment-comment-1'));
-      await act(async () => { fireEvent.click(screen.getByRole('button', { name: /Oldest first/i })); });
+      await act(async () => { fireEvent.click(screen.getByRole('button', { name: /Newest first/i })); });
       return waitFor(() => screen.findByTestId('comment-sort-dropdown-modal-popup'));
     };
 
@@ -766,7 +766,7 @@ describe('ThreadView', () => {
 
       const comment = await waitFor(() => screen.findByTestId('comment-comment-1'));
       const sortWrapper = container.querySelector('.comments-sort');
-      const sortDropDown = within(sortWrapper).getByRole('button', { name: /Oldest first/i });
+      const sortDropDown = within(sortWrapper).getByRole('button', { name: /Newest first/i });
 
       expect(comment).toBeInTheDocument();
       expect(sortDropDown).toBeInTheDocument();
@@ -791,21 +791,21 @@ describe('ThreadView', () => {
       expect(await within(dropdown).getAllByRole('button')).toHaveLength(2);
     });
 
-    it('should be selected Oldest first and auto focus', async () => {
+    it('should be selected Newest first and auto focus', async () => {
       const dropdown = await getCommentSortDropdown();
 
-      expect(within(dropdown).getByRole('button', { name: /Oldest first/i })).toBeInTheDocument();
-      expect(within(dropdown).getByRole('button', { name: /Oldest first/i })).toHaveFocus();
-      expect(within(dropdown).getByRole('button', { name: /Newest first/i })).not.toHaveFocus();
+      expect(within(dropdown).getByRole('button', { name: /Newest first/i })).toBeInTheDocument();
+      expect(within(dropdown).getByRole('button', { name: /Newest first/i })).toHaveFocus();
+      expect(within(dropdown).getByRole('button', { name: /Oldest first/i })).not.toHaveFocus();
     });
 
     test('successfully handles sort state update', async () => {
       const dropdown = await getCommentSortDropdown();
 
-      expect(store.getState().comments.sortOrder).toBeFalsy();
-      await act(async () => { fireEvent.click(within(dropdown).getByRole('button', { name: /Newest first/i })); });
-
       expect(store.getState().comments.sortOrder).toBeTruthy();
+      await act(async () => { fireEvent.click(within(dropdown).getByRole('button', { name: /Oldest first/i })); });
+
+      expect(store.getState().comments.sortOrder).toBeFalsy();
     });
 
     test('successfully handles tour state update', async () => {

--- a/src/discussions/post-comments/PostCommentsView.test.jsx
+++ b/src/discussions/post-comments/PostCommentsView.test.jsx
@@ -21,6 +21,7 @@ import { getThreadsApiUrl } from '../posts/data/api';
 import { fetchThread, fetchThreads } from '../posts/data/thunks';
 import { fetchCourseTopics } from '../topics/data/thunks';
 import { fetchUserDiscussionsToursSuccess } from '../tours/data';
+import { selectTours } from '../tours/data/selectors';
 import { getCommentsApiUrl } from './data/api';
 import { removeComment } from './data/thunks';
 
@@ -42,6 +43,7 @@ let store;
 let axiosMock;
 let testLocation;
 let container;
+let unmount;
 
 function mockAxiosReturnPagedComments() {
   [null, false, true].forEach(endorsed => {
@@ -120,6 +122,7 @@ function renderComponent(postId) {
     </IntlProvider>,
   );
   container = wrapper.container;
+  unmount = wrapper.unmount;
 }
 
 describe('PostView', () => {
@@ -860,10 +863,11 @@ describe('ThreadView', () => {
       }];
       await store.dispatch(fetchUserDiscussionsToursSuccess(tourData));
       renderComponent(discussionPostId);
-      expect(store.getState().tours.tours[1].enabled)
+      await waitFor(() => screen.findByTestId('comment-comment-1'));
+      expect(selectTours(store.getState()).find(item => item.tourName === 'response_sort').enabled)
         .toBeTruthy();
-      container.unmount();
-      expect(store.getState().tours.tours[1].enabled)
+      await unmount();
+      expect(selectTours(store.getState()).find(item => item.tourName === 'response_sort').enabled)
         .toBeFalsy();
     });
   });

--- a/src/discussions/post-comments/PostCommentsView.test.jsx
+++ b/src/discussions/post-comments/PostCommentsView.test.jsx
@@ -20,6 +20,7 @@ import DiscussionContent from '../discussions-home/DiscussionContent';
 import { getThreadsApiUrl } from '../posts/data/api';
 import { fetchThread, fetchThreads } from '../posts/data/thunks';
 import { fetchCourseTopics } from '../topics/data/thunks';
+import { fetchUserDiscussionsToursSuccess } from '../tours/data';
 import { getCommentsApiUrl } from './data/api';
 import { removeComment } from './data/thunks';
 
@@ -749,7 +750,7 @@ describe('ThreadView', () => {
       });
       expect(screen.queryByRole('dialog', {
         name: /Delete/i,
-        exact: false
+        exact: false,
       }))
         .toBeInTheDocument();
     });
@@ -842,6 +843,28 @@ describe('ThreadView', () => {
 
       expect(store.getState().comments.sortOrder)
         .toBeTruthy();
+    });
+    test('successfully handles tour state update', async () => {
+      const tourData = [{
+        id: 15,
+        tourName: 'not_responded_filter',
+        showTour: false,
+        enabled: true,
+        user: 8,
+      }, {
+        id: 16,
+        tourName: 'response_sort',
+        showTour: false,
+        enabled: true,
+        user: 8,
+      }];
+      await store.dispatch(fetchUserDiscussionsToursSuccess(tourData));
+      renderComponent(discussionPostId);
+      expect(store.getState().tours.tours[1].enabled)
+        .toBeTruthy();
+      container.unmount();
+      expect(store.getState().tours.tours[1].enabled)
+        .toBeFalsy();
     });
   });
 });

--- a/src/discussions/post-comments/comments/CommentsSort.jsx
+++ b/src/discussions/post-comments/comments/CommentsSort.jsx
@@ -6,18 +6,14 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import {
   Button, Dropdown, ModalPopup, useToggle,
 } from '@edx/paragon';
-import {
-  ExpandLess, ExpandMore,
-} from '@edx/paragon/icons';
+import { ExpandLess, ExpandMore } from '@edx/paragon/icons';
 
 import { updateUserDiscussionsTourByName } from '../../tours/data';
 import { selectCommentSortOrder } from '../data/selectors';
 import { setCommentSortOrder } from '../data/slices';
 import messages from '../messages';
 
-function CommentSortDropdown({
-  intl,
-}) {
+function CommentSortDropdown({ intl }) {
   const dispatch = useDispatch();
   const sortedOrder = useSelector(selectCommentSortOrder);
   const [isOpen, open, close] = useToggle(false);

--- a/src/discussions/post-comments/comments/CommentsSort.jsx
+++ b/src/discussions/post-comments/comments/CommentsSort.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -10,10 +10,10 @@ import {
   ExpandLess, ExpandMore,
 } from '@edx/paragon/icons';
 
+import { updateUserDiscussionsTourByName } from '../../tours/data';
 import { selectCommentSortOrder } from '../data/selectors';
 import { setCommentSortOrder } from '../data/slices';
 import messages from '../messages';
-import { updateUserDiscussionsTourByName } from '../../tours/data';
 
 function CommentSortDropdown({
   intl,

--- a/src/discussions/post-comments/comments/CommentsSort.jsx
+++ b/src/discussions/post-comments/comments/CommentsSort.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -13,6 +13,7 @@ import {
 import { selectCommentSortOrder } from '../data/selectors';
 import { setCommentSortOrder } from '../data/slices';
 import messages from '../messages';
+import { updateUserDiscussionsTourByName } from '../../tours/data';
 
 function CommentSortDropdown({
   intl,
@@ -21,16 +22,31 @@ function CommentSortDropdown({
   const sortedOrder = useSelector(selectCommentSortOrder);
   const [isOpen, open, close] = useToggle(false);
   const [target, setTarget] = useState(null);
-
   const handleActions = (reverseOrder) => {
     close();
     dispatch(setCommentSortOrder(reverseOrder));
   };
 
+  const enableCommentsSortTour = (enabled) => {
+    const data = {
+      enabled,
+      tourName: 'response_sort',
+    };
+    dispatch(updateUserDiscussionsTourByName(data));
+  };
+
+  useEffect(() => {
+    enableCommentsSortTour(true);
+    return () => {
+      enableCommentsSortTour(false);
+    };
+  }, []);
+
   return (
     <>
       <div className="comments-sort d-flex justify-content-end mx-4 mt-2">
         <Button
+          id="comment-sort"
           alt={intl.formatMessage(messages.actionsAlt)}
           ref={setTarget}
           variant="tertiary"

--- a/src/discussions/post-comments/comments/CommentsSort.jsx
+++ b/src/discussions/post-comments/comments/CommentsSort.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -27,13 +27,13 @@ function CommentSortDropdown({
     dispatch(setCommentSortOrder(reverseOrder));
   };
 
-  const enableCommentsSortTour = (enabled) => {
+  const enableCommentsSortTour = useCallback((enabled) => {
     const data = {
       enabled,
       tourName: 'response_sort',
     };
     dispatch(updateUserDiscussionsTourByName(data));
-  };
+  });
 
   useEffect(() => {
     enableCommentsSortTour(true);

--- a/src/discussions/post-comments/comments/CommentsSort.jsx
+++ b/src/discussions/post-comments/comments/CommentsSort.jsx
@@ -33,7 +33,7 @@ function CommentSortDropdown({
       tourName: 'response_sort',
     };
     dispatch(updateUserDiscussionsTourByName(data));
-  });
+  }, []);
 
   useEffect(() => {
     enableCommentsSortTour(true);

--- a/src/discussions/post-comments/data/slices.js
+++ b/src/discussions/post-comments/data/slices.js
@@ -22,7 +22,7 @@ const commentsSlice = createSlice({
     postStatus: RequestStatus.SUCCESSFUL,
     pagination: {},
     responsesPagination: {},
-    sortOrder: false,
+    sortOrder: true,
   },
   reducers: {
     fetchCommentsRequest: (state) => {

--- a/src/discussions/tours/constants.js
+++ b/src/discussions/tours/constants.js
@@ -10,5 +10,13 @@ export default function tourCheckpoints(intl) {
         title: intl.formatMessage(messages.notRespondedFilterTourTitle),
       },
     ],
+    RESPONSE_SORT: [
+      {
+        body: intl.formatMessage(messages.responseSortTourBody),
+        placement: 'left',
+        target: '#comment-sort',
+        title: intl.formatMessage(messages.responseSortTourTitle),
+      },
+    ],
   };
 }

--- a/src/discussions/tours/data/redux.test.js
+++ b/src/discussions/tours/data/redux.test.js
@@ -11,7 +11,7 @@ import {
   discussionsTourRequest,
   discussionsToursRequestError,
   fetchUserDiscussionsToursSuccess,
-  toursReducer,
+  toursReducer, updateUserDiscussionsTourByName,
   updateUserDiscussionsTourSuccess,
 } from './slices';
 import { fetchDiscussionTours, updateTourShowStatus } from './thunks';
@@ -181,6 +181,34 @@ describe('toursReducer', () => {
         loading: RequestStatus.FAILED,
         error: mockError,
       });
+  });
+  it('handles the updateUserDiscussionsTourByName action', () => {
+    const initialState = {
+      tours: [
+        {
+          id: 1,
+          tourName: 'not_responded_filter',
+        },
+        {
+          id: 2,
+          tourName: 'response_sort',
+        },
+      ],
+    };
+    const updatedTour = {
+      tourName: 'response_sort',
+      enabled: false,
+    };
+    const state = toursReducer(initialState, updateUserDiscussionsTourByName(updatedTour));
+    expect(state.tours)
+      .toEqual([{
+        id: 1,
+        tourName: 'not_responded_filter',
+      }, {
+        id: 2,
+        tourName: 'response_sort',
+        enabled: false,
+      }]);
   });
 });
 

--- a/src/discussions/tours/data/redux.test.js
+++ b/src/discussions/tours/data/redux.test.js
@@ -47,7 +47,7 @@ describe('DiscussionToursThunk', () => {
   });
 
   it('dispatches get request, success actions', async () => {
-    const mockData = discussionTourFactory.buildList(2);
+    const mockData = discussionTourFactory.buildList(2, {}, { tourNameList: [] });
     mockAxios.onGet(url)
       .reply(200, mockData);
 
@@ -83,7 +83,7 @@ describe('DiscussionToursThunk', () => {
   });
 
   it('dispatches put request, success actions', async () => {
-    const mockData = discussionTourFactory.build();
+    const mockData = discussionTourFactory.build({}, { tourNameList: [] });
     mockAxios.onPut(`${url}${1}`)
       .reply(200, mockData);
 

--- a/src/discussions/tours/data/selectors.js
+++ b/src/discussions/tours/data/selectors.js
@@ -1,2 +1,9 @@
 // eslint-disable-next-line import/prefer-default-export
+import { createSelector } from '@reduxjs/toolkit';
+
 export const selectTours = (state) => state.tours.tours;
+
+export const selectTourByName = (tourName) => createSelector(
+  [selectTours],
+  (tours) => tours.find(tour => tour.tourName === tourName),
+);

--- a/src/discussions/tours/data/selectors.js
+++ b/src/discussions/tours/data/selectors.js
@@ -1,9 +1,2 @@
 // eslint-disable-next-line import/prefer-default-export
-import { createSelector } from '@reduxjs/toolkit';
-
 export const selectTours = (state) => state.tours.tours;
-
-export const selectTourByName = (tourName) => createSelector(
-  [selectTours],
-  (tours) => tours.find(tour => tour.tourName === tourName),
-);

--- a/src/discussions/tours/data/slices.js
+++ b/src/discussions/tours/data/slices.js
@@ -31,6 +31,12 @@ const userDiscussionsToursSlice = createSlice({
       state.loading = RequestStatus.SUCCESSFUL;
       state.error = null;
     },
+    updateUserDiscussionsTourByName: (state, action) => {
+      const tourIndex = state.tours.findIndex(tour => tour.tourName === action.payload.tourName);
+      state.tours[tourIndex] = { ...state.tours[tourIndex], ...action.payload };
+      state.loading = RequestStatus.SUCCESSFUL;
+      state.error = null;
+    },
   },
 });
 
@@ -39,6 +45,7 @@ export const {
   fetchUserDiscussionsToursSuccess,
   discussionsToursRequestError,
   updateUserDiscussionsTourSuccess,
+  updateUserDiscussionsTourByName,
 } = userDiscussionsToursSlice.actions;
 
 export const toursReducer = userDiscussionsToursSlice.reducer;

--- a/src/discussions/tours/data/thunks.js
+++ b/src/discussions/tours/data/thunks.js
@@ -10,11 +10,7 @@ import {
 } from './slices';
 
 function normaliseTourData(data) {
-  data.forEach(tour => {
-    // eslint-disable-next-line no-param-reassign
-    tour.enabled = true;
-  });
-  return data;
+  return data.map(tour => ({ ...tour, enabled: true }));
 }
 
 /**

--- a/src/discussions/tours/data/thunks.js
+++ b/src/discussions/tours/data/thunks.js
@@ -9,6 +9,14 @@ import {
   updateUserDiscussionsTourSuccess,
 } from './slices';
 
+function normaliseTourData(data) {
+  data.forEach(tour => {
+    // eslint-disable-next-line no-param-reassign
+    tour.enabled = true;
+  });
+  return data;
+}
+
 /**
  * Action thunk to fetch the list of discussion tours for the current user.
  * @returns {function} - Thunk that dispatches the request, success, and error actions.
@@ -18,7 +26,7 @@ export function fetchDiscussionTours() {
     try {
       dispatch(discussionsTourRequest());
       const data = await getDiscssionTours();
-      dispatch(fetchUserDiscussionsToursSuccess(camelCaseObject(data)));
+      dispatch(fetchUserDiscussionsToursSuccess(camelCaseObject(normaliseTourData(data))));
     } catch (error) {
       dispatch(discussionsToursRequestError());
       logError(error);

--- a/src/discussions/tours/data/tours.factory.js
+++ b/src/discussions/tours/data/tours.factory.js
@@ -2,8 +2,7 @@ import { Factory } from 'rosie';
 
 const discussionTourFactory = new Factory()
   .sequence('id')
-  .option('tourNameList', ['id'], (id) => `Discussion Tour ${id}`)
-  .attr('tourName', ['id', 'tourNameList'], (id, tourNameList) => tourNameList[id] ?? `Discussion Tour ${id}`)
+  .attr('tourName', ['id'], (id) => `Discussion Tour ${id}`)
   .attr('description', ['id'], (id) => `This is the description for Discussion Tour ${id}.`)
   .attr('enabled', ['id'], true);
 

--- a/src/discussions/tours/data/tours.factory.js
+++ b/src/discussions/tours/data/tours.factory.js
@@ -3,6 +3,7 @@ import { Factory } from 'rosie';
 const discussionTourFactory = new Factory()
   .sequence('id')
   .attr('name', ['id'], (id) => `Discussion Tour ${id}`)
-  .attr('description', ['id'], (id) => `This is the description for Discussion Tour ${id}.`);
+  .attr('description', ['id'], (id) => `This is the description for Discussion Tour ${id}.`)
+  .attr('enabled', ['id'], true);
 
 export default discussionTourFactory;

--- a/src/discussions/tours/data/tours.factory.js
+++ b/src/discussions/tours/data/tours.factory.js
@@ -2,7 +2,8 @@ import { Factory } from 'rosie';
 
 const discussionTourFactory = new Factory()
   .sequence('id')
-  .attr('name', ['id'], (id) => `Discussion Tour ${id}`)
+  .option('tourNameList', ['id'], (id) => `Discussion Tour ${id}`)
+  .attr('tourName', ['id', 'tourNameList'], (id, tourNameList) => tourNameList[id] ?? `Discussion Tour ${id}`)
   .attr('description', ['id'], (id) => `This is the description for Discussion Tour ${id}.`)
   .attr('enabled', ['id'], true);
 

--- a/src/discussions/tours/messages.js
+++ b/src/discussions/tours/messages.js
@@ -26,6 +26,16 @@ const messages = defineMessages({
     defaultMessage: 'New filtering option!',
     description: 'Title of the tour for the not responded filter',
   },
+  responseSortTourBody: {
+    id: 'tour.body.responseSortTour',
+    defaultMessage: 'Responses and comments are now sorted by newest first. Please use this option to change the sort order',
+    description: 'Body of the tour for the response sort',
+  },
+  responseSortTourTitle: {
+    id: 'tour.title.responseSortTour',
+    defaultMessage: 'Sort Responses!',
+    description: 'Title of the tour for the response sort',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
### Description
This PR adds a new product tour for the response sort feature. Responses will be sort as Newest first by default

## Ticket 
[INF-782](https://2u-internal.atlassian.net/browse/INF-782)
[INF-781](https://2u-internal.atlassian.net/browse/INF-781)

#### How Has This Been Tested?

1. Tested with both tours enabled.
2. Tested with one tour enabled i.e response_sort.
3. Tested with response_sort tour not available in API
4. Tested with Newest first responses sort


#### Screenshots/sandbox (optional):


https://user-images.githubusercontent.com/26253150/222651490-e5a17a73-7cbb-4733-b544-a357ac524b75.mov
<img width="944" alt="Screenshot 2023-03-09 at 6 59 58 PM" src="https://user-images.githubusercontent.com/79941147/224048069-c83e7809-a75f-4659-90fb-59c6b8b43d79.png">


#### Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.