### PR TITLE
feat: replace divs with semantic ul/li on Topics page for improved accessibility

### DIFF
--- a/src/discussions/in-context-topics/TopicPostsView.jsx
+++ b/src/discussions/in-context-topics/TopicPostsView.jsx
@@ -75,7 +75,7 @@ const TopicPostsView = () => {
         />
       )}
       <div className="border-bottom border-light-400" />
-      <div className="list-group list-group-flush flex-fill" role="list" onKeyDown={e => handleKeyDown(e)}>
+      <ul className="list-group list-group-flush flex-fill" data-testid="list" onKeyDown={e => handleKeyDown(e)}>
         {topicId ? (
           <PostsList
             postsIds={postsIds}
@@ -94,11 +94,11 @@ const TopicPostsView = () => {
           <NoResults />
         )}
         {(category && topicsInProgress) && (
-          <div className="d-flex justify-content-center p-4">
+          <li className="d-flex justify-content-center p-4">
             <Spinner animation="border" variant="primary" size="lg" />
-          </div>
+          </li>
         )}
-      </div>
+      </ul>
     </div>
   );
 };

--- a/src/discussions/in-context-topics/TopicsView.jsx
+++ b/src/discussions/in-context-topics/TopicsView.jsx
@@ -109,11 +109,11 @@ const TopicsView = () => {
           {filteredTopics.length === 0 && loadingStatus === RequestStatus.SUCCESSFUL && <NoResults />}
         </>
       )}
-      <div
+      <ul
         className={classNames('list-group list-group-flush flex-fill', {
           'justify-content-center': loadingStatus === RequestStatus.IN_PROGRESS && isEmpty(topics),
         })}
-        role="list"
+        data-testid="list"
         onKeyDown={e => handleKeyDown(e)}
       >
         {topicFilter ? (
@@ -126,7 +126,7 @@ const TopicsView = () => {
         ) : (
           <TopicsList />
         )}
-      </div>
+      </ul>
     </div>
   );
 };

--- a/src/discussions/in-context-topics/TopicsView.test.jsx
+++ b/src/discussions/in-context-topics/TopicsView.test.jsx
@@ -138,12 +138,12 @@ describe('InContext Topics View', () => {
   it('Section groups should be listed in the middle of the topics list.', async () => {
     await setupMockResponse();
     renderComponent();
-    const topicsList = await screen.getByRole('list');
+    const topicsList = await screen.getByTestId('list');
     const sectionGroups = await screen.getAllByTestId('section-group');
 
-    expect(topicsList.children[1]).toStrictEqual(topicsList.querySelector('.divider'));
+    expect(topicsList.children[1].querySelector('.divider')).toStrictEqual(topicsList.querySelector('.divider'));
     expect(sectionGroups.length).toBe(2);
-    expect(topicsList.children[5]).toStrictEqual(topicsList.querySelector('.divider'));
+    expect(topicsList.children[3].querySelector('.divider')).toStrictEqual(topicsList.querySelector('.divider'));
   });
 
   it('A section group should have only a title and required subsections.', async () => {
@@ -187,7 +187,7 @@ describe('InContext Topics View', () => {
     await userEvent.click(subSection);
     await waitFor(async () => {
       const backButton = await screen.getByLabelText('Back to topics list');
-      const topicsList = await screen.getByRole('list');
+      const topicsList = await screen.getByTestId('list');
       const subSectionHeading = await screen.findByText(subsectionObject.displayName);
       const units = await topicsList.querySelectorAll('.discussion-topic');
 

--- a/src/discussions/in-context-topics/topic/ArchivedBaseGroup.jsx
+++ b/src/discussions/in-context-topics/topic/ArchivedBaseGroup.jsx
@@ -23,7 +23,7 @@ const ArchivedBaseGroup = ({
   ), [archivedTopics]);
 
   return (
-    <>
+    <li>
       {showDivider && (
         <>
           <div className="divider border-top border-light-500" />
@@ -37,7 +37,7 @@ const ArchivedBaseGroup = ({
         <div className="pt-3 px-4 font-weight-bold">{intl.formatMessage(messages.archivedTopics)}</div>
         {renderArchivedTopics}
       </div>
-    </>
+    </li>
   );
 };
 

--- a/src/discussions/in-context-topics/topic/SectionBaseGroup.jsx
+++ b/src/discussions/in-context-topics/topic/SectionBaseGroup.jsx
@@ -60,7 +60,7 @@ const SectionBaseGroup = ({
   ), [section, sectionUrl, isSelected]);
 
   return (
-    <div
+    <li
       className="discussion-topic-group d-flex flex-column text-primary-500"
       data-section-id={sectionId}
       data-testid="section-group"
@@ -75,7 +75,7 @@ const SectionBaseGroup = ({
           <div className="divider pt-1 bg-light-300" />
         </>
       )}
-    </div>
+    </li>
   );
 };
 

--- a/src/discussions/in-context-topics/topic/Topic.jsx
+++ b/src/discussions/in-context-topics/topic/Topic.jsx
@@ -25,7 +25,7 @@ const Topic = ({
   });
 
   return (
-    <>
+    <li>
       <Link
         className={classNames('discussion-topic p-0 text-decoration-none text-primary-500', {
           'border-light-400 border-bottom': showDivider,
@@ -54,7 +54,7 @@ const Topic = ({
           <div className="divider pt-1 bg-light-300" />
         </>
       )}
-    </>
+    </li>
   );
 };
 

--- a/src/discussions/learners/LearnersView.jsx
+++ b/src/discussions/learners/LearnersView.jsx
@@ -76,7 +76,7 @@ const LearnersView = () => {
           onClear={handleOnClear}
         />
       )}
-      <div className="list-group list-group-flush learner" role="list">
+      <ul className="list-group list-group-flush learner" data-testid="list">
         {renderLearnersList}
         {loadingStatus === RequestStatus.IN_PROGRESS ? (
           <div className="d-flex justify-content-center p-4">
@@ -90,7 +90,7 @@ const LearnersView = () => {
           )
         )}
         { usernameSearch !== '' && learners.length === 0 && loadingStatus === RequestStatus.SUCCESSFUL && <NoResults />}
-      </div>
+      </ul>
     </div>
   );
 };

--- a/src/discussions/learners/learner/LearnerCard.jsx
+++ b/src/discussions/learners/learner/LearnerCard.jsx
@@ -21,41 +21,43 @@ const LearnerCard = ({ learner }) => {
   })();
 
   return (
-    <Link
-      className="discussion-post p-0 text-decoration-none text-gray-900 border-bottom border-light-400"
-      to={linkUrl}
-    >
-      <div
-        className="d-flex flex-row flex-fill mw-100 py-3 px-4 border-primary-500"
-        style={username === learnerUsername ? {
-          borderRightWidth: '4px',
-          borderRightStyle: 'solid',
-        } : null}
+    <li>
+      <Link
+        className="discussion-post p-0 text-decoration-none text-gray-900 border-bottom border-light-400"
+        to={linkUrl}
       >
-        <LearnerAvatar username={username} />
-        <div className="d-flex flex-column flex-fill" style={{ minWidth: 0 }}>
-          <div className="d-flex flex-column justify-content-start mw-100 flex-fill">
-            <div className="d-flex align-items-center flex-fill">
-              <div
-                className="text-truncate font-weight-500 text-primary-500 font-style"
-              >
-                {username}
+        <div
+          className="d-flex flex-row flex-fill mw-100 py-3 px-4 border-primary-500"
+          style={username === learnerUsername ? {
+            borderRightWidth: '4px',
+            borderRightStyle: 'solid',
+          } : null}
+        >
+          <LearnerAvatar username={username} />
+          <div className="d-flex flex-column flex-fill" style={{ minWidth: 0 }}>
+            <div className="d-flex flex-column justify-content-start mw-100 flex-fill">
+              <div className="d-flex align-items-center flex-fill">
+                <div
+                  className="text-truncate font-weight-500 text-primary-500 font-style"
+                >
+                  {username}
+                </div>
               </div>
+              {threads !== null && (
+                <LearnerFooter
+                  inactiveFlags={inactiveFlags}
+                  activeFlags={activeFlags}
+                  threads={threads}
+                  responses={responses}
+                  replies={replies}
+                  username={username}
+                />
+              )}
             </div>
-            {threads !== null && (
-              <LearnerFooter
-                inactiveFlags={inactiveFlags}
-                activeFlags={activeFlags}
-                threads={threads}
-                responses={responses}
-                replies={replies}
-                username={username}
-              />
-            )}
           </div>
         </div>
-      </div>
-    </Link>
+      </Link>
+    </li>
   );
 };
 

--- a/src/discussions/posts/PostsView.jsx
+++ b/src/discussions/posts/PostsView.jsx
@@ -100,9 +100,9 @@ const PostsView = () => {
       )}
       <PostFilterBar />
       <div className="border-bottom border-light-400" />
-      <div className="list-group list-group-flush flex-fill" role="list" onKeyDown={e => handleKeyDown(e)}>
+      <ul className="list-group list-group-flush flex-fill" data-testid="list" onKeyDown={e => handleKeyDown(e)}>
         {postsListComponent}
-      </div>
+      </ul>
     </div>
   );
 };

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -57,100 +57,104 @@ const PostLink = ({
   );
 
   return (
-    <Link
-      className={
-          classNames('discussion-post p-0 text-decoration-none text-gray-900', {
-            'border-bottom border-light-400': showDivider,
-          })
-        }
-      to={`${pathname}${enableInContextSidebar ? search : ''}`}
-      aria-current={checkIsSelected ? 'page' : undefined}
-      role="option"
-      tabIndex={(checkIsSelected || idx === 0) ? 0 : -1}
-    >
-      <div
+    <li>
+      <Link
         className={
-            classNames(
-              'd-flex flex-row pt-2 pb-2 px-4 border-primary-500 position-relative',
-              { 'bg-light-300': isPostRead },
-              { 'post-summary-card-selected': id === selectedPostId },
-            )
+            classNames('discussion-post p-0 text-decoration-none text-gray-900', {
+              'border-bottom border-light-400': showDivider,
+            })
           }
+        to={`${pathname}${enableInContextSidebar ? search : ''}`}
+        aria-current={checkIsSelected ? 'page' : undefined}
+        role="option"
+        tabIndex={(checkIsSelected || idx === 0) ? 0 : -1}
       >
-        <PostAvatar
-          postType={type}
-          author={author}
-          authorLabel={authorLabel}
-          fromPostLink
-          read={isPostRead}
-        />
-        <div className="d-flex flex-column flex-fill" style={{ minWidth: 0 }}>
-          <div className="d-flex flex-column justify-content-start mw-100 flex-fill" style={{ marginBottom: '-3px' }}>
-            <div className="d-flex align-items-center pb-0 mb-0 flex-fill">
-              <div className="text-truncate mr-1">
-                <span className={classNames(
-                  'font-weight-500 text-primary-500 font-style align-bottom mr-1',
-                  { 'font-weight-bolder': !read },
-                )}
-                >
-                  {title}
-                </span>
-                <span className="text-gray-700 font-weight-normal  font-style align-bottom">
-                  {isPostPreviewAvailable(previewBody) ? previewBody : intl.formatMessage(messages.postWithoutPreview)}
-                </span>
-              </div>
-              {showAnsweredBadge && (
-                <Icon
-                  data-testid="check-icon"
-                  src={CheckCircle}
-                  className="text-success font-weight-500 ml-auto badge-padding"
-                >
-                  <span className="sr-only">{' '}answered</span>
-                </Icon>
-              )}
-              {canSeeReportedBadge && (
-                <Badge
-                  variant="danger"
-                  data-testid="reported-post"
-                  className={`font-weight-500 badge-padding ${showAnsweredBadge ? 'ml-2' : 'ml-auto'}`}
-                >
-                  {intl.formatMessage(messages.contentReported)}
-                  <span className="sr-only">{' '}reported</span>
-                </Badge>
-              )}
-              {pinned && (
-                <Icon
-                  src={PushPin}
-                  className={classNames('post-summary-icons-dimensions text-gray-700', {
-                    'ml-2': canSeeReportedBadge || showAnsweredBadge,
-                    'ml-auto': !canSeeReportedBadge && !showAnsweredBadge,
-                  })}
-                />
-              )}
-            </div>
-          </div>
-          <AuthorLabel
-            author={author || intl.formatMessage(messages.anonymous)}
+        <div
+          className={
+              classNames(
+                'd-flex flex-row pt-2 pb-2 px-4 border-primary-500 position-relative',
+                { 'bg-light-300': isPostRead },
+                { 'post-summary-card-selected': id === selectedPostId },
+              )
+            }
+        >
+          <PostAvatar
+            postType={type}
+            author={author}
             authorLabel={authorLabel}
-            labelColor={authorLabelColor && `text-${authorLabelColor}`}
+            fromPostLink
+            read={isPostRead}
           />
-          <PostSummaryFooter
-            postId={id}
-            voted={voted}
-            voteCount={voteCount}
-            following={following}
-            commentCount={commentCount}
-            unreadCommentCount={unreadCommentCount}
-            groupId={groupId}
-            groupName={groupName}
-            createdAt={createdAt}
-            preview
-            showNewCountLabel={isPostRead}
-          />
+          <div className="d-flex flex-column flex-fill" style={{ minWidth: 0 }}>
+            <div className="d-flex flex-column justify-content-start mw-100 flex-fill" style={{ marginBottom: '-3px' }}>
+              <div className="d-flex align-items-center pb-0 mb-0 flex-fill">
+                <div className="text-truncate mr-1">
+                  <span className={classNames(
+                    'font-weight-500 text-primary-500 font-style align-bottom mr-1',
+                    { 'font-weight-bolder': !read },
+                  )}
+                  >
+                    {title}
+                  </span>
+                  <span className="text-gray-700 font-weight-normal  font-style align-bottom">
+                    {isPostPreviewAvailable(previewBody)
+                      ? previewBody
+                      : intl.formatMessage(messages.postWithoutPreview)}
+                  </span>
+                </div>
+                {showAnsweredBadge && (
+                  <Icon
+                    data-testid="check-icon"
+                    src={CheckCircle}
+                    className="text-success font-weight-500 ml-auto badge-padding"
+                  >
+                    <span className="sr-only">{' '}answered</span>
+                  </Icon>
+                )}
+                {canSeeReportedBadge && (
+                  <Badge
+                    variant="danger"
+                    data-testid="reported-post"
+                    className={`font-weight-500 badge-padding ${showAnsweredBadge ? 'ml-2' : 'ml-auto'}`}
+                  >
+                    {intl.formatMessage(messages.contentReported)}
+                    <span className="sr-only">{' '}reported</span>
+                  </Badge>
+                )}
+                {pinned && (
+                  <Icon
+                    src={PushPin}
+                    className={classNames('post-summary-icons-dimensions text-gray-700', {
+                      'ml-2': canSeeReportedBadge || showAnsweredBadge,
+                      'ml-auto': !canSeeReportedBadge && !showAnsweredBadge,
+                    })}
+                  />
+                )}
+              </div>
+            </div>
+            <AuthorLabel
+              author={author || intl.formatMessage(messages.anonymous)}
+              authorLabel={authorLabel}
+              labelColor={authorLabelColor && `text-${authorLabelColor}`}
+            />
+            <PostSummaryFooter
+              postId={id}
+              voted={voted}
+              voteCount={voteCount}
+              following={following}
+              commentCount={commentCount}
+              unreadCommentCount={unreadCommentCount}
+              groupId={groupId}
+              groupName={groupName}
+              createdAt={createdAt}
+              preview
+              showNewCountLabel={isPostRead}
+            />
+          </div>
         </div>
-      </div>
-      {!showDivider && pinned && <div className="pt-1 bg-light-500 border-top border-light-700" />}
-    </Link>
+        {!showDivider && pinned && <div className="pt-1 bg-light-500 border-top border-light-700" />}
+      </Link>
+    </li>
   );
 };
 

--- a/src/discussions/topics/TopicsView.jsx
+++ b/src/discussions/topics/TopicsView.jsx
@@ -92,10 +92,10 @@ const TopicsView = () => {
           onClear={handleOnClear}
         />
       )}
-      <div className="list-group list-group-flush flex-fill" role="list" onKeyDown={e => handleKeyDown(e)}>
+      <ul className="list-group list-group-flush flex-fill" data-testid="list" onKeyDown={e => handleKeyDown(e)}>
         <CourseWideTopics />
         <LegacyCoursewareTopics />
-      </div>
+      </ul>
       {
         filteredTopicsCount === 0
         && loadingStatus === RequestStatus.SUCCESSFUL

--- a/src/discussions/topics/topic-group/TopicGroupBase.jsx
+++ b/src/discussions/topics/topic-group/TopicGroupBase.jsx
@@ -64,7 +64,7 @@ const TopicGroupBase = ({
   }
 
   return (
-    <div
+    <li
       className="discussion-topic-group d-flex flex-column text-primary-500"
       data-category-id={groupId}
       data-testid="topic-group"
@@ -82,7 +82,7 @@ const TopicGroupBase = ({
         )}
       </div>
       {renderFilteredTopics}
-    </div>
+    </li>
   );
 };
 


### PR DESCRIPTION

### Description

Replaced non-semantic `<div>` elements with proper semantic `<ul>` and `<li>` tags for the list structure on the **Topics** page. This improves the accessibility of the page by ensuring screen readers and assistive technologies can correctly interpret and navigate the list content.

This change aligns with [[WCAG 1.3.1 – Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html)](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html), which requires that structure and relationships in content be programmatically determined.

**Related GitHub Issue:** [[tutor-indigo/#146 – Accessibility compliance](https://github.com/overhangio/tutor-indigo/issues/146)](https://github.com/overhangio/tutor-indigo/issues/146)
**Taiga Ticket:** [[US 106 – Replace div with semantic ul/li on Topics page](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/106)](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/106)

---

#### How Has This Been Tested?

* Verified that the semantic structure is correctly rendered in the DOM.
* Used keyboard navigation and a screen reader to ensure list items are read and navigated as expected.
* Confirmed no visual or functional regressions were introduced.

---

#### Screenshots/sandbox (optional):

**Live Preview:** [[Topics Page – Demo Course](https://apps.sandbox.openedx.edly.io/discussions/course-v1:OpenedX+DemoX+DemoCourse/topics)](https://apps.sandbox.openedx.edly.io/discussions/course-v1:OpenedX+DemoX+DemoCourse/topics)

| Before                        | After                         |
| ----------------------------- | ----------------------------- |
| *Non-semantic div-based list* | *Proper ul/li list structure* |

---

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

---

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it.
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.

---

Let me know if you need help drafting a related changelog or internal documentation note.