### PR TITLE
feat: removed sort and filter tour

### DIFF
--- a/src/discussions/post-comments/comments/CommentsSort.jsx
+++ b/src/discussions/post-comments/comments/CommentsSort.jsx
@@ -44,7 +44,6 @@ const CommentSortDropdown = () => {
     <>
       <div className="comments-sort d-flex justify-content-end mx-4 mt-2">
         <Button
-          id="comment-sort"
           alt={intl.formatMessage(messages.actionsAlt)}
           ref={setTarget}
           variant="tertiary"

--- a/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
+++ b/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
@@ -197,7 +197,7 @@ const PostFilterBar = () => {
             cohort: capitalize(selectedCohort?.name),
           })}
         </span>
-        <span id="icon-tune">
+        <span>
           <Collapsible.Visible whenClosed>
             <Icon src={Tune} />
           </Collapsible.Visible>

--- a/src/discussions/tours/DiscussionsProductTour.jsx
+++ b/src/discussions/tours/DiscussionsProductTour.jsx
@@ -17,14 +17,11 @@ const DiscussionsProductTour = () => {
   }, []);
 
   return (
-    // eslint-disable-next-line react/jsx-no-useless-fragment
-    <>
-      {!isEmpty(config) && (
-        <ProductTour
-          tours={config}
-        />
-      )}
-    </>
+    !isEmpty(config) && (
+      <ProductTour
+        tours={config}
+      />
+    )
   );
 };
 

--- a/src/discussions/tours/constants.js
+++ b/src/discussions/tours/constants.js
@@ -1,21 +1,18 @@
 import messages from './messages';
 
+/**
+ *
+ * @param {Object} intl
+ * @returns {Object} tour checkpoints
+ */
 export default function tourCheckpoints(intl) {
   return {
-    NOT_RESPONDED_FILTER: [
+    EXAMPLE_TOUR: [
       {
-        body: intl.formatMessage(messages.notRespondedFilterTourBody),
-        placement: 'right',
-        target: '#icon-tune',
-        title: intl.formatMessage(messages.notRespondedFilterTourTitle),
-      },
-    ],
-    RESPONSE_SORT: [
-      {
-        body: intl.formatMessage(messages.responseSortTourBody),
-        placement: 'left',
-        target: '#comment-sort',
-        title: intl.formatMessage(messages.responseSortTourTitle),
+        title: intl.formatMessage(messages.exampleTourTitle),
+        body: intl.formatMessage(messages.exampleTourBody),
+        target: '#example-tour-target',
+        placement: 'bottom',
       },
     ],
   };

--- a/src/discussions/tours/messages.js
+++ b/src/discussions/tours/messages.js
@@ -16,25 +16,15 @@ const messages = defineMessages({
     defaultMessage: 'Okay',
     description: 'Action to end current tour',
   },
-  notRespondedFilterTourBody: {
-    id: 'tour.body.notRespondedFilter',
-    defaultMessage: 'Now you can filter discussions to find posts with no response.',
-    description: 'Body of the tour for the not responded filter',
+  exampleTourTitle: {
+    id: 'tour.example.title',
+    defaultMessage: 'Example Tour',
+    description: 'Title for example tour',
   },
-  notRespondedFilterTourTitle: {
-    id: 'tour.title.notRespondedFilter',
-    defaultMessage: 'New filtering option!',
-    description: 'Title of the tour for the not responded filter',
-  },
-  responseSortTourBody: {
-    id: 'tour.body.responseSortTour',
-    defaultMessage: 'Responses and comments are now sorted by newest first. Please use this option to change the sort order',
-    description: 'Body of the tour for the response sort',
-  },
-  responseSortTourTitle: {
-    id: 'tour.title.responseSortTour',
-    defaultMessage: 'Sort Responses!',
-    description: 'Title of the tour for the response sort',
+  exampleTourBody: {
+    id: 'tour.example.body',
+    defaultMessage: 'This is an example tour',
+    description: 'Body for example tour',
   },
 });
 


### PR DESCRIPTION
[INF-1172](https://2u-internal.atlassian.net/browse/INF-1172)

### Description
We have 2 product tours currently active:
- Unresponded filter in discussions
- Responses/comments sort in discussions

These features are not “new” especially to ~2000 users signing up daily. They have 3 more clicks to do before they can interact with discussions and the product tours may be somewhat distracting to a user. We need to deactivate all product tours that we created.