### PR TITLE
Fix bug with a repeated search query for Olive

### DIFF
--- a/src/components/Search.jsx
+++ b/src/components/Search.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 
 import camelCase from 'lodash/camelCase';
 import { useDispatch, useSelector } from 'react-redux';
@@ -14,6 +14,7 @@ import postsMessages from '../discussions/posts/post-actions-bar/messages';
 import { setFilter as setTopicFilter } from '../discussions/topics/data/slices';
 
 function Search({ intl }) {
+  const [previousSearchValue, setPreviousSearchValue] = useState('');
   const dispatch = useDispatch();
   const { page } = useContext(DiscussionContext);
   const postSearch = useSelector(({ threads }) => threads.filters.search);
@@ -35,6 +36,7 @@ function Search({ intl }) {
     dispatch(setSearchQuery(''));
     dispatch(setTopicFilter(''));
     dispatch(setUsernameSearch(''));
+    setPreviousSearchValue('');
   };
 
   const onChange = (query) => {
@@ -42,7 +44,7 @@ function Search({ intl }) {
   };
 
   const onSubmit = (query) => {
-    if (query === '') {
+    if (query === '' || query === previousSearchValue) {
       return;
     }
     if (isPostSearch) {
@@ -52,6 +54,7 @@ function Search({ intl }) {
     } else if (page === 'learners') {
       dispatch(setUsernameSearch(query));
     }
+    setPreviousSearchValue(query);
   };
 
   useEffect(() => onClear(), [page]);


### PR DESCRIPTION
### Description

An issue has been found with research if no changes are made to the search field:
- first search:
![image-1](https://github.com/openedx/frontend-app-discussions/assets/98233552/32a322a9-f81f-43fa-b8a5-5b85825ae799)

- second search:
![image-2](https://github.com/openedx/frontend-app-discussions/assets/98233552/bc311453-663c-426e-88f5-6b8e27b50d5e)

This fix allows actions to be ignored if the current search query matches a previous query.
If there are any changes in the search query, then it is sent to the backend.
