### PR TITLE
Fixed tab index order for tab press

### DIFF
--- a/src/discussions/learners/learner/LearnerFilterBar.jsx
+++ b/src/discussions/learners/learner/LearnerFilterBar.jsx
@@ -28,10 +28,10 @@ const ActionItem = React.memo(({
     style={{ cursor: 'pointer' }}
     aria-checked={value === selected}
     // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-    tabIndex={value === selected ? '0' : '-1'}
+    tabIndex={'0'}
   >
     <Icon src={Check} className={classNames('text-success mr-2', { invisible: value !== selected })} />
-    <Form.Radio id={id} className="sr-only sr-only-focusable" value={value} tabIndex="0">
+    <Form.Radio id={id} className="sr-only sr-only-focusable" value={value} tabIndex="-1">
       {label}
     </Form.Radio>
     <span aria-hidden className="text-truncate">

--- a/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
+++ b/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
@@ -42,10 +42,10 @@ export const ActionItem = React.memo(({
     style={{ cursor: 'pointer' }}
     aria-checked={value === selected}
     // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-    tabIndex={value === selected ? '0' : '-1'}
+    tabIndex={'0'}
   >
     <Icon src={Check} className={classNames('text-success dropdown-icon-dimensions', { invisible: value !== selected })} />
-    <Form.Radio id={id} className="sr-only sr-only-focusable" value={value} tabIndex="0">
+    <Form.Radio id={id} className="sr-only sr-only-focusable" value={value} tabIndex="-1">
       {label}
     </Form.Radio>
     <span aria-hidden className="text-truncate">


### PR DESCRIPTION
### Description

On the **Posts** page, the keyboard focus was restricted to only the pre-selected option within the filter, and it was not moving to other non-selected options.

**Steps to reproduce:**

1. Open the page: [[Posts Page](https://apps.sandbox.openedx.edly.io/discussions/course-v1:OpenedX+DemoX+DemoCourse/posts)](https://apps.sandbox.openedx.edly.io/discussions/course-v1:OpenedX+DemoX+DemoCourse/posts)
2. Select either **"My Posts"**, **"All Posts"**, or **"Learners"**.
3. Access the filter icon.
4. Notice that the keyboard focus remains on the pre-selected option and does not move to other non-selected options.

Related to https://github.com/overhangio/tutor-indigo/issues/146

### How Has This Been Tested?

I set up Tutor locally with the Indigo Plugin enabled (which is enabled by default). I followed the above steps to reproduce the issue, inspected the HTML on the frontend, and identified where the adjustment was needed. After applying the fix, the keyboard now correctly navigates through both selected and non-selected options using the tab key.

#### Screenshots/sandbox (optional):
[Sandbox Link](https://apps.sandbox.openedx.edly.io/discussions/course-v1:OpenedX+DemoX+DemoCourse/posts)
[Taiga Ticket (If someone have access)](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/27)

## Screenshots
Here is the screen where only selected options were keyboard accessible, but after making the fix it should be accessible for all the options.
![image](https://github.com/user-attachments/assets/0d408a08-d02c-4c77-95d7-009b5425e04e)


#### Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [x] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.