### PR TITLE
fix: error 400  editing comment

### DIFF
--- a/src/discussions/post-comments/comments/comment/CommentEditor.jsx
+++ b/src/discussions/post-comments/comments/comment/CommentEditor.jsx
@@ -61,7 +61,7 @@ const CommentEditor = ({
   const initialValues = {
     comment: rawBody,
     // eslint-disable-next-line react/prop-types
-    editReasonCode: lastEdit?.reasonCode || (userIsStaff ? 'violates-guidelines' : ''),
+    editReasonCode: lastEdit?.reasonCode || (userIsStaff && canDisplayEditReason ? 'violates-guidelines' : undefined),
   };
 
   const handleCloseEditor = useCallback((resetForm) => {


### PR DESCRIPTION
### Description

When trying to edit a comment, an error 400 occurred. Provided that the user is a course instructor or staff, and simultaneously the author of the comment.

The issue is the presence of the `editReasonCode` parameter in the request.

<img width="1661" alt="discussion_mfe_bug" src="https://github.com/openedx/frontend-app-discussions/assets/98233552/9ad0e585-adec-4f10-89cc-c996bb2e98cc">

This parameter is expected only if the editor is not the author of the post/comment, and is a staff or instructor.

After the fixes, everything works correctly.

<img width="1658" alt="discussion_mfe_fix" src="https://github.com/openedx/frontend-app-discussions/assets/98233552/4ad78ee4-0ef2-427e-aa0e-b80d21cb58fc">

NOTE: Similar changes were made to [fix the post editing error](https://github.com/openedx/frontend-app-discussions/pull/513).

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.