### PR TITLE
fix: 400 error editing comment

### DIFF
--- a/src/discussions/post-comments/comments/comment/CommentEditor.jsx
+++ b/src/discussions/post-comments/comments/comment/CommentEditor.jsx
@@ -58,7 +58,9 @@ const CommentEditor = ({
   const initialValues = {
     comment: comment.rawBody,
     // eslint-disable-next-line react/prop-types
-    editReasonCode: comment?.lastEdit?.reasonCode || (userIsStaff ? 'violates-guidelines' : ''),
+    editReasonCode: comment?.lastEdit?.reasonCode || (
+      userIsStaff && canDisplayEditReason ? 'violates-guidelines' : undefined
+    ),
   };
 
   const handleCloseEditor = (resetForm) => {


### PR DESCRIPTION
This is a backport from the [master](https://github.com/openedx/frontend-app-discussions/pull/513) and and this [PR](https://github.com/openedx/frontend-app-discussions/pull/533)

### Description

When trying to edit a comment, an error 400 occurred. Provided that the user is a course instructor or staff, and simultaneously the author of the comment.

<img width="1029" alt="discussion_mfe_bug_2" src="https://github.com/openedx/frontend-app-discussions/assets/98233552/4b6f0b4c-8678-415c-8e4d-aa3348268bb8">

The issue is the presence of the `editReasonCode` parameter in the request.

<img width="1655" alt="discussion_mfe_bug_1" src="https://github.com/openedx/frontend-app-discussions/assets/98233552/038ad989-e76a-468d-842c-0006ba90a6e2">

This parameter is expected only if the editor is not the author of the comment, and is a staff or instructor.

After the fixes, everything works correctly.

<img width="1029" alt="discussion_mfe_fix" src="https://github.com/openedx/frontend-app-discussions/assets/98233552/90066413-ef9e-405f-9a0c-57646154667f">

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.