### PR TITLE
TIA-41: Added * for required fields in labels

### DIFF
--- a/src/components/TinyMCEEditor.jsx
+++ b/src/components/TinyMCEEditor.jsx
@@ -152,6 +152,7 @@ const TinyMCEEditor = (props) => {
           relative_urls: false,
           default_link_target: '_blank',
           target_list: false,
+          placeholder: props.placeholder,
           images_upload_handler: uploadHandler,
           setup,
         }}

--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -409,6 +409,7 @@ const PostEditor = ({
             value={values.comment}
             onEditorChange={formikCompatibleHandler(handleChange, 'comment')}
             onBlur={formikCompatibleHandler(handleBlur, 'comment')}
+            placeholder={'Post content*'}
           />
           <PostHelpPanel />
           <FormikErrorFeedback name="comment" />

--- a/src/discussions/posts/post-editor/messages.js
+++ b/src/discussions/posts/post-editor/messages.js
@@ -55,7 +55,7 @@ const messages = defineMessages({
   },
   postTitle: {
     id: 'discussions.post.editor.title',
-    defaultMessage: 'Post title',
+    defaultMessage: 'Post title*',
   },
   titleDescription: {
     id: 'discussions.post.editor.titleDescription',


### PR DESCRIPTION
### Description

On **Discussion** page, while adding the post, Compulsory fields are missing the required alert sign (e.g. Asterisk). So, I've added Asterisk sign on post title and content area to prevent user from posting content without it. This will prevent the error message and save user time.

**Steps to Reproduce:**
Open [Sandbox URL](https://apps.sandbox.openedx.edly.io/discussions/course-v1:OpenedX+DemoX+DemoCourse/category/block-v1:OpenedX+DemoX+DemoCourse+type@sequential+block@4e1de5e13fc3422997fe246b40a43aa1)
1. Through keyboard tap on topics tab.
2. Select Enter 
3. Now press tab again it will focus on the modules.
4. Select Enter again
5. It will expand the module section
6. Now select Tab
7. It will move the focus to “Add a post” section"

Related to https://github.com/overhangio/tutor-indigo/issues/146

### How Has This Been Tested?
I set up Tutor locally with the Indigo Plugin enabled (which is enabled by default). I followed the above steps to reproduce the issue, inspected the HTML on the frontend, and identified where the adjustment was needed.

#### Sandbox (optional):
[Sandbox Link](https://apps.sandbox.openedx.edly.io/discussions/course-v1:OpenedX+DemoX+DemoCourse/posts)

**Following Taiga tickets has been addressed in this PR(Access required):**
1. https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/41

## Screenshots
**Before**
![image](https://github.com/user-attachments/assets/86794b84-f58e-4bea-95d7-3034c70bc77f)

#### Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [x] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.