### PR TITLE
test: added test cases for learner post view

### DIFF
--- a/src/discussions/learners/LearnerPostsView.test.jsx
+++ b/src/discussions/learners/LearnerPostsView.test.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 
 import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
+  fireEvent, render, screen, waitFor,
 } from '@testing-library/react';
 import MockAdapter from 'axios-mock-adapter';
 import { act } from 'react-dom/test-utils';
@@ -137,5 +134,36 @@ describe('Learner Posts View', () => {
 
     expect(posts).toHaveLength(2);
     expect(posts).toHaveLength(Object.values(store.getState().threads.threadsById).length);
+  });
+
+  it.each([
+    { searchBy: 'type-all', result: 2 },
+    { searchBy: 'type-discussions', result: 2 },
+    { searchBy: 'type-questions', result: 2 },
+    { searchBy: 'status-unread', result: 2 },
+    { searchBy: 'sort-comments', result: 2 },
+    { searchBy: 'sort-votes', result: 2 },
+    { searchBy: 'sort-activity', result: 2 },
+  ])('successfully display learners by %s.', async ({ searchBy, result }) => {
+    await setUpPrivilages(axiosMock, store, true);
+    await renderComponent();
+
+    const filterBar = container.querySelector('.collapsible-trigger');
+    await act(async () => {
+      fireEvent.click(filterBar);
+    });
+
+    await waitFor(async () => {
+      const activity = container.querySelector(`[for='${searchBy}']`);
+
+      await act(async () => {
+        fireEvent.click(activity);
+      });
+      await waitFor(() => {
+        const learners = container.querySelectorAll('.discussion-post');
+
+        expect(learners).toHaveLength(result);
+      });
+    });
   });
 });

--- a/src/discussions/learners/test-utils.js
+++ b/src/discussions/learners/test-utils.js
@@ -5,7 +5,7 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 import { initializeStore } from '../../store';
 import { executeThunk } from '../../test-utils';
-import { getCourseConfigApiUrl } from '../data/api';
+import { getDiscussionsConfigUrl } from '../data/api';
 import { fetchCourseConfig } from '../data/thunks';
 import { getUserProfileApiUrl, learnerPostsApiUrl, learnersApiUrl } from './data/api';
 import { fetchLearners, fetchUserPosts } from './data/thunks';
@@ -54,9 +54,9 @@ export async function setupPostsMockResponse({
 }
 
 export async function setUpPrivilages(axiosMock, store, hasModerationPrivileges) {
-  axiosMock.onGet(`${getCourseConfigApiUrl()}${courseId}/`).reply(200, {
+  axiosMock.onGet(getDiscussionsConfigUrl(courseId)).reply(200, {
     has_moderation_privileges: hasModerationPrivileges,
   });
-  axiosMock.onGet(`${getCourseConfigApiUrl()}${courseId}/settings`).reply(200, {});
+
   await executeThunk(fetchCourseConfig(courseId), store.dispatch, store.getState);
 }

--- a/src/discussions/learners/test-utils.js
+++ b/src/discussions/learners/test-utils.js
@@ -5,6 +5,8 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 import { initializeStore } from '../../store';
 import { executeThunk } from '../../test-utils';
+import { getCourseConfigApiUrl } from '../data/api';
+import { fetchCourseConfig } from '../data/thunks';
 import { getUserProfileApiUrl, learnerPostsApiUrl, learnersApiUrl } from './data/api';
 import { fetchLearners, fetchUserPosts } from './data/thunks';
 
@@ -49,4 +51,12 @@ export async function setupPostsMockResponse({
 
   await executeThunk(fetchUserPosts(courseId, { filters }), store.dispatch, store.getState);
   return store.getState().threads;
+}
+
+export async function setUpPrivilages(axiosMock, store, hasModerationPrivileges) {
+  axiosMock.onGet(`${getCourseConfigApiUrl()}${courseId}/`).reply(200, {
+    has_moderation_privileges: hasModerationPrivileges,
+  });
+  axiosMock.onGet(`${getCourseConfigApiUrl()}${courseId}/settings`).reply(200, {});
+  await executeThunk(fetchCourseConfig(courseId), store.dispatch, store.getState);
 }


### PR DESCRIPTION
[INF-792](https://2u-internal.atlassian.net/browse/INF-792)
### Description

Added test case for the following area
1. learner title bar
    a. It should display a title bar, a learner name, and a back button
    b. It should redirect to the learners list when clicking on the back button

2. learners posts filter
    a. It should display a post-filter bar and All posts sorted by recent activity text as default.

3. learner posts list
    a. It should display a list of the interactive posts of a selected learner and the posts count should be equal to the API 
        response count. 

#### How Has This Been Tested?

npm run test

#### Merge Checklist

* [✅] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.