### PR TITLE
fix: fixed Learner Post filter issue

### DIFF
--- a/src/discussions/learners/learner-post-filter-bar/LearnerPostFilterBar.jsx
+++ b/src/discussions/learners/learner-post-filter-bar/LearnerPostFilterBar.jsx
@@ -7,6 +7,7 @@ import { useParams } from 'react-router-dom';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 
 import FilterBar from '../../../components/FilterBar';
+import { PostsStatusFilter, ThreadType } from '../../../data/constants';
 import { selectCourseCohorts } from '../../cohorts/data/selectors';
 import { fetchCourseCohorts } from '../../cohorts/data/thunks';
 import { selectUserHasModerationPrivileges, selectUserIsGroupTa } from '../../data/selectors';
@@ -58,10 +59,16 @@ const LearnerPostFilterBar = () => {
       }
     } else if (name === 'status') {
       if (postFilter.status !== value) {
+        const newPostType = (value === PostsStatusFilter.UNANSWERED && ThreadType.QUESTION)
+        || (value === PostsStatusFilter.UNRESPONDED && ThreadType.DISCUSSION)
+        || postFilter.postType;
+
         dispatch(setPostFilter({
           ...postFilter,
+          postType: newPostType,
           status: value,
         }));
+
         filterContentEventProperties.statusFilter = value;
       }
     } else if (name === 'orderBy') {

--- a/src/discussions/learners/learner-post-filter-bar/LearnerPostFilterBar.jsx
+++ b/src/discussions/learners/learner-post-filter-bar/LearnerPostFilterBar.jsx
@@ -59,13 +59,13 @@ const LearnerPostFilterBar = () => {
       }
     } else if (name === 'status') {
       if (postFilter.status !== value) {
-        const newPostType = (value === PostsStatusFilter.UNANSWERED && ThreadType.QUESTION)
+        const postType = (value === PostsStatusFilter.UNANSWERED && ThreadType.QUESTION)
         || (value === PostsStatusFilter.UNRESPONDED && ThreadType.DISCUSSION)
         || postFilter.postType;
 
         dispatch(setPostFilter({
           ...postFilter,
-          postType: newPostType,
+          postType,
           status: value,
         }));
 


### PR DESCRIPTION
[INF-1236](https://2u-internal.atlassian.net/browse/INF-1236)

### Description
**Issue:**
The Learner Post filter is exhibiting unexpected behavior. When choosing the "unanswered" status, it should automatically switch the type filter to "question," and when selecting "not responded," it should switch to "discussion."

**Solution:**
The issue mentioned earlier has been resolved. Now, when the "unanswered" status is selected, the type filter automatically switches to "question," and when "not responded" is chosen, it switches to "discussion."

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.