### PR TITLE
[BACKPORT] fix: posts sorting on sidebar

### DIFF
--- a/src/discussions/posts/PostsList.jsx
+++ b/src/discussions/posts/PostsList.jsx
@@ -67,7 +67,7 @@ const PostsList = ({
     if (isTopicTab) {
       loadThreads(topicsIds, 1, true);
     }
-  }, [filters]);
+  }, [filters, JSON.stringify(sortedPostsIds)]);
 
   const postInstances = useMemo(() => (
     sortedPostsIds?.map((postId, idx) => (


### PR DESCRIPTION
## Backport from the [master](https://github.com/openedx/frontend-app-discussions/pull/686)

## Description
Fix wrong sorting when a user creates several posts without the page reloading.

## Steps to reproduce
1. [Precondition] The new discussions experience (discussions sidebar) should be enabled
2. Navigate to any course unit where the discussions sidebar is enabled
3. Create a new post. 
4. Click on the "Back to list" button. Note that the default sorting is used (most recent first) and it's correct.
5. Create another post **without reloading the page**
6. Click on the "Back to list" button and check the result

## Actual result
The second created post is the last in the list (the same for any number of posts created additionally).

<img width="663" alt="image" src="https://github.com/openedx/frontend-app-discussions/assets/47273130/b9acdad8-5849-4b4e-b99c-e153011c1189">

## Expected result (with the fix applied)
Sorting works as expected - most recent posts are displayed first.

![discuss_sorting](https://github.com/openedx/frontend-app-discussions/assets/47273130/0b8fc075-4a49-4588-ac77-eb80a4f38250)

## Additional Notes
- Reproduces only with the discussions sidebar inside the Learning MFE. 
  That's because when you create a post in the Discussions MFE itself - you will be navigated to the "My Posts" tab and the list of the posts will always be fetched.
- Sorting works as expected after the page is reloaded.