### PR TITLE
fix: fixed feedback widget position issue

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -518,3 +518,7 @@ header {
   font-size: 18px;
   line-height: 28px;
 }
+
+.usabilla_live_button_container{
+  right: 0px !important;
+}


### PR DESCRIPTION
[INF-817](https://2u-internal.atlassian.net/browse/INF-817)
### Description

We need to move the feedback button towards the bottom right in the Discussion tab and in the sidebar to avoid overlap with post content and summary, respectively.
As of now, it overlaps with post summary/content.


#### Screenshots/sandbox (optional):
Include a link to the sandbox for design changes or screenshot for before and after. **Remove this section if it's not applicable.**

|Before|After|
|-------|-----|
| <img width="622" alt="Screenshot 2023-04-17 at 11 50 50 AM" src="https://user-images.githubusercontent.com/72802712/232407482-da6baa2f-0c3e-4a1c-bb38-de1b2ff40e1a.png">|<img width="626" alt="Screenshot 2023-04-17 at 11 50 13 AM" src="https://user-images.githubusercontent.com/72802712/232407525-e38d6d7c-494f-4006-a7ad-ad2b1f6fe7e7.png">|

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.