### PR TITLE
Made icons inside topic module tab accessible

### DIFF
--- a/src/components/TopicStats.jsx
+++ b/src/components/TopicStats.jsx
@@ -39,7 +39,7 @@ const TopicStats = ({
           </Tooltip>
         )}
       >
-        <div className="d-flex align-items-center mr-3.5">
+        <div className="d-flex align-items-center mr-3.5" tabIndex={0}>
           <Icon src={PostOutline} className="icon-size mr-2" />
           {threadCounts?.discussion || 0}
         </div>
@@ -57,7 +57,7 @@ const TopicStats = ({
           </Tooltip>
         )}
       >
-        <div className="d-flex align-items-center mr-3.5">
+        <div className="d-flex align-items-center mr-3.5" tabIndex={0}>
           <Icon src={HelpOutline} className="icon-size mr-2" />
           {threadCounts?.question || 0}
         </div>

--- a/src/discussions/in-context-topics/topic/Topic.jsx
+++ b/src/discussions/in-context-topics/topic/Topic.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import classNames from 'classnames';
-import { Link, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
 
@@ -10,6 +10,7 @@ import TopicStats from '../../../components/TopicStats';
 import { Routes } from '../../../data/constants';
 import { discussionsPath } from '../../utils';
 import messages from '../messages';
+import { useNavigate } from 'react-router-dom';
 
 const Topic = ({
   topic,
@@ -18,6 +19,7 @@ const Topic = ({
 }) => {
   const intl = useIntl();
   const { courseId } = useParams();
+  const navigate = useNavigate();
   const isSelected = (id) => window.location.pathname.includes(id);
   const topicUrl = discussionsPath(Routes.TOPICS.TOPIC, {
     courseId,
@@ -26,16 +28,24 @@ const Topic = ({
 
   return (
     <>
-      <Link
-        className={classNames('discussion-topic p-0 text-decoration-none text-primary-500', {
-          'border-light-400 border-bottom': showDivider,
-        })}
+      <div
+        className={classNames('discussion-topic p-0 text-decoration-none text-primary-500', { 'border-light-400 border-bottom': showDivider })}
         data-topic-id={topic.id}
-        to={topicUrl()}
-        onClick={() => isSelected(topic.id)}
+        onClick={() => {
+          isSelected(topic.id);
+          navigate(topicUrl());
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            isSelected(topic.id);
+            navigate(topicUrl());
+          }
+        }}
         aria-current={isSelected(topic.id) ? 'page' : undefined}
         role="option"
         tabIndex={(isSelected(topic.id) || index === 0) ? 0 : -1}
+        style={{ cursor: 'pointer' }}
       >
         <div className="d-flex flex-row pt-2.5 pb-2 px-4">
           <div className="d-flex flex-column flex-fill" style={{ minWidth: 0 }}>
@@ -47,7 +57,7 @@ const Topic = ({
             <TopicStats threadCounts={topic?.threadCounts} />
           </div>
         </div>
-      </Link>
+      </div>
       {!showDivider && (
         <>
           <div className="divider border-top border-light-500" />


### PR DESCRIPTION
### Description

On Discussion page, Under topic tab, modules sub sections are not keyboard accessible. User was not able to move inside the module to access message thread count etc now user can go inside and press enter to open the details.

Ticket: https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/33

#### How Has This Been Tested?

Please describe in detail how you tested your changes.

#### Screenshots/sandbox (optional):
Include a link to the sandbox for design changes or screenshot for before and after. **Remove this section if it's not applicable.**

|Before|After|
|-------|-----|
|      |      |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.