### PR TITLE
fix: fixed commentsInThreads[s] is not iterable

### DIFF
--- a/src/discussions/post-comments/data/slices.js
+++ b/src/discussions/post-comments/data/slices.js
@@ -36,10 +36,6 @@ const commentsSlice = createSlice({
       const newState = { ...state };
 
       newState.status = RequestStatus.SUCCESSFUL;
-      newState.commentsInThreads = {
-        ...newState.commentsInThreads,
-        [threadId]: newState.commentsInThreads[threadId] || [],
-      };
 
       newState.pagination = {
         ...newState.pagination,
@@ -49,7 +45,7 @@ const commentsSlice = createSlice({
       if (page === 1) {
         newState.commentsInThreads = {
           ...newState.commentsInThreads,
-          [threadId]: [...payload.commentsInThreads[threadId]] || [],
+          [threadId]: payload.commentsInThreads[threadId] ? [...payload.commentsInThreads[threadId]] : [],
         };
       } else {
         newState.commentsInThreads = {


### PR DESCRIPTION
[INF-1285](https://2u-internal.atlassian.net/browse/INF-1285)
### Description

This PR fixes a Type error [prod-frontend-app-discussions]
`Error message: t.commentsInThreads[s] is not iterable `on new relic related to frontend change
