### PR TITLE
feat: add auto scroll to editor functionality

### DIFF
--- a/src/discussions/common/ActionsDropdown.jsx
+++ b/src/discussions/common/ActionsDropdown.jsx
@@ -48,7 +48,8 @@ const ActionsDropdown = ({
     }
   }, [actions, isPostingEnabled]);
 
-  const onClickButton = useCallback(() => {
+  const onClickButton = useCallback((event) => {
+    event.preventDefault();
     setTarget(buttonRef.current);
     open();
   }, [open]);

--- a/src/discussions/post-comments/PostCommentsView.test.jsx
+++ b/src/discussions/post-comments/PostCommentsView.test.jsx
@@ -212,6 +212,7 @@ describe('ThreadView', () => {
       })];
     });
     axiosMock.onGet(`${courseConfigApiUrl}${courseId}/`).reply(200, { isPostingEnabled: true });
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
 
     await executeThunk(fetchCourseConfig(courseId), store.dispatch, store.getState);
     await executeThunk(fetchCourseCohorts(courseId), store.dispatch, store.getState);

--- a/src/discussions/post-comments/comments/comment/CommentEditor.jsx
+++ b/src/discussions/post-comments/comments/comment/CommentEditor.jsx
@@ -1,4 +1,6 @@
-import React, { useCallback, useContext, useRef } from 'react';
+import React, {
+  useCallback, useContext, useEffect, useRef,
+} from 'react';
 import PropTypes from 'prop-types';
 
 import { Formik } from 'formik';
@@ -35,6 +37,7 @@ const CommentEditor = ({
   } = comment;
   const intl = useIntl();
   const editorRef = useRef(null);
+  const formRef = useRef(null);
   const { authenticatedUser } = useContext(AppContext);
   const { enableInContextSidebar } = useContext(DiscussionContext);
   const userHasModerationPrivileges = useSelector(selectUserHasModerationPrivileges);
@@ -88,6 +91,12 @@ const CommentEditor = ({
   // the current comment id, or the current comment parent or the curren thread.
   const editorId = `comment-editor-${id || parentId || threadId}`;
 
+  useEffect(() => {
+    if (formRef.current) {
+      formRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [formRef]);
+
   return (
     <Formik
       initialValues={initialValues}
@@ -103,7 +112,7 @@ const CommentEditor = ({
         handleChange,
         resetForm,
       }) => (
-        <Form onSubmit={handleSubmit} className={formClasses}>
+        <Form onSubmit={handleSubmit} className={formClasses} ref={formRef}>
           {canDisplayEditReason && (
             <Form.Group
               isInvalid={isFormikFieldInvalid('editReasonCode', {


### PR DESCRIPTION
[INF-1158](https://2u-internal.atlassian.net/browse/INF-1158)
### Description 
Currently, when clicking on the 'Add Response' button at the top right of the comment, the screen does not scroll to the input box. In scenarios where the response is too large, this behavior may give the impression that edX is not responding to the course team's action of creating a response. The suggestion is that when a user clicks on 'Add Response,' they should be directed directly to the end of the text, where the text field is visible.

### Before
https://www.loom.com/share/edf13a96bcb84512a3b725418c13cafd?sid=92841d71-8fec-4450-a41f-38b7fc65b883
### After
https://www.loom.com/share/2dd82907f7904c6493807f67f83bda0a?sid=7a803fe7-5060-4564-945c-1d4cb0fe4506

