### PR TITLE
fix: removes double line between tabs

### DIFF
--- a/src/discussions/navigation/navigation-bar/NavigationBar.jsx
+++ b/src/discussions/navigation/navigation-bar/NavigationBar.jsx
@@ -38,13 +38,12 @@ function NavigationBar({ intl }) {
   }
 
   return (
-    <Nav variant="pills" className="py-2">
+    <Nav variant="button-group" className="py-2">
       {navLinks.map(link => (
         <Nav.Item key={link.route}>
           <Nav.Link
             as={NavLink}
             to={discussionsPath(link.route, { courseId })}
-            className="border"
             isActive={link.isActive}
           >
             {intl.formatMessage(link.labelMessage)}

--- a/src/index.scss
+++ b/src/index.scss
@@ -340,6 +340,14 @@ header {
   box-shadow: 0px 2px 4px rgb(0 0 0 / 15%), 0px 2px 8px rgb(0 0 0 / 15%);
   position: sticky;
   top: 0;
+
+  .nav-button-group{
+    .nav-item:not(:last-child){
+      .nav-link {
+          border-right: 0;
+      }
+    }
+  }
 }
 
 .breadcrumb-menu {


### PR DESCRIPTION
[INF-389](https://2u-internal.atlassian.net/browse/INF-389)
### Description

Removed double line between tabs

**Before**

<img width="636" alt="Screenshot 2023-03-29 at 1 00 11 PM" src="https://user-images.githubusercontent.com/73840786/228466894-30772971-ca28-40fe-9981-fc523bd7a96a.png">


**After**

<img width="1196" alt="Screenshot 2023-03-29 at 12 55 04 PM" src="https://user-images.githubusercontent.com/73840786/228466933-0557f9d9-7b61-4618-b167-bc63d4356185.png">


#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.