### PR TITLE
fix: post sharing URL

### DIFF
--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -67,6 +67,11 @@ function Post({
     hideReportConfirmation();
   };
 
+  const handlePostCopyLink = useCallback(() => {
+    const postURL = new URL(`${getConfig().PUBLIC_PATH}${courseId}/posts/${post.id}`, window.location.origin);
+    navigator.clipboard.writeText(postURL.href);
+  }, [window.location.origin, post.id, courseId]);
+
   const actionHandlers = useMemo(() => ({
     [ContentActions.EDIT_CONTENT]: () => history.push({
       ...location,
@@ -82,7 +87,7 @@ function Post({
         dispatch(updateExistingThread(post.id, { closed: true }));
       }
     },
-    [ContentActions.COPY_LINK]: () => { navigator.clipboard.writeText(`${window.location.origin}/${courseId}/posts/${post.id}`); },
+    [ContentActions.COPY_LINK]: handlePostCopyLink,
     [ContentActions.PIN]: () => dispatch(updateExistingThread(post.id, { pinned: !post.pinned })),
     [ContentActions.REPORT]: () => handleAbusedFlag(),
   }), [


### PR DESCRIPTION
When MFE uses path-based deployment (common domain for all MFEs divided by path) - the copied link leads to 404 error.

The fix:
- construct a Post URL using MFE's `PUBLIC_PATH` env var
- works for both subdomain and subdirectory-based deployments

**This is a backport of https://github.com/openedx/frontend-app-discussions/pull/445**