### PR TITLE
fix: resolved load more posts delay issue (quince.master)

### DIFF
--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unknown-property */
 import React, { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
@@ -7,7 +6,7 @@ import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { Badge, Icon, Truncate } from '@edx/paragon';
+import { Badge, Icon } from '@edx/paragon';
 import { CheckCircle } from '@edx/paragon/icons';
 
 import { PushPin } from '../../../components/icons';
@@ -87,48 +86,46 @@ const PostLink = ({
         />
         <div className="d-flex flex-column flex-fill" style={{ minWidth: 0 }}>
           <div className="d-flex flex-column justify-content-start mw-100 flex-fill" style={{ marginBottom: '-3px' }}>
-            <div className="d-flex align-items-center pb-0 mb-0 flex-fill font-weight-500">
-              <Truncate lines={1} className="mr-1.5" whiteSpace>
-                <span
-                  class={
-                      classNames(
-                        'font-weight-500 font-size-14 text-primary-500 font-style align-bottom',
-                        { 'font-weight-bolder': !read },
-                      )
-                    }
+            <div className="d-flex align-items-center pb-0 mb-0 flex-fill">
+              <div className="text-truncate mr-1">
+                <span className={classNames(
+                  'font-weight-500 font-size-14 text-primary-500 font-style align-bottom mr-1',
+                  { 'font-weight-bolder': !read },
+                )}
                 >
                   {title}
                 </span>
-                <span class="align-bottom"> </span>
-                <span
-                  class="text-gray-700 font-weight-normal font-size-14 font-style align-bottom"
-                >
-                  {isPostPreviewAvailable(previewBody)
-                    ? previewBody
-                    : intl.formatMessage(messages.postWithoutPreview)}
+                <span className="text-gray-700 font-weight-normal font-size-14 font-style align-bottom">
+                  {isPostPreviewAvailable(previewBody) ? previewBody : intl.formatMessage(messages.postWithoutPreview)}
                 </span>
-              </Truncate>
+              </div>
               {showAnsweredBadge && (
-              <Icon src={CheckCircle} className="text-success font-weight-500 ml-auto badge-padding" data-testid="check-icon">
-                <span className="sr-only">{' '}answered</span>
-              </Icon>
+                <Icon
+                  data-testid="check-icon"
+                  src={CheckCircle}
+                  className="text-success font-weight-500 ml-auto badge-padding"
+                >
+                  <span className="sr-only">{' '}answered</span>
+                </Icon>
               )}
               {canSeeReportedBadge && (
-              <Badge
-                variant="danger"
-                data-testid="reported-post"
-                className={`font-weight-500 badge-padding ${showAnsweredBadge ? 'ml-2' : 'ml-auto'}`}
-              >
-                {intl.formatMessage(messages.contentReported)}
-                <span className="sr-only">{' '}reported</span>
-              </Badge>
+                <Badge
+                  variant="danger"
+                  data-testid="reported-post"
+                  className={`font-weight-500 badge-padding ${showAnsweredBadge ? 'ml-2' : 'ml-auto'}`}
+                >
+                  {intl.formatMessage(messages.contentReported)}
+                  <span className="sr-only">{' '}reported</span>
+                </Badge>
               )}
               {pinned && (
-              <Icon
-                src={PushPin}
-                className={`post-summary-icons-dimensions text-gray-700
-                    ${canSeeReportedBadge || showAnsweredBadge ? 'ml-2' : 'ml-auto'}`}
-              />
+                <Icon
+                  src={PushPin}
+                  className={classNames('post-summary-icons-dimensions text-gray-700', {
+                    'ml-2': canSeeReportedBadge || showAnsweredBadge,
+                    'ml-auto': !canSeeReportedBadge && !showAnsweredBadge,
+                  })}
+                />
               )}
             </div>
           </div>


### PR DESCRIPTION
### **[INF-1090](https://2u-internal.atlassian.net/browse/INF-1090)**

**Description** 
I noticed in Hotjar recordings that the “Load more posts” button is very slow and gets even slower with successive clicks. I’ve attached a recording of a test I conducted.
- First, load more clicks: API response takes 983 msec but it takes 6 seconds to load 10 new posts in the UI. :open_mouth:  
- 12th load more click: API response takes 816 msec but it takes 42 seconds to load 10 new posts in the UI. :exploding_head: It seems like the API call is sent 14 seconds after the button clicks.
https://www.loom.com/share/c2e296f135734a6389a238768d6e4602?sid=d0c0d7cb-7e9c-4cc5-b519-99c3c31bf9ad

**Implementation** 
- Component is optimized and every Post item is rendered one time. 
- The post item component was using the Truncate component to truncate the post title and preview. Which was taking too much time. 
- Our use cases are simple. So truncated the post title and preview using Bootstrap classes.

<img width="521" alt="Screenshot 2023-11-06 at 9 55 07 PM" src="https://github.com/openedx/frontend-app-discussions/assets/79941147/2c49067b-e36e-4918-bda5-996933162ee5">

https://www.loom.com/share/4453d72e480243888de2a89cf206ce8f?sid=4f0da169-c032-4f40-99f5-ae6800f6b7aa
