### PR TITLE
fix: now discussion sidebar modal appears above the fold

### DIFF
--- a/src/components/TinyMCEEditor.jsx
+++ b/src/components/TinyMCEEditor.jsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { Editor } from '@tinymce/tinymce-react';
-import { useParams } from 'react-router';
+import { useLocation, useParams } from 'react-router';
 // TinyMCE so the global var exists
 // eslint-disable-next-line no-unused-vars,import/no-extraneous-dependencies
 import tinymce from 'tinymce/tinymce';
@@ -45,10 +45,11 @@ import contentUiCss from '!!raw-loader!tinymce/skins/ui/oxide/content.min.css';
 const TinyMCEEditor = (props) => {
   // note that skin and content_css is disabled to avoid the normal
   // loading process and is instead loaded as a string via content_style
-
+  const locationObj = useLocation();
   const { courseId, postId } = useParams();
   const [showImageWarning, setShowImageWarning] = useState(false);
   const intl = useIntl();
+  const enableInContextSidebar = Boolean(new URLSearchParams(locationObj.search).get('inContextSidebar') !== null);
 
   /* istanbul ignore next */
   const setup = useCallback((editor) => {
@@ -98,6 +99,29 @@ const TinyMCEEditor = (props) => {
   } catch (err) {
     contentStyle = '';
   }
+
+  // eslint-disable-next-line consistent-return
+  useEffect(() => {
+    if (enableInContextSidebar) {
+      const checkToxDialogVisibility = () => {
+        const toxDialog = document.querySelector('.tox-dialog');
+        if (toxDialog) {
+          toxDialog.style.alignSelf = 'start';
+          toxDialog.style.marginTop = '50px';
+        }
+      };
+
+      const observer = new MutationObserver(checkToxDialogVisibility);
+
+      // Observe changes to the entire document
+      observer.observe(document, { childList: true, subtree: true });
+
+      // Clean up the observer when the component unmounts
+      return () => {
+        observer.disconnect();
+      };
+    }
+  }, [enableInContextSidebar]);
 
   return (
     <>


### PR DESCRIPTION
[INF-1033](https://2u-internal.atlassian.net/browse/INF-1033)
### Description

One of our partner’s has shared the following:

”When I've been testing out the discussion sidebar, when trying to add an image or code the modal that pops up is not actually visible, and requires scrolling to reach it. The post UI fades out like this with no indication that there's anything below it:

You then have to scroll down quite far to be able to add your image/code

Now for learning discussion side i fixed this issue by change the modal position from align center to align start.

#### Screenshots/sandbox (optional):
![Screenshot 2023-09-12 at 1 35 07 PM](https://github.com/openedx/frontend-app-discussions/assets/72802712/e0f046b4-ff20-41e8-97ec-c92492ad27d2)

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.