### PR TITLE
style: tooltips aligned to the side in topic stats

### DIFF
--- a/src/components/TopicStats.jsx
+++ b/src/components/TopicStats.jsx
@@ -26,6 +26,7 @@ function TopicStats({
   return (
     <div className="d-flex align-items-center mt-2.5" style={{ marginBottom: '2px' }}>
       <OverlayTrigger
+        placement="right"
         overlay={(
           <Tooltip>
             <div className="d-flex flex-column align-items-start">
@@ -42,6 +43,7 @@ function TopicStats({
         </div>
       </OverlayTrigger>
       <OverlayTrigger
+        placement="right"
         overlay={(
           <Tooltip>
             <div className="d-flex flex-column align-items-start">
@@ -59,6 +61,7 @@ function TopicStats({
       </OverlayTrigger>
       {Boolean(canSeeReportedStats) && (
         <OverlayTrigger
+          placement="right"
           overlay={(
             <Tooltip>
               <div className="d-flex flex-column align-items-start">

--- a/src/discussions/topics/topic-group/topic/Topic.jsx
+++ b/src/discussions/topics/topic-group/topic/Topic.jsx
@@ -56,6 +56,7 @@ function Topic({
           </div>
           <div className="d-flex align-items-center mt-2.5" style={{ marginBottom: '2px' }}>
             <OverlayTrigger
+              placement="right"
               overlay={(
                 <Tooltip>
                   <div className="d-flex flex-column align-items-start">
@@ -72,6 +73,7 @@ function Topic({
               </div>
             </OverlayTrigger>
             <OverlayTrigger
+              placement="right"
               overlay={(
                 <Tooltip>
                   <div className="d-flex flex-column align-items-start">
@@ -89,6 +91,7 @@ function Topic({
             </OverlayTrigger>
             {Boolean(canSeeReportedStats) && (
               <OverlayTrigger
+                placement="right"
                 overlay={(
                   <Tooltip>
                     <div className="d-flex flex-column align-items-start">


### PR DESCRIPTION
[INNF-624](https://2u-internal.atlassian.net/browse/INF-624)
### Description

In topic stats, tooltips are aligned to the side, instead of the top.

<img width="452" alt="Screenshot 2023-03-29 at 8 40 33 PM" src="https://user-images.githubusercontent.com/73840786/228593128-e3890521-d80a-4e81-9bba-6d132bbdbbc1.png">


#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.