### PR TITLE
fix: direct link thread no found issue

### DIFF
--- a/src/discussions/post-comments/PostCommentsView.jsx
+++ b/src/discussions/post-comments/PostCommentsView.jsx
@@ -39,14 +39,14 @@ const PostCommentsView = () => {
   const { closed, id: threadId, type } = usePost(postId);
 
   useEffect(() => {
-    if (!postId) {
+    if (!threadId) {
       submitDispatch(fetchThread(postId, courseId, true));
     }
 
     return () => {
       setAddingResponse(false);
     };
-  }, [postId, courseId]);
+  }, [postId]);
 
   const handleAddResponseButton = useCallback(() => {
     setAddingResponse(true);


### PR DESCRIPTION
### [INF-883](https://2u-internal.atlassian.net/browse/INF-883)
### Description
Some direct links to discussion posts seem to be broken. The discussion post can be found using search and then viewed, but a direct link leads to an error that says, "Thread not found"

#### How Has This Been Tested?
Steps to reproduce
1.) Visit the discussion forum.
2.) Search for any post which is not visible on the first page.
3.) Discussion post loads.
4.) Now try reloading the page or directly visiting the link.
5.) See "Thread not found" error.

#### Screenshots/sandbox (optional):
**Before**
<img width="1439" alt="Screenshot 2023-05-10 at 1 10 45 PM" src="https://github.com/openedx/frontend-app-discussions/assets/79941147/5b6513e6-c1a7-4dfe-8f2a-2f8e33f9feaa">


**After**
<img width="1439" alt="Screenshot 2023-05-10 at 1 08 55 PM" src="https://github.com/openedx/frontend-app-discussions/assets/79941147/a0be4a1e-baad-4d07-a7e3-e74637c3cb20">
