### PR TITLE
fix: updated css styling to prevent content spilling

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -463,6 +463,12 @@ header {
   margin-bottom: 0px;
 }
 
+code {
+  word-wrap: break-word !important;
+  text-wrap: initial;
+  word-break: break-word !important;
+}
+
 .post-card-comment {
   outline: none;
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -464,8 +464,7 @@ header {
 }
 
 code {
-  word-wrap: break-word !important;
-  text-wrap: initial;
+  text-wrap: initial !important;
   word-break: break-word !important;
 }
 


### PR DESCRIPTION
[INF-891](https://2u-internal.atlassian.net/browse/INF-891)

**Explanation**

Styling for the code part of HTML has been added to prevent spilling out of the container.

**Before Change:**
<img width="1196" alt="299603738-40927ae9-0bf8-4d73-9ebf-e1cad9087e5a-2" src="https://github.com/openedx/frontend-app-discussions/assets/73840786/291d14f8-60e7-4d33-953d-377606564b0d">

**After Change:**

<img width="945" alt="299603907-9dd7b9c6-cfd8-49ba-b1f8-23f501a07cc1-2" src="https://github.com/openedx/frontend-app-discussions/assets/73840786/4bc81e09-2c05-4424-804a-e3dedf830232">
