### PR TITLE
fix: switch to use PUBLIC_PATH for routes

### DIFF
--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -137,7 +137,7 @@ export const DiscussionProvider = {
   OPEN_EDX: 'openedx',
 };
 
-const BASE_PATH = '/:courseId';
+const BASE_PATH = `${getConfig().PUBLIC_PATH}:courseId`;
 
 export const Routes = {
   DISCUSSIONS: {


### PR DESCRIPTION
### Description

Changes how the path are created for navigation. It will now use PUBLIC_PATH for path

Ticket; [INF-890](https://2u-internal.atlassian.net/browse/INF-890)

#### How Has This Been Tested?

Tested locally by navigating to different routes

#### Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [x] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.