### PR TITLE
fix: fixed crash issue for post in learner tab

### DIFF
--- a/src/discussions/posts/data/slices.js
+++ b/src/discussions/posts/data/slices.js
@@ -185,7 +185,7 @@ const threadsSlice = createSlice({
         },
         pages: !payload.anonymousToPeers
           ? [
-            ...[payload.id].concat(state.pages[0]) || [],
+            ...(state.pages[0] ? [payload.id].concat(state.pages[0]) : []),
             ...state.pages.slice(1),
           ]
           : [...state.pages],


### PR DESCRIPTION
[INF-1316](https://2u-internal.atlassian.net/browse/INF-1316)

### Description

An unexpected error occurs appear when attempting to create a new post from the learners' tab.

**Steps to reproduce.**

Create a post from the learners tab and you will see this error

**Solution**

Crash issue has been fixed.

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.