### PR TITLE
fix: lock is used for post close or reopen

### DIFF
--- a/src/discussions/utils.js
+++ b/src/discussions/utils.js
@@ -5,7 +5,7 @@ import { generatePath, useRouteMatch } from 'react-router';
 
 import { getConfig } from '@edx/frontend-platform';
 import {
-  CheckCircle, CheckCircleOutline, Delete, Edit, Pin, QuestionAnswer, Report, Verified, VerifiedOutline,
+  CheckCircle, CheckCircleOutline, Delete, Edit, Lock, LockOpen, Pin, Report, Verified, VerifiedOutline,
 } from '@edx/paragon/icons';
 
 import { InsertLink } from '../components/icons';
@@ -141,14 +141,14 @@ export const ACTIONS_LIST = [
   {
     id: 'close',
     action: ContentActions.CLOSE,
-    icon: QuestionAnswer,
+    icon: Lock,
     label: messages.closeAction,
     conditions: { closed: false },
   },
   {
     id: 'reopen',
     action: ContentActions.CLOSE,
-    icon: QuestionAnswer,
+    icon: LockOpen,
     label: messages.reopenAction,
     conditions: { closed: true },
   },


### PR DESCRIPTION
[INF-529](https://2u-internal.atlassian.net/browse/INF-529)
### Description

Lock icon is  used for post close and LockOpen icon is used for reopen action in actions menu.


**Before**


![locck](https://user-images.githubusercontent.com/73840786/228301554-c5681956-6812-4051-bf86-f112b088d85e.png)

**After**

<img width="154" alt="Screenshot 2023-03-28 at 4 39 00 PM" src="https://user-images.githubusercontent.com/73840786/228301633-bd3f01d1-950f-4802-8881-2ccb679c7d2a.png">

<img width="152" alt="Screenshot 2023-03-28 at 4 39 22 PM" src="https://user-images.githubusercontent.com/73840786/228301650-e3acdde5-a1ee-4884-bf9e-8045f74afb53.png">


#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.