### PR TITLE
fix: add replace prop to fallback route

### DIFF
--- a/src/discussions/discussions-home/DiscussionSidebar.jsx
+++ b/src/discussions/discussions-home/DiscussionSidebar.jsx
@@ -110,7 +110,7 @@ const DiscussionSidebar = ({ displaySidebar, postActionBarRef }) => {
           }
           <Route path={ROUTES.LEARNERS.PATH} element={<LearnersView />} />
           {configStatus === RequestStatus.SUCCESSFUL && (
-            <Route path={`${ROUTES.DISCUSSIONS.PATH}/*`} element={<Navigate to="posts" />} />
+            <Route path={`${ROUTES.DISCUSSIONS.PATH}/*`} element={<Navigate to="posts" replace />} />
           )}
         </Routes>
       </Suspense>


### PR DESCRIPTION
This PR fixes https://github.com/openedx/frontend-app-discussions/issues/703; this issue prevented users from going to the previous page when clicking the back button.

### Description

When the router ended at the fallback route, the browser history was contaminated with unnecessary logs; this merge request adds a `replace` prop in the `Navigate` component so this overrides the current route instead of creating a new one

#### How Has This Been Tested?

Following the **Steps to reproduce** from the issue #703

#### Screenshots/sandbox (optional):
|Before|After|
|-------|-----|
|[Screencast from 27-06-25 13:30:51.webm](https://github.com/user-attachments/assets/b99e0fa9-e219-43b0-b290-2b0e17e6d871)|[Screencast from 27-06-25 13:31:34.webm](https://github.com/user-attachments/assets/ce7e8a87-28a8-468c-ae73-893436532be3)|
