### PR TITLE
fix: container indents and style imports

### DIFF
--- a/src/components/NavigationBar/navBar.scss
+++ b/src/components/NavigationBar/navBar.scss
@@ -1,10 +1,11 @@
-@import "@edx/brand/paragon/fonts.scss";
-@import "@edx/brand/paragon/variables.scss";
-@import "@edx/paragon/scss/core/core.scss";
-@import "@edx/brand/paragon/overrides.scss";
+@import "~@edx/brand/paragon/fonts.scss";
+@import "~@edx/brand/paragon/variables.scss";
+@import "~@edx/paragon/scss/core/core.scss";
+@import "~@edx/brand/paragon/overrides.scss";
 
 $fa-font-path: "~font-awesome/fonts";
 @import "~font-awesome/scss/font-awesome";
+
 .course-tabs-navigation {
   border-bottom: solid 1px #eaeaea;
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,7 +1,7 @@
-@import "@edx/brand/paragon/fonts.scss";
-@import "@edx/brand/paragon/variables.scss";
-@import "@edx/paragon/scss/core/core.scss";
-@import "@edx/brand/paragon/overrides.scss";
+@import "~@edx/brand/paragon/fonts.scss";
+@import "~@edx/brand/paragon/variables.scss";
+@import "~@edx/paragon/scss/core/core.scss";
+@import "~@edx/brand/paragon/overrides.scss";
 
 @import "~@edx/frontend-component-footer/dist/footer";
 @import "~@edx/frontend-component-header/dist/index";
@@ -319,7 +319,6 @@ header {
   background-color: #fff;
 
   .container-xl {
-    padding-left: 31px;
     font-size: 1.125rem;
 
     .nav {


### PR DESCRIPTION
### Description
This pull request contains:
- a small fix for navigation container side indents and make them the same
- fix paragon and brand style imports (prepending module paths with a `~` tells webpack to search through node_modules)

### Related Pull Requests
PR to the open-release/palm.master branch: https://github.com/openedx/frontend-app-discussions/pull/599
PR to the open-release/quince.master branch: https://github.com/openedx/frontend-app-discussions/pull/601

#### Screenshots/sandbox (optional):
|Before|After|
|-------|-----|
|    ![image](https://github.com/openedx/frontend-app-discussions/assets/17108583/8d9e77af-b9e4-4a15-b47e-9e94c1ff833d)   |    ![image](https://github.com/openedx/frontend-app-discussions/assets/17108583/9ff83d1e-66e5-4992-8dd6-b5f8701daaba)  |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.