### PR TITLE
fix: anonymous post should not be visible in my post

### DIFF
--- a/src/discussions/posts/data/slices.js
+++ b/src/discussions/posts/data/slices.js
@@ -133,8 +133,10 @@ const threadsSlice = createSlice({
         ...(state.threadsInTopic[payload.topicId] || []),
         payload.id,
       ];
-      // Temporarily add it to the top of the list so it's visible
-      state.pages[0] = [payload.id].concat(state.pages[0] || []);
+      if (!payload.anonymousToPeers) {
+        // Temporarily add it to the top of the list so it's visible
+        state.pages[0] = [payload.id].concat(state.pages[0] || []);
+      }
       state.avatars = { ...state.avatars, ...payload.avatars };
       state.redirectToThread = { topicId: payload.topicId, threadId: payload.id };
       state.threadDraft = null;


### PR DESCRIPTION
### Description

Anonymous was visible in `My Post` when a new post was created as anonymous.  It automatically disappears on page refresh
Ticket: [INF-1232](https://2u-internal.atlassian.net/browse/INF-1232)

#### How Has This Been Tested?

Tested by creating both anonymous and non-anonymous post. Anonymous posts are not visible in `My Post` on new post creation whereas non-anonymous post are visible.

#### Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.