### PR TITLE
fix: sort menu collapse after filter selection

### DIFF
--- a/src/components/FilterBar.jsx
+++ b/src/components/FilterBar.jsx
@@ -94,18 +94,14 @@ const FilterBar = ({
   ];
 
   const handleFilterToggle = useCallback((event) => {
-    setOpen((prevIsOpen) => !prevIsOpen);
     onFilterChange(event);
+    setOpen(false);
   }, [onFilterChange]);
-
-  const handleToggle = useCallback(() => {
-    setOpen((prevIsOpen) => !prevIsOpen);
-  }, []);
 
   return (
     <Collapsible.Advanced
       open={isOpen}
-      onToggle={handleToggle}
+      onToggle={setOpen}
       className="filter-bar collapsible-card-lg border-0"
     >
       <Collapsible.Trigger className="collapsible-trigger border-0">

--- a/src/components/FilterBar.jsx
+++ b/src/components/FilterBar.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/forbid-prop-types */
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { capitalize, toString } from 'lodash';
@@ -93,10 +93,19 @@ const FilterBar = ({
     },
   ];
 
+  const handleFilterToggle = useCallback((event) => {
+    setOpen((prevIsOpen) => !prevIsOpen);
+    onFilterChange(event);
+  }, [onFilterChange]);
+
+  const handleToggle = useCallback(() => {
+    setOpen((prevIsOpen) => !prevIsOpen);
+  }, []);
+
   return (
     <Collapsible.Advanced
       open={isOpen}
-      onToggle={() => setOpen(!isOpen)}
+      onToggle={handleToggle}
       className="filter-bar collapsible-card-lg border-0"
     >
       <Collapsible.Trigger className="collapsible-trigger border-0">
@@ -126,7 +135,7 @@ const FilterBar = ({
                 name={value.name}
                 className="d-flex flex-column list-group list-group-flush"
                 value={selectedFilters[value.name]}
-                onChange={onFilterChange}
+                onChange={handleFilterToggle}
               >
                 {value.filters.map(filterName => {
                   const element = allFilters.find(obj => obj.id === filterName);
@@ -159,7 +168,7 @@ const FilterBar = ({
                     name="cohort"
                     className="d-flex flex-column list-group list-group-flush w-100"
                     value={selectedFilters.cohort}
-                    onChange={onFilterChange}
+                    onChange={handleFilterToggle}
                   >
                     <ActionItem
                       id="all-groups"

--- a/src/discussions/learners/learner/LearnerFilterBar.jsx
+++ b/src/discussions/learners/learner/LearnerFilterBar.jsx
@@ -67,11 +67,12 @@ const LearnerFilterBar = () => {
         },
       );
     }
+    setOpen((prevIsOpen) => !prevIsOpen);
   }, []);
 
   const handleOnToggle = useCallback(() => {
-    setOpen(!isOpen);
-  }, [isOpen]);
+    setOpen((prevIsOpen) => !prevIsOpen);
+  }, []);
 
   return (
     <Collapsible.Advanced

--- a/src/discussions/learners/learner/LearnerFilterBar.jsx
+++ b/src/discussions/learners/learner/LearnerFilterBar.jsx
@@ -67,17 +67,13 @@ const LearnerFilterBar = () => {
         },
       );
     }
-    setOpen((prevIsOpen) => !prevIsOpen);
-  }, []);
-
-  const handleOnToggle = useCallback(() => {
-    setOpen((prevIsOpen) => !prevIsOpen);
+    setOpen(false);
   }, []);
 
   return (
     <Collapsible.Advanced
       open={isOpen}
-      onToggle={handleOnToggle}
+      onToggle={setOpen}
       className="filter-bar collapsible-card-lg border-0"
     >
       <Collapsible.Trigger className="collapsible-trigger border-0">

--- a/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
+++ b/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
@@ -130,11 +130,12 @@ const PostFilterBar = () => {
     }
 
     sendTrackEvent('edx.forum.filter.content', filterContentEventProperties);
+    setOpen((prevIsOpen) => !prevIsOpen);
   }, [currentFilters, currentSorting, dispatch, selectedCohort]);
 
   const handleToggle = useCallback(() => {
-    setOpen(!isOpen);
-  }, [isOpen]);
+    setOpen((prevIsOpen) => !prevIsOpen);
+  }, []);
 
   useEffect(() => {
     if (userHasModerationPrivileges && isEmpty(cohorts)) {

--- a/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
+++ b/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
@@ -130,12 +130,8 @@ const PostFilterBar = () => {
     }
 
     sendTrackEvent('edx.forum.filter.content', filterContentEventProperties);
-    setOpen((prevIsOpen) => !prevIsOpen);
+    setOpen(false);
   }, [currentFilters, currentSorting, dispatch, selectedCohort]);
-
-  const handleToggle = useCallback(() => {
-    setOpen((prevIsOpen) => !prevIsOpen);
-  }, []);
 
   useEffect(() => {
     if (userHasModerationPrivileges && isEmpty(cohorts)) {
@@ -184,7 +180,7 @@ const PostFilterBar = () => {
   return (
     <Collapsible.Advanced
       open={isOpen}
-      onToggle={handleToggle}
+      onToggle={setOpen}
       className="filter-bar collapsible-card-lg border-0"
     >
       <Collapsible.Trigger className="collapsible-trigger border-0">


### PR DESCRIPTION
[INF-1096](https://2u-internal.atlassian.net/browse/INF-1096)

### Description

**Issue:** If filter menu is lengthy, selecting an option does not seem to have any impact, as seen in attached screen recording. Users will need to scroll down or close the menu to see the impact.

**Solution:** To remedy that, the filter menu is now collapsible  once an option has been selected.

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.