### PR TITLE
feat: added help section for post documentation

### DIFF
--- a/src/components/PostHelpPanel.jsx
+++ b/src/components/PostHelpPanel.jsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+
+import {
+  Hyperlink, Icon, IconButton, IconButtonWithTooltip,
+} from '@openedx/paragon';
+import { Close, HelpOutline } from '@openedx/paragon/icons';
+
+import { useIntl } from '@edx/frontend-platform/i18n';
+
+import messages from '../discussions/posts/post-editor/messages';
+
+const PostHelpPanel = () => {
+  const intl = useIntl();
+  const [showHelpPane, setShowHelpPane] = useState(false);
+
+  return (
+    <>
+      <div className="d-flex justify-content-end">
+        <IconButtonWithTooltip
+          onClick={() => setShowHelpPane(true)}
+          alt={intl.formatMessage(messages.showHelpIcon)}
+          tooltipContent={<div>Learn more about MathJax & LaTeX</div>}
+          src={HelpOutline}
+          iconAs={Icon}
+          size="inline"
+          className="float-right p-3 help-icon"
+          iconClassNames="icon-size"
+          data-testid="help-button"
+        />
+      </div>
+      {showHelpPane && (
+        <div
+          className="w-100 p-2 bg-light-200 rounded box-shadow-down-1 post-preview overflow-auto my-3"
+          style={{ minHeight: '200px', wordBreak: 'break-word' }}
+        >
+          <IconButton
+            onClick={() => setShowHelpPane(false)}
+            alt={intl.formatMessage(messages.actionsAlt)}
+            src={Close}
+            iconAs={Icon}
+            size="inline"
+            className="float-right p-3"
+            iconClassNames="icon-size"
+            data-testid="hide-help-button"
+          />
+          <div className="pt-2 px-3">
+            <h4 className="font-weight-bold">{intl.formatMessage(messages.discussionHelpHeader)}</h4>
+            <p className="pt-2 font-size-12">{intl.formatMessage(messages.discussionHelpDescription)}</p>
+            <Hyperlink
+              target="_blank"
+              className="font-size-12 w-100"
+              destination="https://support.edx.org/hc/en-us/sections/115004169687-Participating-in-Course-Discussions"
+              showLaunchIcon={false}
+            >
+              {intl.formatMessage(messages.discussionHelpCourseParticipation)}
+            </Hyperlink>
+            <Hyperlink
+              target="_blank"
+              className="font-size-12 w-100"
+              destination="https://support.edx.org/hc/en-us/articles/360000035267-Entering-math-expressions-in-course-discussions"
+              showLaunchIcon={false}
+            >
+              {intl.formatMessage(messages.discussionHelpMathExpressions)}
+            </Hyperlink>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default React.memo(PostHelpPanel);

--- a/src/components/PostHelpPanel.jsx
+++ b/src/components/PostHelpPanel.jsx
@@ -19,13 +19,15 @@ const PostHelpPanel = () => {
         <IconButtonWithTooltip
           onClick={() => setShowHelpPane(true)}
           alt={intl.formatMessage(messages.showHelpIcon)}
-          tooltipContent={<div>Learn more about MathJax & LaTeX</div>}
+          tooltipContent={<div>{intl.formatMessage(messages.discussionHelpTooltip)}</div>}
           src={HelpOutline}
           iconAs={Icon}
           size="inline"
           className="float-right p-3 help-icon"
-          iconClassNames="icon-size"
+          iconClassNames="help-icon-size"
           data-testid="help-button"
+          invertColors
+          isActive
         />
       </div>
       {showHelpPane && (
@@ -45,10 +47,10 @@ const PostHelpPanel = () => {
           />
           <div className="pt-2 px-3">
             <h4 className="font-weight-bold">{intl.formatMessage(messages.discussionHelpHeader)}</h4>
-            <p className="pt-2 font-size-12">{intl.formatMessage(messages.discussionHelpDescription)}</p>
+            <p className="pt-2">{intl.formatMessage(messages.discussionHelpDescription)}</p>
             <Hyperlink
               target="_blank"
-              className="font-size-12 w-100"
+              className="w-100"
               destination="https://support.edx.org/hc/en-us/sections/115004169687-Participating-in-Course-Discussions"
               showLaunchIcon={false}
             >
@@ -56,7 +58,7 @@ const PostHelpPanel = () => {
             </Hyperlink>
             <Hyperlink
               target="_blank"
-              className="font-size-12 w-100"
+              className="w-100"
               destination="https://support.edx.org/hc/en-us/articles/360000035267-Entering-math-expressions-in-course-discussions"
               showLaunchIcon={false}
             >

--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -18,6 +18,7 @@ import { AppContext } from '@edx/frontend-platform/react';
 
 import { TinyMCEEditor } from '../../../components';
 import FormikErrorFeedback from '../../../components/FormikErrorFeedback';
+import PostHelpPanel from '../../../components/PostHelpPanel';
 import PostPreviewPanel from '../../../components/PostPreviewPanel';
 import useDispatchWithState from '../../../data/hooks';
 import selectCourseCohorts from '../../cohorts/data/selectors';
@@ -411,6 +412,7 @@ const PostEditor = ({
           />
           <FormikErrorFeedback name="comment" />
         </div>
+        <PostHelpPanel />
         <PostPreviewPanel htmlNode={values.comment} isPost editExisting={editExisting} />
         <div className="d-flex flex-row mt-n4 w-75 text-primary font-style">
           {!editExisting && (

--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -410,9 +410,9 @@ const PostEditor = ({
             onEditorChange={formikCompatibleHandler(handleChange, 'comment')}
             onBlur={formikCompatibleHandler(handleBlur, 'comment')}
           />
+          <PostHelpPanel />
           <FormikErrorFeedback name="comment" />
         </div>
-        <PostHelpPanel />
         <PostPreviewPanel htmlNode={values.comment} isPost editExisting={editExisting} />
         <div className="d-flex flex-row mt-n4 w-75 text-primary font-style">
           {!editExisting && (

--- a/src/discussions/posts/post-editor/PostEditor.test.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.test.jsx
@@ -368,5 +368,34 @@ describe('PostEditor', () => {
         expect(container.querySelector('[data-testid="hide-preview-button"]')).not.toBeInTheDocument();
       });
     });
+
+    it('should show Help Panel', async () => {
+      await renderComponent(true, `/${courseId}/posts/${threadId}/edit`);
+
+      await act(async () => {
+        fireEvent.click(container.querySelector('[data-testid="help-button"]'));
+      });
+
+      await waitFor(() => {
+        expect(container.querySelector('[data-testid="hide-help-button"]')).toBeInTheDocument();
+      });
+    });
+
+    it('should hide Help Panel', async () => {
+      await renderComponent(true, `/${courseId}/posts/${threadId}/edit`);
+
+      await act(async () => {
+        fireEvent.click(container.querySelector('[data-testid="help-button"]'));
+      });
+
+      await act(async () => {
+        fireEvent.click(container.querySelector('[data-testid="hide-help-button"]'));
+      });
+
+      await waitFor(() => {
+        expect(container.querySelector('[data-testid="help-button"]')).toBeInTheDocument();
+        expect(container.querySelector('[data-testid="hide-help-button"]')).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/src/discussions/posts/post-editor/messages.js
+++ b/src/discussions/posts/post-editor/messages.js
@@ -141,6 +141,11 @@ const messages = defineMessages({
     defaultMessage: 'Entering math expressions in course discussions',
     description: 'Documentation link title for entering math expressions in course discussions.',
   },
+  discussionHelpTooltip: {
+    id: 'discussions.editor.posts.discussionHelpTooltip',
+    defaultMessage: 'Learn more about MathJax & LaTeX',
+    description: 'Tooltip help message for documentation help.',
+  },
   actionsAlt: {
     id: 'discussions.actions.label',
     defaultMessage: 'Actions menu',

--- a/src/discussions/posts/post-editor/messages.js
+++ b/src/discussions/posts/post-editor/messages.js
@@ -116,6 +116,31 @@ const messages = defineMessages({
     defaultMessage: 'Show preview',
     description: 'show preview button text to allow user to see their post content.',
   },
+  showHelpIcon: {
+    id: 'discussions.editor.posts.showHelp.icon',
+    defaultMessage: 'Show Help',
+    description: 'show help icon to allow user to see important documentation.',
+  },
+  discussionHelpHeader: {
+    id: 'discussions.editor.posts.discussionHelpHeader',
+    defaultMessage: 'Discussions help',
+    description: 'header text for post help section.',
+  },
+  discussionHelpDescription: {
+    id: 'discussions.editor.posts.discussionHelpDescription',
+    defaultMessage: 'Course discussions give you the opportunity to start conversations, ask questions, and interact with other learners. See the links below to learn more:',
+    description: 'description message for post help section.',
+  },
+  discussionHelpCourseParticipation: {
+    id: 'discussions.editor.posts.discussionHelpCourseParticipation',
+    defaultMessage: 'Participating in course discussions',
+    description: 'Documentation link title for participating in course discussions.',
+  },
+  discussionHelpMathExpressions: {
+    id: 'discussions.editor.posts.discussionHelpMathExpressions',
+    defaultMessage: 'Entering math expressions in course discussions',
+    description: 'Documentation link title for entering math expressions in course discussions.',
+  },
   actionsAlt: {
     id: 'discussions.actions.label',
     defaultMessage: 'Actions menu',

--- a/src/index.scss
+++ b/src/index.scss
@@ -64,6 +64,10 @@ body,
   font-size: 8px !important;
 }
 
+.font-size-12 {
+  font-size: 12px !important;
+}
+
 .font-weight-500 {
   font-weight: 500 !important;
 }
@@ -591,6 +595,10 @@ th, td {
   border: 1px dashed $gray-200;
   padding: 0.4rem;
   white-space: nowrap;
+}
+
+.help-icon {
+  margin: -70px 4px 40px 0px;
 }
 
 @media only screen and (max-width: 367px) {

--- a/src/index.scss
+++ b/src/index.scss
@@ -64,10 +64,6 @@ body,
   font-size: 8px !important;
 }
 
-.font-size-12 {
-  font-size: 12px !important;
-}
-
 .font-weight-500 {
   font-weight: 500 !important;
 }
@@ -598,7 +594,12 @@ th, td {
 }
 
 .help-icon {
-  margin: -70px 4px 40px 0px;
+  margin: -47px -3px 0px 0px;
+}
+
+.help-icon-size {
+  height: 16px !important;
+  width: 16px !important;
 }
 
 @media only screen and (max-width: 367px) {
@@ -611,7 +612,8 @@ th, td {
   .pgn__modal,
   .pgn__form-label,
   .dropdown-menu,
-  .tox-tbtn {
+  .tox-tbtn, 
+  .tooltip {
     font-size: 10px !important;
   }
 
@@ -648,7 +650,8 @@ th, td {
   .pgn__form-label,
   .pgn__modal,
   .dropdown-menu,
-  .tox-tbtn {
+  .tox-tbtn,
+  .tooltip {
     font-size: 12px !important;
   }
 
@@ -667,7 +670,8 @@ th, td {
 @media only screen and (min-width: 769px) {
 
   body,
-  #main {
+  #main,
+  .tooltip {
     font-size: 14px;
   }
 }


### PR DESCRIPTION
[INF-821](https://2u-internal.atlassian.net/browse/INF-821)

### Description

To improve learner access to documentation about mathjax and forums in general, we introduced links to these docs within the text editor as show in option #7 of this mockup: [Discussions](https://www.figma.com/file/LVFnO9oRHYiamoicZuXDAC/Discussions?node-id=8264-311323&t=TZdvl2bN7uUYtzmO-4) and shown below.

Clicking on the “?” icon at the bottom right of the text editor will open a help menu. Users should be able to close it, similar to preview. 

Links to 2 docs will be shown initially, but more may be added later.

The “Participating in course discussions” will point to this link: [Participating in Course Discussions – edX Help Center](https://support.edx.org/hc/en-us/sections/115004169687-Participating-in-Course-Discussions)  

The “Entering math expressions in course discussions” will point to this link: [Entering math expressions in course discussions](https://support.edx.org/hc/en-us/articles/360000035267-Entering-math-expressions-in-course-discussions)  

#### Screenshots/sandbox (optional):
<img width="500" alt="Screenshot 2024-08-07 at 10 56 44 PM" src="https://github.com/user-attachments/assets/f190cad1-63d3-4984-b955-0888967d53a3">

<img width="1436" alt="Screenshot 2024-08-07 at 10 56 20 PM" src="https://github.com/user-attachments/assets/9dfb0971-7ec5-4fd1-91e2-684524ecb7ce">

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.