### PR TITLE
Fix bug with a repeated search query

### DIFF
--- a/src/components/Search.jsx
+++ b/src/components/Search.jsx
@@ -1,5 +1,5 @@
 import React, {
-  useCallback, useContext, useEffect, useState,
+  useCallback, useContext, useEffect, useRef, useState,
 } from 'react';
 
 import camelCase from 'lodash/camelCase';
@@ -25,6 +25,7 @@ const Search = () => {
   const isPostSearch = ['posts', 'my-posts'].includes(page);
   const isTopicSearch = 'topics'.includes(page);
   const [searchValue, setSearchValue] = useState('');
+  const previousSearchValueRef = useRef('');
   let currentValue = '';
 
   if (isPostSearch) {
@@ -39,14 +40,15 @@ const Search = () => {
     dispatch(setSearchQuery(''));
     dispatch(setTopicFilter(''));
     dispatch(setUsernameSearch(''));
-  }, []);
+    previousSearchValueRef.current = '';
+  }, [previousSearchValueRef]);
 
   const onChange = useCallback((query) => {
     setSearchValue(query);
   }, []);
 
   const onSubmit = useCallback((query) => {
-    if (query === '') {
+    if (query === '' || query === previousSearchValueRef.current) {
       return;
     }
 
@@ -57,7 +59,8 @@ const Search = () => {
     } else if (page === 'learners') {
       dispatch(setUsernameSearch(query));
     }
-  }, [page, searchValue]);
+    previousSearchValueRef.current = query;
+  }, [page, searchValue, previousSearchValueRef]);
 
   const handleIconClick = useCallback((e) => {
     e.preventDefault();


### PR DESCRIPTION
### Description

An issue has been found with research if no changes are made to the search field:
- first search:
![image-1](https://github.com/openedx/frontend-app-discussions/assets/98233552/32a322a9-f81f-43fa-b8a5-5b85825ae799)

- second search:
![image-2](https://github.com/openedx/frontend-app-discussions/assets/98233552/bc311453-663c-426e-88f5-6b8e27b50d5e)

This fix allows actions to be ignored if the current search query matches a previous query.
If there are any changes in the search query, then it is sent to the backend.
