### PR TITLE
style: add important in post type card border

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -256,7 +256,8 @@ header {
 }
 
 .border-2 {
-  border-width: 2px;
+  border: 2px solid #cccccc !important;
+  border-width: 2px !important;
 }
 
 .post-form {


### PR DESCRIPTION
- Add important in post type card border width which was overriding because of the paragon card class.
<img width="524" alt="Screenshot 2023-07-14 at 2 21 29 PM" src="https://github.com/openedx/frontend-app-discussions/assets/79941147/ee7ea1de-bbc4-4964-93c5-585d3efed689">
<img width="460" alt="Screenshot 2023-07-14 at 2 24 32 PM" src="https://github.com/openedx/frontend-app-discussions/assets/79941147/7bb5e662-e8c5-40f2-96ea-23f9d7ebb669">
