### PR TITLE
fix: clicking on back button after post creation

### DIFF
--- a/src/discussions/posts/data/hooks.js
+++ b/src/discussions/posts/data/hooks.js
@@ -11,10 +11,12 @@ const usePostList = (ids) => {
 
   const sortedIds = useMemo(() => {
     posts.forEach((post) => {
-      if (post.pinned) {
-        pinnedPostsIds.push(post.id);
-      } else {
-        unpinnedPostsIds.push(post.id);
+      if (post) {
+        if (post.pinned) {
+          pinnedPostsIds.push(post.id);
+        } else {
+          unpinnedPostsIds.push(post.id);
+        }
       }
     });
 

--- a/src/discussions/posts/data/slices.js
+++ b/src/discussions/posts/data/slices.js
@@ -92,7 +92,7 @@ const threadsSlice = createSlice({
       if (!updatedPages[page - 1]) {
         updatedPages[page - 1] = ids;
       } else {
-        updatedPages[page - 1] = [...new Set([...updatedPages[page - 1], ...ids])];
+        updatedPages[page - 1] = [...new Set([updatedPages[page - 1], ...ids])];
       }
       newState.pages = updatedPages;
 


### PR DESCRIPTION
## Description

### Steps to Reproduce:
1. Open course in LMS
2. Open discussions sidebar
3. Add post -> Submit
  ![Знімок екрана 2024-09-26 о 16 20 06](https://github.com/user-attachments/assets/a2522070-6b8b-4644-94f4-15de7dc747a8)


4. Click on back browser button
  ![Знімок екрана 2024-09-26 о 16 20 46](https://github.com/user-attachments/assets/9540465f-6a4f-4171-8702-9bdadf744958)

5. Result
  ![Знімок екрана 2024-09-26 о 16 21 30](https://github.com/user-attachments/assets/797647d6-f6cc-486d-a8fd-32a1cb9ec1da)


### Result of the investigation:
**Found that `post id` is unpacked when saving to state, although it should be saved intact:**
  <img width="1766" alt="Знімок екрана 2024-11-28 о 14 28 11" src="https://github.com/user-attachments/assets/dd84c442-e122-48d3-b72f-16cf9ec85e6a">

After fixing the unpacking, this error also started to occur:
  <img width="1691" alt="Знімок екрана 2024-11-28 о 16 25 29" src="https://github.com/user-attachments/assets/61c195b9-153e-40c2-8b7a-35026be553c1">

I have added a check that the post exists to fix this situation:
  <img width="1727" alt="Знімок екрана 2024-11-28 о 14 57 56" src="https://github.com/user-attachments/assets/d8ec05b4-4de4-4244-830c-f6073f2b94c5">
