### PR TITLE
fix: typeset failed: window.MathJax.typesetClear is not a function

### DIFF
--- a/src/components/HTMLLoader.jsx
+++ b/src/components/HTMLLoader.jsx
@@ -34,7 +34,6 @@ function HTMLLoader({
     if (debouncedPostContent) {
       typeset(() => {
         if (previewRef.current !== null && typeof window?.MathJax !== 'undefined') {
-          window.MathJax.typesetClear();
           previewRef.current.innerHTML = sanitizedMath;
         }
       });


### PR DESCRIPTION
[INF-840](https://2u-internal.atlassian.net/browse/INF-840)
Description

Currently, Discussions MFE has many frequent JS errors on the new relic dashboard.
This PR intends to resolve `typeset failed:e.typesetPromise is not a function`

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.