### PR TITLE
fix: unify font-family with paragon component styles

### DIFF
--- a/src/discussions/common/AuthorLabel.jsx
+++ b/src/discussions/common/AuthorLabel.jsx
@@ -99,7 +99,7 @@ const AuthorLabel = ({
       {postCreatedAt && (
         <span
           title={postCreatedAt}
-          className={classNames('font-family-inter align-content-center', {
+          className={classNames('align-content-center', {
             'text-white': alert,
             'text-gray-500': !alert,
           })}

--- a/src/discussions/common/EndorsedAlertBanner.jsx
+++ b/src/discussions/common/EndorsedAlertBanner.jsx
@@ -39,7 +39,7 @@ const EndorsedAlertBanner = ({
                 height: '20px',
               }}
             />
-            <strong className="ml-2 font-family-inter">
+            <strong className="ml-2">
               {intl.formatMessage(isQuestion ? messages.answer : messages.endorsed)}
             </strong>
           </div>

--- a/src/index.scss
+++ b/src/index.scss
@@ -65,10 +65,6 @@ $fa-font-path: "~font-awesome/fonts";
   font-style: normal;
 }
 
-.font-family-inter {
-  font-family: "Inter";
-}
-
 .post-footer-icon-dimentions {
   width: 32px !important;
   height: 32px !important;
@@ -277,7 +273,6 @@ header {
 
 header {
   line-height: 28px;
-  font-family: Inter, Helvetica Neue, Arial, sans-serif;
   font-size: 18px;
   height: 60px;
 
@@ -314,7 +309,6 @@ header {
 
 #courseTabsNavigation {
   font-size: 18px;
-  font-family: Inter, Helvetica Neue, Arial, sans-serif;
 
   .container-xl {
     padding-left: 31px;
@@ -477,7 +471,6 @@ header {
 }
 
 .font-style {
-  font-family: "Inter";
   font-style: normal;
 }
 


### PR DESCRIPTION
### Description
This pull request contains recommendations for fixing custom font-family and make it unified with all MFEs and Paragon components.
All MFEs must have the same default appearance and change them globally via `brand-openedx` component on demand.

### Related Pull Requests
PR to the open-release/quince.master branch: https://github.com/openedx/frontend-app-discussions/pull/597
PR to the master branch: https://github.com/openedx/frontend-app-discussions/pull/598

#### Screenshots/sandbox (optional):
|Before|After|
|-------|-----|
|   <img width="1727" alt="image" src="https://github.com/openedx/frontend-app-discussions/assets/17108583/1a3b047e-f973-43e3-9052-3bb1e90cd11a">   |   <img width="1727" alt="image" src="https://github.com/openedx/frontend-app-discussions/assets/17108583/c2535f55-d65a-4634-9b73-7a76312173f3"> |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.