### PR TITLE
feat: added draft functionality for comment and responses

### DIFF
--- a/src/discussions/common/ActionsDropdown.jsx
+++ b/src/discussions/common/ActionsDropdown.jsx
@@ -94,6 +94,7 @@ const ActionsDropdown = ({
                     handleActions(action.action);
                   }}
                   className="d-flex justify-content-start actions-dropdown-item"
+                  data-testId={action.id}
                 >
                   <Icon
                     src={action.icon}

--- a/src/discussions/data/selectors.js
+++ b/src/discussions/data/selectors.js
@@ -91,4 +91,6 @@ export const selectIsUserLearner = createSelector(
   ),
 );
 
-export const selectDraft = state => state.comments.draft || null;
+export const selectDraftComments = state => state.comments.draftComments || null;
+
+export const selectDraftResponses = state => state.comments.draftResponses || null;

--- a/src/discussions/data/selectors.js
+++ b/src/discussions/data/selectors.js
@@ -90,7 +90,3 @@ export const selectIsUserLearner = createSelector(
     ) || false
   ),
 );
-
-export const selectDraftComments = state => state.comments.draftComments || null;
-
-export const selectDraftResponses = state => state.comments.draftResponses || null;

--- a/src/discussions/data/selectors.js
+++ b/src/discussions/data/selectors.js
@@ -90,3 +90,5 @@ export const selectIsUserLearner = createSelector(
     ) || false
   ),
 );
+
+export const selectDraft = state => state.comments.draft || null; 

--- a/src/discussions/data/selectors.js
+++ b/src/discussions/data/selectors.js
@@ -91,4 +91,4 @@ export const selectIsUserLearner = createSelector(
   ),
 );
 
-export const selectDraft = state => state.comments.draft || null; 
+export const selectDraft = state => state.comments.draft || null;

--- a/src/discussions/post-comments/PostCommentsView.test.jsx
+++ b/src/discussions/post-comments/PostCommentsView.test.jsx
@@ -671,6 +671,30 @@ describe('ThreadView', () => {
       expect(screen.queryByTestId('reply-comment-3')).not.toBeInTheDocument();
     });
 
+    it('successfully added response in the draft.', async () => {
+      await waitFor(() => renderComponent(discussionPostId));
+
+      let addResponseBtn = screen.queryByText('Add response');
+      await act(async () => {
+        fireEvent.click(addResponseBtn);
+      });
+
+      await waitFor(() => {
+        const editor = screen.queryByTestId('tinymce-editor');
+        fireEvent.change(editor, { target: { value: 'Hello, world!' } });
+      });
+      const cancelBtn = screen.queryByText('Cancel');
+      await act(async () => {
+        fireEvent.click(cancelBtn);
+      });
+      addResponseBtn = screen.queryByText('Add response');
+      await act(async () => {
+        fireEvent.click(addResponseBtn);
+      });
+
+      expect(screen.queryByText('Hello, world!')).toBeInTheDocument();
+    });
+
     it('pressing load more button will load next page of replies', async () => {
       await waitFor(() => renderComponent(discussionPostId));
 

--- a/src/discussions/post-comments/PostCommentsView.test.jsx
+++ b/src/discussions/post-comments/PostCommentsView.test.jsx
@@ -698,6 +698,50 @@ describe('ThreadView', () => {
       expect(screen.queryByText('Draft comment!')).toBeInTheDocument();
     });
 
+    it('successfully updated comment in the draft.', async () => {
+      await waitFor(() => renderComponent(discussionPostId));
+
+      const comment = screen.queryByTestId('reply-comment-2');
+      const actionBtn = comment.querySelector('button[aria-label="Actions menu"]');
+
+      await act(async () => {
+        fireEvent.click(actionBtn);
+      });
+
+      let editBtn = screen.queryByTestId('edit');
+
+      await act(async () => {
+        fireEvent.click(editBtn);
+      });
+
+      await waitFor(() => {
+        const editor = screen.queryByTestId('tinymce-editor');
+        fireEvent.change(editor, { target: { value: 'Draft comment!' } });
+      });
+
+      const cancelBtn = screen.queryByText('Cancel');
+      await act(async () => {
+        fireEvent.click(cancelBtn);
+      });
+
+      await act(async () => {
+        fireEvent.click(actionBtn);
+      });
+
+      editBtn = screen.queryByTestId('edit');
+
+      await act(async () => {
+        fireEvent.click(editBtn);
+      });
+
+      const submitBtn = screen.queryByText('Submit');
+      await act(async () => {
+        fireEvent.click(submitBtn);
+      });
+
+      await waitFor(() => expect(screen.queryByText('Draft comment!')).toBeInTheDocument());
+    });
+
     it('successfully removed comment from the draft.', async () => {
       await waitFor(() => renderComponent(discussionPostId));
 
@@ -709,7 +753,7 @@ describe('ThreadView', () => {
 
       await waitFor(() => {
         const editor = screen.queryByTestId('tinymce-editor');
-        fireEvent.change(editor, { target: { value: 'Draft comment!' } });
+        fireEvent.change(editor, { target: { value: 'Draft comment 123!' } });
       });
 
       const submitBtn = screen.queryByText('Submit');
@@ -721,8 +765,8 @@ describe('ThreadView', () => {
       await act(async () => {
         fireEvent.click(addCommentBtn[0]);
       });
-
-      expect(screen.queryByText('Draft comment!')).not.toBeInTheDocument();
+      const editor = screen.queryByTestId('tinymce-editor');
+      expect(editor.value).toBe('');
     });
 
     it('successfully added response in the draft.', async () => {
@@ -770,7 +814,8 @@ describe('ThreadView', () => {
         fireEvent.click(addResponseBtn);
       });
 
-      expect(screen.queryByText('Draft Response!')).not.toBeInTheDocument();
+      const editor = screen.queryByTestId('tinymce-editor');
+      expect(editor.value).toBe('');
     });
 
     it('successfully maintain response for the specific post in the draft.', async () => {

--- a/src/discussions/post-comments/PostCommentsView.test.jsx
+++ b/src/discussions/post-comments/PostCommentsView.test.jsx
@@ -674,25 +674,20 @@ describe('ThreadView', () => {
     it('successfully added comment in the draft.', async () => {
       await waitFor(() => renderComponent(discussionPostId));
 
-      let addCommentBtn = screen.queryByText('Add comment');
-
       await act(async () => {
-        fireEvent.click(addCommentBtn);
+        fireEvent.click(screen.queryByText('Add comment'));
       });
 
       await waitFor(() => {
-        const editor = screen.queryByTestId('tinymce-editor');
-        fireEvent.change(editor, { target: { value: 'Draft comment!' } });
+        fireEvent.change(screen.queryByTestId('tinymce-editor'), { target: { value: 'Draft comment!' } });
       });
 
-      const cancelBtn = screen.queryByText('Cancel');
       await act(async () => {
-        fireEvent.click(cancelBtn);
+        fireEvent.click(screen.queryByText('Cancel'));
       });
 
-      addCommentBtn = screen.queryByText('Add comment');
       await act(async () => {
-        fireEvent.click(addCommentBtn);
+        fireEvent.click(screen.queryByText('Add comment'));
       });
 
       expect(screen.queryByText('Draft comment!')).toBeInTheDocument();
@@ -708,35 +703,28 @@ describe('ThreadView', () => {
         fireEvent.click(actionBtn);
       });
 
-      let editBtn = screen.queryByTestId('edit');
-
       await act(async () => {
-        fireEvent.click(editBtn);
+        fireEvent.click(screen.queryByTestId('edit'));
       });
 
       await waitFor(() => {
-        const editor = screen.queryByTestId('tinymce-editor');
-        fireEvent.change(editor, { target: { value: 'Draft comment!' } });
+        fireEvent.change(screen.queryByTestId('tinymce-editor'), { target: { value: 'Draft comment!' } });
       });
 
-      const cancelBtn = screen.queryByText('Cancel');
       await act(async () => {
-        fireEvent.click(cancelBtn);
+        fireEvent.click(screen.queryByText('Cancel'));
       });
 
       await act(async () => {
         fireEvent.click(actionBtn);
       });
 
-      editBtn = screen.queryByTestId('edit');
-
       await act(async () => {
-        fireEvent.click(editBtn);
+        fireEvent.click(screen.queryByTestId('edit'));
       });
 
-      const submitBtn = screen.queryByText('Submit');
       await act(async () => {
-        fireEvent.click(submitBtn);
+        fireEvent.click(screen.queryByText('Submit'));
       });
 
       await waitFor(() => expect(screen.queryByText('Draft comment!')).toBeInTheDocument());
@@ -745,49 +733,42 @@ describe('ThreadView', () => {
     it('successfully removed comment from the draft.', async () => {
       await waitFor(() => renderComponent(discussionPostId));
 
-      let addCommentBtn = screen.queryByText('Add comment');
-
       await act(async () => {
-        fireEvent.click(addCommentBtn);
+        fireEvent.click(screen.queryByText('Add comment'));
       });
 
       await waitFor(() => {
-        const editor = screen.queryByTestId('tinymce-editor');
-        fireEvent.change(editor, { target: { value: 'Draft comment 123!' } });
+        fireEvent.change(screen.queryByTestId('tinymce-editor'), { target: { value: 'Draft comment 123!' } });
       });
 
-      const submitBtn = screen.queryByText('Submit');
       await act(async () => {
-        fireEvent.click(submitBtn);
+        fireEvent.click(screen.queryByText('Submit'));
       });
 
-      addCommentBtn = screen.queryAllByText('Add comment');
       await act(async () => {
-        fireEvent.click(addCommentBtn[0]);
+        fireEvent.click(screen.queryAllByText('Add comment')[0]);
       });
-      const editor = screen.queryByTestId('tinymce-editor');
-      expect(editor.value).toBe('');
+
+      expect(screen.queryByTestId('tinymce-editor').value).toBe('');
     });
 
     it('successfully added response in the draft.', async () => {
       await waitFor(() => renderComponent(discussionPostId));
 
-      let addResponseBtn = screen.queryByText('Add response');
       await act(async () => {
-        fireEvent.click(addResponseBtn);
+        fireEvent.click(screen.queryByText('Add response'));
       });
 
       await waitFor(() => {
-        const editor = screen.queryByTestId('tinymce-editor');
-        fireEvent.change(editor, { target: { value: 'Draft Response!' } });
+        fireEvent.change(screen.queryByTestId('tinymce-editor'), { target: { value: 'Draft Response!' } });
       });
-      const cancelBtn = screen.queryByText('Cancel');
+
       await act(async () => {
-        fireEvent.click(cancelBtn);
+        fireEvent.click(screen.queryByText('Cancel'));
       });
-      addResponseBtn = screen.queryByText('Add response');
+
       await act(async () => {
-        fireEvent.click(addResponseBtn);
+        fireEvent.click(screen.queryByText('Add response'));
       });
 
       expect(screen.queryByText('Draft Response!')).toBeInTheDocument();
@@ -796,46 +777,40 @@ describe('ThreadView', () => {
     it('successfully removed response from the draft.', async () => {
       await waitFor(() => renderComponent(discussionPostId));
 
-      let addResponseBtn = screen.queryByText('Add response');
       await act(async () => {
-        fireEvent.click(addResponseBtn);
+        fireEvent.click(screen.queryByText('Add response'));
       });
 
       await waitFor(() => {
-        const editor = screen.queryByTestId('tinymce-editor');
-        fireEvent.change(editor, { target: { value: 'Draft Response!' } });
-      });
-      const submitBtn = screen.queryByText('Submit');
-      await act(async () => {
-        fireEvent.click(submitBtn);
-      });
-      addResponseBtn = screen.queryByText('Add response');
-      await act(async () => {
-        fireEvent.click(addResponseBtn);
+        fireEvent.change(screen.queryByTestId('tinymce-editor'), { target: { value: 'Draft Response!' } });
       });
 
-      const editor = screen.queryByTestId('tinymce-editor');
-      expect(editor.value).toBe('');
+      await act(async () => {
+        fireEvent.click(screen.queryByText('Submit'));
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.queryByText('Add response'));
+      });
+
+      expect(screen.queryByTestId('tinymce-editor').value).toBe('');
     });
 
     it('successfully maintain response for the specific post in the draft.', async () => {
       await waitFor(() => renderComponent(discussionPostId));
 
-      let addResponseBtn = screen.queryByText('Add response');
       await act(async () => {
-        fireEvent.click(addResponseBtn);
+        fireEvent.click(screen.queryByText('Add response'));
       });
 
       await waitFor(() => {
-        const editor = screen.queryByTestId('tinymce-editor');
-        fireEvent.change(editor, { target: { value: 'Hello, world!' } });
+        fireEvent.change(screen.queryByTestId('tinymce-editor'), { target: { value: 'Hello, world!' } });
       });
 
       await waitFor(() => renderComponent('thread-2'));
-      await waitFor(() => renderComponent(discussionPostId));
-      addResponseBtn = screen.queryAllByText('Add response');
+
       await act(async () => {
-        fireEvent.click(addResponseBtn[0]);
+        fireEvent.click(screen.queryAllByText('Add response')[0]);
       });
 
       expect(screen.queryByText('Hello, world!')).toBeInTheDocument();

--- a/src/discussions/post-comments/PostCommentsView.test.jsx
+++ b/src/discussions/post-comments/PostCommentsView.test.jsx
@@ -671,7 +671,109 @@ describe('ThreadView', () => {
       expect(screen.queryByTestId('reply-comment-3')).not.toBeInTheDocument();
     });
 
+    it('successfully added comment in the draft.', async () => {
+      await waitFor(() => renderComponent(discussionPostId));
+
+      let addCommentBtn = screen.queryByText('Add comment');
+
+      await act(async () => {
+        fireEvent.click(addCommentBtn);
+      });
+
+      await waitFor(() => {
+        const editor = screen.queryByTestId('tinymce-editor');
+        fireEvent.change(editor, { target: { value: 'Draft comment!' } });
+      });
+
+      const cancelBtn = screen.queryByText('Cancel');
+      await act(async () => {
+        fireEvent.click(cancelBtn);
+      });
+
+      addCommentBtn = screen.queryByText('Add comment');
+      await act(async () => {
+        fireEvent.click(addCommentBtn);
+      });
+
+      expect(screen.queryByText('Draft comment!')).toBeInTheDocument();
+    });
+
+    it('successfully removed comment from the draft.', async () => {
+      await waitFor(() => renderComponent(discussionPostId));
+
+      let addCommentBtn = screen.queryByText('Add comment');
+
+      await act(async () => {
+        fireEvent.click(addCommentBtn);
+      });
+
+      await waitFor(() => {
+        const editor = screen.queryByTestId('tinymce-editor');
+        fireEvent.change(editor, { target: { value: 'Draft comment!' } });
+      });
+
+      const submitBtn = screen.queryByText('Submit');
+      await act(async () => {
+        fireEvent.click(submitBtn);
+      });
+
+      addCommentBtn = screen.queryAllByText('Add comment');
+      await act(async () => {
+        fireEvent.click(addCommentBtn[0]);
+      });
+
+      expect(screen.queryByText('Draft comment!')).not.toBeInTheDocument();
+    });
+
     it('successfully added response in the draft.', async () => {
+      await waitFor(() => renderComponent(discussionPostId));
+
+      let addResponseBtn = screen.queryByText('Add response');
+      await act(async () => {
+        fireEvent.click(addResponseBtn);
+      });
+
+      await waitFor(() => {
+        const editor = screen.queryByTestId('tinymce-editor');
+        fireEvent.change(editor, { target: { value: 'Draft Response!' } });
+      });
+      const cancelBtn = screen.queryByText('Cancel');
+      await act(async () => {
+        fireEvent.click(cancelBtn);
+      });
+      addResponseBtn = screen.queryByText('Add response');
+      await act(async () => {
+        fireEvent.click(addResponseBtn);
+      });
+
+      expect(screen.queryByText('Draft Response!')).toBeInTheDocument();
+    });
+
+    it('successfully removed response from the draft.', async () => {
+      await waitFor(() => renderComponent(discussionPostId));
+
+      let addResponseBtn = screen.queryByText('Add response');
+      await act(async () => {
+        fireEvent.click(addResponseBtn);
+      });
+
+      await waitFor(() => {
+        const editor = screen.queryByTestId('tinymce-editor');
+        fireEvent.change(editor, { target: { value: 'Draft Response!' } });
+      });
+      const submitBtn = screen.queryByText('Submit');
+      await act(async () => {
+        fireEvent.click(submitBtn);
+      });
+      addResponseBtn = screen.queryByText('Add response');
+      await act(async () => {
+        fireEvent.click(addResponseBtn);
+      });
+
+      expect(screen.queryByText('Draft Response!')).not.toBeInTheDocument();
+    });
+
+    it('successfully maintain response for the specific post in the draft.', async () => {
       await waitFor(() => renderComponent(discussionPostId));
 
       let addResponseBtn = screen.queryByText('Add response');
@@ -683,13 +785,12 @@ describe('ThreadView', () => {
         const editor = screen.queryByTestId('tinymce-editor');
         fireEvent.change(editor, { target: { value: 'Hello, world!' } });
       });
-      const cancelBtn = screen.queryByText('Cancel');
+
+      await waitFor(() => renderComponent('thread-2'));
+      await waitFor(() => renderComponent(discussionPostId));
+      addResponseBtn = screen.queryAllByText('Add response');
       await act(async () => {
-        fireEvent.click(cancelBtn);
-      });
-      addResponseBtn = screen.queryByText('Add response');
-      await act(async () => {
-        fireEvent.click(addResponseBtn);
+        fireEvent.click(addResponseBtn[0]);
       });
 
       expect(screen.queryByText('Hello, world!')).toBeInTheDocument();

--- a/src/discussions/post-comments/comments/comment/CommentEditor.jsx
+++ b/src/discussions/post-comments/comments/comment/CommentEditor.jsx
@@ -75,14 +75,14 @@ const CommentEditor = ({
     onCloseEditor();
   }, [onCloseEditor, initialValues]);
 
-  const deleteEditorContent = async () => {
+  const deleteEditorContent = useCallback(async () => {
     const { updatedResponses, updatedComments } = removeDraftContent(parentId, id, threadId);
     if (parentId) {
       await dispatch(setDraftComments(updatedComments));
     } else {
       await dispatch(setDraftResponses(updatedResponses));
     }
-  };
+  }, [parentId, id, threadId]);
 
   const saveUpdatedComment = useCallback(async (values, { resetForm }) => {
     if (id) {

--- a/src/discussions/post-comments/comments/comment/CommentEditor.jsx
+++ b/src/discussions/post-comments/comments/comment/CommentEditor.jsx
@@ -82,7 +82,7 @@ const CommentEditor = ({
     } else {
       await dispatch(setDraftResponses(updatedResponses));
     }
-  }, [parentId, id, threadId]);
+  }, [parentId, id, threadId, setDraftComments, setDraftResponses]);
 
   const saveUpdatedComment = useCallback(async (values, { resetForm }) => {
     if (id) {

--- a/src/discussions/post-comments/comments/comment/CommentEditor.jsx
+++ b/src/discussions/post-comments/comments/comment/CommentEditor.jsx
@@ -82,14 +82,16 @@ const CommentEditor = ({
   };
 
   const saveUpdatedComment = useCallback(async (values, { resetForm }) => {
+    const clonedValues = { ...values };
+    clonedValues.comment = editorContent;
     if (id) {
       const payload = {
-        ...values,
-        editReasonCode: values.editReasonCode || undefined,
+        ...clonedValues,
+        editReasonCode: clonedValues.editReasonCode || undefined,
       };
       await dispatch(editComment(id, payload));
     } else {
-      await dispatch(addComment(values.comment, threadId, parentId, enableInContextSidebar));
+      await dispatch(addComment(clonedValues.comment, threadId, parentId, enableInContextSidebar));
     }
     /* istanbul ignore if: TinyMCE is mocked so this cannot be easily tested */
     if (editorRef.current) {

--- a/src/discussions/post-comments/comments/comment/CommentEditor.jsx
+++ b/src/discussions/post-comments/comments/comment/CommentEditor.jsx
@@ -118,8 +118,7 @@ const CommentEditor = ({
     setEditorContent(draftObject ? draftObject.content : '');
   }, [responses, comments, parentId, threadId, id]);
 
-  const SaveDraftComment = async () => {
-    const content = editorRef.current.getContent();
+  const SaveDraftComment = async (content) => {
     const { updatedResponses, updatedComments } = useAddDraftContent(
       content,
       responses,
@@ -191,9 +190,9 @@ const CommentEditor = ({
             id={editorId}
             value={editorContent || values.comment}
             onEditorChange={(content) => handleEditorChange(content, setFieldValue)}
-            onBlur={() => {
+            onBlur={(content) => {
               formikCompatibleHandler(handleChange, 'comment');
-              SaveDraftComment();
+              SaveDraftComment(typeof content === 'object' ? content.target.getContent() : content);
             }}
           />
           {isFormikFieldInvalid('comment', {

--- a/src/discussions/post-comments/data/hooks.js
+++ b/src/discussions/post-comments/data/hooks.js
@@ -156,21 +156,14 @@ export const useDraftContent = () => {
     return newDraftData;
   };
 
-  const removeDraftContent = (parentId, id, threadId) => {
-    let updatedResponses = responses;
-    let updatedComments = comments;
+  const updateContent = (items, itemId, parentId, isComment) => {
+    const itemObj = itemId ? items[itemId] : getObjectByParentId(items, parentId, isComment, itemId);
+    return itemObj ? removeItem(items, itemObj.id) : items;
+  };
 
-    if (!parentId) {
-      const responseObj = id ? responses[id] : getObjectByParentId(responses, threadId, false, id);
-      if (responseObj) {
-        updatedResponses = removeItem(responses, responseObj.id);
-      }
-    } else {
-      const commentObj = id ? comments[id] : getObjectByParentId(comments, parentId, true, id);
-      if (commentObj) {
-        updatedComments = removeItem(comments, commentObj.id);
-      }
-    }
+  const removeDraftContent = (parentId, id, threadId) => {
+    const updatedResponses = !parentId ? updateContent(responses, id, threadId, false) : responses;
+    const updatedComments = parentId ? updateContent(comments, id, parentId, true) : comments;
 
     return { updatedResponses, updatedComments };
   };

--- a/src/discussions/post-comments/data/hooks.js
+++ b/src/discussions/post-comments/data/hooks.js
@@ -119,9 +119,19 @@ export const useDraftContent = () => {
   });
 
   const addDraftContent = (content, parentId, id, threadId) => {
-    const newObject = {
-      threadId, content, parentId, id: id || uuidv4(), isNewContent: !id,
-    };
+    const data = parentId ? comments : responses;
+    const draftParentId = parentId || threadId;
+    const isComment = !!parentId;
+    const existingObj = getObjectByParentId(data, draftParentId, isComment, id);
+    const newObject = existingObj
+      ? { ...existingObj, content }
+      : {
+        threadId,
+        content,
+        parentId,
+        id: id || uuidv4(),
+        isNewContent: !id,
+      };
 
     const updatedComments = parentId ? updateDraftData(comments, newObject) : comments;
     const updatedResponses = !parentId ? updateDraftData(responses, newObject) : responses;

--- a/src/discussions/post-comments/data/hooks.js
+++ b/src/discussions/post-comments/data/hooks.js
@@ -102,3 +102,50 @@ export function useCommentsCount(postId) {
 
   return commentsLength;
 }
+
+const removeItem = (list, condition) => {
+  const index = list.findIndex(condition);
+  if (index > -1) {
+    list.splice(index, 1);
+  }
+};
+
+export const useRemoveDraftContent = (responses, comments, parentId, id, threadId) => {
+  const updatedResponses = [...responses];
+  const updatedComments = [...comments];
+
+  if (!parentId) {
+    removeItem(updatedResponses, x => x.threadId === threadId && x.id === id);
+  } else {
+    removeItem(updatedComments, x => x.parentId === parentId && x.id === id);
+  }
+
+  return { updatedResponses, updatedComments };
+};
+
+const updateList = (list, condition, newItem) => {
+  const index = list.findIndex(condition);
+  if (index === -1) {
+    return [...list, newItem];
+  }
+  return list.map((item, i) => (i === index ? {
+    ...item, content: newItem.content, id: newItem.id, parentId: newItem.parentId,
+  } : item));
+};
+
+export const useAddDraftContent = (content, responses, comments, parentId, id, threadId) => {
+  let updatedResponses = [...responses];
+  let updatedComments = [...comments];
+
+  if (!parentId) {
+    updatedResponses = updateList(updatedResponses, (x) => x.threadId === threadId && x.id === id, {
+      threadId, content, parentId, id,
+    });
+  } else {
+    updatedComments = updateList(updatedComments, (x) => x.parentId === parentId && x.id === id, {
+      threadId, content, parentId, id,
+    });
+  }
+
+  return { updatedResponses, updatedComments };
+};

--- a/src/discussions/post-comments/data/selectors.js
+++ b/src/discussions/post-comments/data/selectors.js
@@ -47,3 +47,7 @@ export const selectCommentCurrentPage = commentId => (
 export const selectCommentsStatus = state => state.comments.status;
 
 export const selectCommentSortOrder = state => state.comments.sortOrder;
+
+export const selectDraftComments = state => state.comments.draftComments;
+
+export const selectDraftResponses = state => state.comments.draftResponses;

--- a/src/discussions/post-comments/data/slices.js
+++ b/src/discussions/post-comments/data/slices.js
@@ -22,6 +22,10 @@ const commentsSlice = createSlice({
     pagination: {},
     responsesPagination: {},
     sortOrder: true,
+    draft: {
+      responses: [],
+      comments: [],
+    },
   },
   reducers: {
     fetchCommentsRequest: (state) => (
@@ -257,6 +261,12 @@ const commentsSlice = createSlice({
         sortOrder: payload,
       }
     ),
+    setDraftContent: (state, { payload }) => (
+      {
+        ...state,
+        draft: payload,
+      }
+    ),
   },
 });
 
@@ -282,6 +292,7 @@ export const {
   deleteCommentRequest,
   deleteCommentSuccess,
   setCommentSortOrder,
+  setDraftContent,
 } = commentsSlice.actions;
 
 export const commentsReducer = commentsSlice.reducer;

--- a/src/discussions/post-comments/data/slices.js
+++ b/src/discussions/post-comments/data/slices.js
@@ -259,13 +259,13 @@ const commentsSlice = createSlice({
         sortOrder: payload,
       }
     ),
-    setDraftComment: (state, { payload }) => (
+    setDraftComments: (state, { payload }) => (
       {
         ...state,
         draftComments: payload,
       }
     ),
-    setDraftResponse: (state, { payload }) => (
+    setDraftResponses: (state, { payload }) => (
       {
         ...state,
         draftResponses: payload,
@@ -296,8 +296,8 @@ export const {
   deleteCommentRequest,
   deleteCommentSuccess,
   setCommentSortOrder,
-  setDraftComment,
-  setDraftResponse,
+  setDraftComments,
+  setDraftResponses,
 } = commentsSlice.actions;
 
 export const commentsReducer = commentsSlice.reducer;

--- a/src/discussions/post-comments/data/slices.js
+++ b/src/discussions/post-comments/data/slices.js
@@ -22,10 +22,8 @@ const commentsSlice = createSlice({
     pagination: {},
     responsesPagination: {},
     sortOrder: true,
-    draft: {
-      responses: [],
-      comments: [],
-    },
+    draftResponses: {},
+    draftComments: {},
   },
   reducers: {
     fetchCommentsRequest: (state) => (
@@ -261,10 +259,16 @@ const commentsSlice = createSlice({
         sortOrder: payload,
       }
     ),
-    setDraftContent: (state, { payload }) => (
+    setDraftComment: (state, { payload }) => (
       {
         ...state,
-        draft: payload,
+        draftComments: payload,
+      }
+    ),
+    setDraftResponse: (state, { payload }) => (
+      {
+        ...state,
+        draftResponses: payload,
       }
     ),
   },
@@ -292,7 +296,8 @@ export const {
   deleteCommentRequest,
   deleteCommentSuccess,
   setCommentSortOrder,
-  setDraftContent,
+  setDraftComment,
+  setDraftResponse,
 } = commentsSlice.actions;
 
 export const commentsReducer = commentsSlice.reducer;

--- a/src/discussions/utils.js
+++ b/src/discussions/utils.js
@@ -316,3 +316,10 @@ export function getAuthorLabel(intl, authorLabel) {
 }
 
 export const isCourseStatusValid = (courseStatus) => [DENIED, LOADED].includes(courseStatus);
+
+export const extractContent = (content) => {
+  if (typeof content === 'object') {
+    return content.target.getContent();
+  }
+  return content;
+};

--- a/src/setupTest.jsx
+++ b/src/setupTest.jsx
@@ -19,6 +19,15 @@ Object.defineProperty(window, 'matchMedia', {
   })),
 });
 
+global.MathJax = {
+  typeset: jest.fn(callback => {
+    if (callback) { callback(); }
+  }),
+  startup: {
+    defaultPageReady: jest.fn(() => Promise.resolve()),
+  },
+};
+
 // Provides a mock editor component that functions like tinyMCE without the overhead
 const MockEditor = ({
   onBlur,

--- a/src/setupTest.jsx
+++ b/src/setupTest.jsx
@@ -1,5 +1,9 @@
 import PropTypes from 'prop-types';
 
+import { useDispatch } from 'react-redux';
+
+import { setDraftContent } from './discussions/post-comments/data/slices';
+
 import '@testing-library/jest-dom/extend-expect';
 import 'babel-polyfill';
 
@@ -23,21 +27,29 @@ Object.defineProperty(window, 'matchMedia', {
 const MockEditor = ({
   onBlur,
   onEditorChange,
-}) => (
-  <textarea
-    data-testid="tinymce-editor"
-    onChange={(event) => {
-      onEditorChange(event.currentTarget.value);
-    }}
-    onBlur={event => {
-      onBlur(event.currentTarget.value);
-    }}
-  />
-);
+  value,
+}) => {
+  const dispatch = useDispatch();
+
+  return (
+    <textarea
+      data-testid="tinymce-editor"
+      value={value}
+      onChange={(event) => {
+        onEditorChange(`${event.currentTarget.value}`);
+        dispatch(setDraftContent({ responses: [{ threadId: 'thread-1', content: `${event.currentTarget.value}` }], comments: [] }));
+      }}
+      onBlur={event => {
+        onBlur(event.currentTarget.value);
+      }}
+    />
+  );
+};
 
 MockEditor.propTypes = {
   onBlur: PropTypes.func.isRequired,
   onEditorChange: PropTypes.func.isRequired,
+  value: PropTypes.string.isRequired,
 };
 jest.mock('@tinymce/tinymce-react', () => {
   const originalModule = jest.requireActual('@tinymce/tinymce-react');

--- a/src/setupTest.jsx
+++ b/src/setupTest.jsx
@@ -1,9 +1,5 @@
 import PropTypes from 'prop-types';
 
-import { useDispatch } from 'react-redux';
-
-import { setDraftContent } from './discussions/post-comments/data/slices';
-
 import '@testing-library/jest-dom/extend-expect';
 import 'babel-polyfill';
 
@@ -28,24 +24,17 @@ const MockEditor = ({
   onBlur,
   onEditorChange,
   value,
-}) => {
-  const dispatch = useDispatch();
-
-  return (
-    <textarea
-      data-testid="tinymce-editor"
-      value={value}
-      onChange={(event) => {
-        onEditorChange(`${event.currentTarget.value}`);
-        dispatch(setDraftContent({ responses: [{ threadId: 'thread-1', content: `${event.currentTarget.value}` }], comments: [] }));
-      }}
-      onBlur={event => {
-        onBlur(event.currentTarget.value);
-      }}
-    />
-  );
-};
-
+}) => (
+  <textarea
+    data-testid="tinymce-editor"
+    value={value}
+    onChange={(event) => {
+      onEditorChange(event.currentTarget.value);
+      onBlur(event.currentTarget.value);
+    }}
+    onBlur={onBlur}
+  />
+);
 MockEditor.propTypes = {
   onBlur: PropTypes.func.isRequired,
   onEditorChange: PropTypes.func.isRequired,


### PR DESCRIPTION
[INF-1444](https://2u-internal.atlassian.net/browse/INF-1444)
### Description

Learners using the discussion board have faced a frustrating issue: losing their work when switching tabs and returning to the post. This can be especially disheartening for those writing lengthy comments or responses. The issue occurs specifically while writing comments or responses on posts.

Solution 

Draft Feature: Offering a draft functionality where users can save unfinished posts and return to them later. The draft only be saved on the frontend and are lost on page reload.

#### Screenshots/sandbox (optional):
https://www.loom.com/share/fa0007a967ea406f89835409009dd3b1?sid=72cdf8c3-2e9f-4816-ba62-d7b991b5872b

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.