### PR TITLE
[BACKPORT] fix: redirection to learners tab in inContext view

### DIFF
--- a/src/discussions/common/AuthorLabel.jsx
+++ b/src/discussions/common/AuthorLabel.jsx
@@ -28,7 +28,7 @@ const AuthorLabel = ({
 }) => {
   timeago.register('time-locale', timeLocale);
   const intl = useIntl();
-  const { courseId } = useContext(DiscussionContext);
+  const { courseId, enableInContextSidebar } = useContext(DiscussionContext);
   let icon = null;
   let authorLabelMessage = null;
 
@@ -47,7 +47,7 @@ const AuthorLabel = ({
   const className = classNames('d-flex align-items-center', { 'mb-0.5': !postOrComment }, labelColor);
 
   const showUserNameAsLink = useShowLearnersTab()
-    && linkToProfile && author && author !== intl.formatMessage(messages.anonymous);
+    && linkToProfile && author && author !== intl.formatMessage(messages.anonymous) && !enableInContextSidebar;
 
   const authorName = useMemo(() => (
     <span

--- a/src/discussions/common/AuthorLabel.test.jsx
+++ b/src/discussions/common/AuthorLabel.test.jsx
@@ -21,11 +21,11 @@ let store;
 let axiosMock;
 let container;
 
-function renderComponent(author, authorLabel, linkToProfile, labelColor) {
+function renderComponent(author, authorLabel, linkToProfile, labelColor, enableInContextSidebar) {
   const wrapper = render(
     <IntlProvider locale="en">
       <AppProvider store={store}>
-        <DiscussionContext.Provider value={{ courseId }}>
+        <DiscussionContext.Provider value={{ courseId, enableInContextSidebar }}>
           <AuthorLabel
             author={author}
             authorLabel={authorLabel}
@@ -79,15 +79,24 @@ describe('Author label', () => {
     );
 
     it(
-      `it is "${!linkToProfile && 'not'}" clickable when linkToProfile is ${!!linkToProfile}`,
+      `it is "${(!linkToProfile) && 'not'}" clickable when linkToProfile is ${!!linkToProfile} and enableInContextSidebar is false`,
       async () => {
-        renderComponent(author, authorLabel, linkToProfile, labelColor);
+        renderComponent(author, authorLabel, linkToProfile, labelColor, false);
 
         if (linkToProfile) {
           expect(screen.queryByTestId('learner-posts-link')).toBeInTheDocument();
         } else {
           expect(screen.queryByTestId('learner-posts-link')).not.toBeInTheDocument();
         }
+      },
+    );
+
+    it(
+      'it is not clickable when enableInContextSidebar is true',
+      async () => {
+        renderComponent(author, authorLabel, linkToProfile, labelColor, true);
+
+        expect(screen.queryByTestId('learner-posts-link')).not.toBeInTheDocument();
       },
     );
 


### PR DESCRIPTION
## Description
This is a backport from the master (https://github.com/openedx/frontend-app-discussions/pull/659)

Changes were cherry-picked from the master branch. 
The only difference is that `useShowLearnersTab` is still taken into account (depends on the `discussions.enable_learners_tab_in_discussions_mfe` waffle flag in the LMS, removed in master).

- fix: redirection to learners tab in inContext view. So a user can't navigate the site in the discussion sidebar <img width="1265" alt="image" src="https://github.com/openedx/frontend-app-discussions/assets/47273130/079668e5-4a6a-475c-bd6d-67023e4a446a">
- fix: changed username to simple text for in-context view
- test: username is not clickable in in-context view

## Steps to reproduce
- ensure the `discussions.enable_learners_tab_in_discussions_mfe` is enabled (you should see the Learners tab in the discussions MFE)
- ensure that discussions sidebar is enabled
- open any unit in the Learning MFE containing the Discussions sidebar and create a new post
- click on the new post and then click on author's username
- observe the result

## Actual result (before the fix)
A user is viewing the whole Discussion MFE page including the header, so they can navigate elsewhere (e.g. to the profile MFE)

## Expected result (after the fix)
The username is just a text in the sidebar content, so no redirection is performed on click.
No changes on the Discussions MFE - clicking on the username will show the user's posts.

Please check the [original PR](https://github.com/openedx/frontend-app-discussions/pull/659) for video presentations before/after the fix.

---------

Co-authored-by: sohailfatima <23100065@lums.edu.pk>
Co-authored-by: Fatima Sohail <68312464+sohailfatima@users.noreply.github.com>
Co-authored-by: Awais Ansari <79941147+awais-ansari@users.noreply.github.com>