### PR TITLE
fix: updated css styling to prevent content spilling

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -463,6 +463,12 @@ header {
   margin-bottom: 0px;
 }
 
+code {
+  word-wrap: break-word !important;
+  text-wrap: initial;
+  word-break: break-word !important;
+}
+
 .post-card-comment {
   outline: none;
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -464,8 +464,7 @@ header {
 }
 
 code {
-  word-wrap: break-word !important;
-  text-wrap: initial;
+  text-wrap: initial !important;
   word-break: break-word !important;
 }
 


### PR DESCRIPTION
[INF-891](https://2u-internal.atlassian.net/browse/INF-891)

### Explanation 

Styling for the code part of HTML has been added to prevent spilling out of the container. 


### Before Change:
<img width="1196" alt="Screenshot 2024-01-25 at 2 12 34 PM" src="https://github.com/openedx/frontend-app-discussions/assets/57627710/40927ae9-0bf8-4d73-9ebf-e1cad9087e5a">


### After Change:
<img width="945" alt="Screenshot 2024-01-25 at 2 13 36 PM" src="https://github.com/openedx/frontend-app-discussions/assets/57627710/9dd7b9c6-cfd8-49ba-b1f8-23f501a07cc1">
