### PR TITLE
fix: added role for editedby and closedby user

### DIFF
--- a/src/discussions/common/AlertBanner.jsx
+++ b/src/discussions/common/AlertBanner.jsx
@@ -8,6 +8,7 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Alert } from '@edx/paragon';
 import { Report } from '@edx/paragon/icons';
 
+import { AvatarOutlineAndLabelColors } from '../../data/constants';
 import {
   selectModerationSettings, selectUserHasModerationPrivileges, selectUserIsGroupTa, selectUserIsStaff,
 } from '../data/selectors';
@@ -29,6 +30,7 @@ function AlertBanner({
   const canSeeLastEditOrClosedAlert = (userHasModerationPrivileges || userIsGroupTa
     || userIsGlobalStaff || userIsContentAuthor
   );
+  const authorLabelColor = AvatarOutlineAndLabelColors[content.authorLabel];
 
   return (
     <>
@@ -44,7 +46,13 @@ function AlertBanner({
               <div className="d-flex align-items-center flex-wrap text-gray-700 font-style">
                 {intl.formatMessage(messages.editedBy)}
                 <span className="ml-1 mr-3">
-                  <AuthorLabel author={content.lastEdit.editorUsername} linkToProfile postOrComment />
+                  <AuthorLabel
+                    author={content.lastEdit.editorUsername}
+                    authorLabel={content.authorLabel}
+                    labelColor={authorLabelColor && `text-${authorLabelColor}`}
+                    linkToProfile
+                    postOrComment
+                  />
                 </span>
                 <span
                   className="mx-1.5 font-size-8 font-style text-light-700"
@@ -61,7 +69,13 @@ function AlertBanner({
               <div className="d-flex align-items-center flex-wrap text-gray-700 font-style">
                 {intl.formatMessage(messages.closedBy)}
                 <span className="ml-1 ">
-                  <AuthorLabel author={content.closedBy} linkToProfile postOrComment />
+                  <AuthorLabel
+                    author={content.closedBy}
+                    authorLabel={content.authorLabel}
+                    labelColor={authorLabelColor && `text-${authorLabelColor}`}
+                    linkToProfile
+                    postOrComment
+                  />
                 </span>
                 <span
                   className="mx-1.5 font-size-8 font-style text-light-700"

--- a/src/discussions/common/AlertBanner.jsx
+++ b/src/discussions/common/AlertBanner.jsx
@@ -56,7 +56,7 @@ function AlertBanner({
                   />
                 </span>
                 <span
-                  className="mx-1.5 font-size-8 font-style text-light-700"
+                  className="mr-1.5 font-size-8 font-style text-light-700"
                   style={{ lineHeight: '15px' }}
                 >
                   {intl.formatMessage(messages.fullStop)}
@@ -79,14 +79,12 @@ function AlertBanner({
                   />
                 </span>
                 <span
-                  className="mx-1.5 font-size-8 font-style text-light-700"
+                  className="mr-1.5 font-size-8 font-style text-light-700"
                   style={{ lineHeight: '15px' }}
                 >
                   {intl.formatMessage(messages.fullStop)}
                 </span>
-
                 {content.closeReason && (`${intl.formatMessage(messages.reason)}: ${content.closeReason}`)}
-
               </div>
             </Alert>
           )}

--- a/src/discussions/common/AlertBanner.jsx
+++ b/src/discussions/common/AlertBanner.jsx
@@ -15,7 +15,7 @@ import {
 import { commentShape } from '../post-comments/comments/comment/proptypes';
 import messages from '../post-comments/messages';
 import { postShape } from '../posts/post/proptypes';
-import AuthorLabel from './AuthorLabel';
+import AlertBar from './AlertBar';
 
 function AlertBanner({
   intl,
@@ -43,50 +43,22 @@ function AlertBanner({
       {reasonCodesEnabled && canSeeLastEditOrClosedAlert && (
         <>
           {content.lastEdit?.reason && (
-            <Alert variant="info" className="px-3 shadow-none mb-1 py-10px bg-light-200">
-              <div className="d-flex align-items-center flex-wrap text-gray-700 font-style">
-                {intl.formatMessage(messages.editedBy)}
-                <span className="ml-1">
-                  <AuthorLabel
-                    author={content.lastEdit.editorUsername}
-                    authorLabel={content.editByLabel}
-                    labelColor={editByLabelColor && `text-${editByLabelColor}`}
-                    linkToProfile
-                    postOrComment
-                  />
-                </span>
-                <span
-                  className="mr-1.5 font-size-8 font-style text-light-700"
-                  style={{ lineHeight: '15px' }}
-                >
-                  {intl.formatMessage(messages.fullStop)}
-                </span>
-                {intl.formatMessage(messages.reason)}:&nbsp;{content.lastEdit.reason}
-              </div>
-            </Alert>
+            <AlertBar
+              message={messages.editedBy}
+              author={content.lastEdit.editorUsername}
+              authorLabel={content.editByLabel}
+              labelColor={editByLabelColor && `text-${editByLabelColor}`}
+              reason={content.lastEdit.reason}
+            />
           )}
           {content.closed && (
-            <Alert variant="info" className="px-3 shadow-none mb-1 py-10px bg-light-200">
-              <div className="d-flex align-items-center flex-wrap text-gray-700 font-style">
-                {intl.formatMessage(messages.closedBy)}
-                <span className="ml-1 ">
-                  <AuthorLabel
-                    author={content.closedBy}
-                    authorLabel={content.closedByLabel}
-                    labelColor={closedByLabelColor && `text-${closedByLabelColor}`}
-                    linkToProfile
-                    postOrComment
-                  />
-                </span>
-                <span
-                  className="mr-1.5 font-size-8 font-style text-light-700"
-                  style={{ lineHeight: '15px' }}
-                >
-                  {intl.formatMessage(messages.fullStop)}
-                </span>
-                {content.closeReason && (`${intl.formatMessage(messages.reason)}: ${content.closeReason}`)}
-              </div>
-            </Alert>
+          <AlertBar
+            message={messages.closedBy}
+            author={content.closedBy}
+            authorLabel={content.closedByLabel}
+            labelColor={closedByLabelColor && `text-${closedByLabelColor}`}
+            reason={content.closeReason}
+          />
           )}
         </>
       )}

--- a/src/discussions/common/AlertBanner.jsx
+++ b/src/discussions/common/AlertBanner.jsx
@@ -30,7 +30,8 @@ function AlertBanner({
   const canSeeLastEditOrClosedAlert = (userHasModerationPrivileges || userIsGroupTa
     || userIsGlobalStaff || userIsContentAuthor
   );
-  const authorLabelColor = AvatarOutlineAndLabelColors[content.authorLabel];
+  const editByLabelColor = AvatarOutlineAndLabelColors[content.editByLabel];
+  const closedByLabelColor = AvatarOutlineAndLabelColors[content.closedByLabel];
 
   return (
     <>
@@ -45,11 +46,11 @@ function AlertBanner({
             <Alert variant="info" className="px-3 shadow-none mb-1 py-10px bg-light-200">
               <div className="d-flex align-items-center flex-wrap text-gray-700 font-style">
                 {intl.formatMessage(messages.editedBy)}
-                <span className="ml-1 mr-3">
+                <span className="ml-1">
                   <AuthorLabel
                     author={content.lastEdit.editorUsername}
-                    authorLabel={content.authorLabel}
-                    labelColor={authorLabelColor && `text-${authorLabelColor}`}
+                    authorLabel={content.editByLabel}
+                    labelColor={editByLabelColor && `text-${editByLabelColor}`}
                     linkToProfile
                     postOrComment
                   />
@@ -71,8 +72,8 @@ function AlertBanner({
                 <span className="ml-1 ">
                   <AuthorLabel
                     author={content.closedBy}
-                    authorLabel={content.authorLabel}
-                    labelColor={authorLabelColor && `text-${authorLabelColor}`}
+                    authorLabel={content.closedByLabel}
+                    labelColor={closedByLabelColor && `text-${closedByLabelColor}`}
                     linkToProfile
                     postOrComment
                   />

--- a/src/discussions/common/AlertBar.jsx
+++ b/src/discussions/common/AlertBar.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { Alert } from '@edx/paragon';
+
+import messages from '../post-comments/messages';
+import AuthorLabel from './AuthorLabel';
+
+function AlertBar({
+  intl,
+  message,
+  author,
+  authorLabel,
+  labelColor,
+  reason,
+}) {
+  return (
+    <Alert variant="info" className="px-3 shadow-none mb-1 py-10px bg-light-200">
+      <div className="d-flex align-items-center flex-wrap text-gray-700 font-style">
+        {intl.formatMessage(message)}
+        <span className="ml-1">
+          <AuthorLabel
+            author={author}
+            authorLabel={authorLabel}
+            labelColor={labelColor}
+            linkToProfile
+            postOrComment
+          />
+        </span>
+        <span
+          className="mr-1.5 font-size-8 font-style text-light-700"
+          style={{ lineHeight: '15px' }}
+        >
+          {intl.formatMessage(messages.fullStop)}
+        </span>
+        {reason && (`${intl.formatMessage(messages.reason)}: ${reason}`)}
+      </div>
+    </Alert>
+  );
+}
+
+AlertBar.propTypes = {
+  intl: intlShape.isRequired,
+  message: PropTypes.string,
+  author: PropTypes.string,
+  authorLabel: PropTypes.string,
+  labelColor: PropTypes.string,
+  reason: PropTypes.string,
+};
+
+AlertBar.defaultProps = {
+  message: '',
+  author: '',
+  authorLabel: '',
+  labelColor: '',
+  reason: '',
+};
+
+export default injectIntl(AlertBar);

--- a/src/discussions/common/AuthorLabel.jsx
+++ b/src/discussions/common/AuthorLabel.jsx
@@ -85,7 +85,7 @@ function AuthorLabel({
           />
           {authorLabelMessage && (
             <span
-              className={classNames('font-size-14 font-style font-weight-500', {
+              className={classNames('mr-1.5 font-size-14 font-style font-weight-500', {
                 'text-primary-500': showTextPrimary,
                 'text-gray-700': isRetiredUser,
               })}

--- a/src/discussions/common/AuthorLabel.jsx
+++ b/src/discussions/common/AuthorLabel.jsx
@@ -85,7 +85,7 @@ function AuthorLabel({
           />
           {authorLabelMessage && (
             <span
-              className={classNames('mr-1.5 font-size-14 font-style font-weight-500', {
+              className={classNames('font-size-14 font-style font-weight-500', {
                 'text-primary-500': showTextPrimary,
                 'text-gray-700': isRetiredUser,
               })}


### PR DESCRIPTION
[INF-818](https://2u-internal.atlassian.net/browse/INF-818)
### Description

1. Role info needs to be present in edited and closed banner.
2. Username and role color in the banner should match figma.

|Before|After|
|-------|-----|
|   <img width="562" alt="Screenshot 2023-04-14 at 3 54 29 PM" src="https://user-images.githubusercontent.com/72802712/232026106-d56575d1-5eb4-4c0e-8ac5-ab51ea13b7cf.png">   |   <img width="532" alt="Screenshot 2023-04-18 at 2 40 47 PM" src="https://user-images.githubusercontent.com/72802712/232737967-a856502c-2fe1-4a72-9573-752447e46cf1.png">  |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.