### PR TITLE
fix: postLink footer icon size

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -95,13 +95,13 @@ $fa-font-path: "~font-awesome/fonts";
 }
 
 .post-summary-comment-count-dimensions {
-  height: 15.39px;
-  width: 15.5px
+  height: 15.39px !important;
+  width: 15.5px !important;
 }
 
 .post-summary-like-dimensions {
-  height: 16px;
-  width: 17px
+  height: 16px !important;
+  width: 17px !important;
 }
 
 .post-summary-timestamp {


### PR DESCRIPTION
### Description
This PR fixes the postLink footer icon size. Currently, icon sizes are big on stage.

|Before|After|
### Before
<img width="368" alt="Screenshot 2023-05-08 at 6 03 23 PM" src="https://user-images.githubusercontent.com/79941147/236831458-deeea8dd-0172-48d7-a3ae-1759cdbd956b.png">

### After
<img width="376" alt="Screenshot 2023-05-08 at 6 03 11 PM" src="https://user-images.githubusercontent.com/79941147/236831486-f6354c04-51d6-400b-a48d-8d7490eef881.png">


#### Merge Checklist
* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.