### PR TITLE
fix: block overflow when editing comment

### DIFF
--- a/src/discussions/post-comments/comments/comment/Reply.jsx
+++ b/src/discussions/post-comments/comments/comment/Reply.jsx
@@ -129,7 +129,7 @@ const Reply = ({ responseId }) => {
         </div>
         <div
           className="bg-light-300 pl-4 pt-2.5 pr-2.5 pb-10px flex-fill"
-          style={{ borderRadius: '0rem 0.375rem 0.375rem' }}
+          style={{ borderRadius: '0rem 0.375rem 0.375rem', maxWidth: 'calc(100% - 50px)' }}
         >
           <div className="d-flex flex-row justify-content-between">
             <AuthorLabel


### PR DESCRIPTION
### Description

This merge request contains a fix for the comment edit block width at small screen resolutions for course Discussions pages or discussion sidebar in MFE Learning.

### Related PR 
- master branch: https://github.com/openedx/frontend-app-discussions/pull/706
- redwood branch: https://github.com/openedx/frontend-app-discussions/pull/710

#### Screenshots:

|Before|After|
|-------|-----|
|  <img width="560" alt="image" src="https://github.com/openedx/frontend-app-discussions/assets/17108583/db0170cb-a46d-472d-9941-2013046013d6">    |    <img width="560" alt="image" src="https://github.com/openedx/frontend-app-discussions/assets/17108583/4c075157-28df-482b-8bca-138b160c0a20">  |