### PR TITLE
Add react-helmet to have the favico icon in production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "raw-loader": "4.0.2",
         "react": "17.0.2",
         "react-dom": "17.0.2",
+        "react-helmet": "^6.1.0",
         "react-redux": "7.2.9",
         "react-router": "6.18.0",
         "react-router-dom": "6.18.0",
@@ -17890,6 +17891,25 @@
         }
       }
     },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
+    "node_modules/react-helmet/node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
     "node_modules/react-imask": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/react-imask/-/react-imask-7.4.0.tgz",
@@ -18139,6 +18159,14 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-side-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "raw-loader": "4.0.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "react-helmet": "^6.1.0",
     "react-redux": "7.2.9",
     "react-router": "6.18.0",
     "react-router-dom": "6.18.0",
@@ -62,8 +63,8 @@
   },
   "devDependencies": {
     "@edx/browserslist-config": "1.2.0",
-    "@openedx/frontend-build": "^13.0.28",
     "@edx/reactifex": "1.1.0",
+    "@openedx/frontend-build": "^13.0.28",
     "@testing-library/jest-dom": "5.17.0",
     "@testing-library/react": "12.1.5",
     "@testing-library/user-event": "13.5.0",

--- a/src/discussions/discussions-home/DiscussionsHome.jsx
+++ b/src/discussions/discussions-home/DiscussionsHome.jsx
@@ -3,12 +3,14 @@ import React, {
 } from 'react';
 
 import classNames from 'classnames';
+import { Helmet } from 'react-helmet';
 import { useSelector } from 'react-redux';
 import {
   matchPath, Route, Routes, useLocation, useMatch,
 } from 'react-router-dom';
 
 import { LearningHeader as Header } from '@edx/frontend-component-header';
+import { getConfig } from '@edx/frontend-platform';
 
 import { Spinner } from '../../components';
 import selectCourseTabs from '../../components/NavigationBar/data/selectors';
@@ -80,6 +82,9 @@ const DiscussionsHome = () => {
   return (
     <Suspense fallback={(<Spinner />)}>
       <DiscussionContext.Provider value={discussionContextValue}>
+        <Helmet>
+          <link rel="shortcut icon" href={getConfig().FAVICON_URL} type="image/x-icon" />
+        </Helmet>
         {!enableInContextSidebar && (<Header courseOrg={org} courseNumber={courseNumber} courseTitle={courseTitle} />)}
         <main className="container-fluid d-flex flex-column p-0 w-100" id="main" tabIndex="-1">
           {!enableInContextSidebar && <CourseTabsNavigation />}


### PR DESCRIPTION
### Description

When viewing discussion on Production, the app doesn't pick any link for `favico.ico` as it's link is set to null on start. On Researching in other MFEs, the other MFEs use `react-helmet` and set the `favico.ico` link on runtime. I believe we should do similar in this MFE so that `favico` can be viewed in production. So, I added `react-helmet` in this PR.

#### How Has This Been Tested?

I've tested it on my local system in development environment and have seen the `react-data-helmet` link tag for `favico.ico`

#### Screenshots/sandbox (optional):
Include a link to the sandbox for design changes or screenshot for before and after. **Remove this section if it's not applicable.**

|Before|After|
|-------|-----|
|  <img width="1355" alt="Screenshot 2024-03-29 at 4 29 32 PM" src="https://github.com/openedx/frontend-app-discussions/assets/112946189/898ff5f1-c105-4e1c-abcf-5f6d3d23fbb2"> |  <img width="1355" alt="Screenshot 2024-03-29 at 4 30 35 PM" src="https://github.com/openedx/frontend-app-discussions/assets/112946189/a75a0e54-f13f-460c-87b0-1134d6b42f6d"> |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.