### PR TITLE
fix: removes outline around comment cards

### DIFF
--- a/src/discussions/post-comments/comments/comment/Comment.jsx
+++ b/src/discussions/post-comments/comments/comment/Comment.jsx
@@ -110,7 +110,7 @@ function Comment({
       {/* eslint-disable jsx-a11y/no-noninteractive-tabindex */}
       <div
         tabIndex="0"
-        className="d-flex flex-column card on-focus"
+        className="d-flex flex-column card on-focus border-0"
         data-testid={`comment-${comment.id}`}
         role="listitem"
       >


### PR DESCRIPTION
[INF-381](https://github.com/openedx/frontend-app-discussions/pull/new/Ayesha/inf-381)
### Description

Remove outline around posts and response/comment cards

**Before**

<img width="533" alt="Screenshot 2023-03-29 at 1 22 29 PM" src="https://user-images.githubusercontent.com/73840786/228472456-86369254-c353-42cb-a536-8229fd0872d5.png">

**After**

<img width="483" alt="Screenshot 2023-03-29 at 1 21 33 PM" src="https://user-images.githubusercontent.com/73840786/228472483-efcadf95-2cee-4dce-8603-8fe4e9cd6e7b.png">


#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.