### PR TITLE
fix: fixed camel case issue so profile image shows for all users

### DIFF
--- a/src/discussions/posts/data/selectors.js
+++ b/src/discussions/posts/data/selectors.js
@@ -1,4 +1,5 @@
 import { createSelector } from '@reduxjs/toolkit';
+import camelCase from 'lodash/camelCase';
 
 const selectThreads = state => state.threads.threadsById;
 
@@ -58,5 +59,5 @@ export const selectThreadFilters = () => state => state.threads.filters;
 export const selectThreadNextPage = () => state => state.threads.nextPage;
 
 export const selectAuthorAvatar = author => state => (
-  state.threads.avatars?.[author]?.profile.image
+  state.threads.avatars?.[camelCase(author)]?.profile.image
 );


### PR DESCRIPTION
Ticket: [INF-1961](https://2u-internal.atlassian.net/browse/INF-1961)

The profile image was not visible for some users because of the difference in the case of the author avatars and the author names. 
