### PR TITLE
feat: added product tour to notify all learners

### DIFF
--- a/src/discussions/data/hooks.js
+++ b/src/discussions/data/hooks.js
@@ -252,7 +252,7 @@ export const useTourConfiguration = () => {
         enabled: tour && Boolean(tour.enabled && tour.showTour && !enableInContextSidebar),
         onDismiss: () => handleOnDismiss(tour.id),
         onEnd: () => handleOnEnd(tour.id),
-        checkpoints: tourCheckpoints(intl)[camelToConstant(tour.tourName)],
+        checkpoints: tourCheckpoints(intl)[tour.tourName],
       }
     ))
   ), [tours, enableInContextSidebar]);

--- a/src/discussions/data/hooks.js
+++ b/src/discussions/data/hooks.js
@@ -224,10 +224,6 @@ export const useUserPostingEnabled = () => {
   return (isPostingEnabled || isPrivileged);
 };
 
-function camelToConstant(string) {
-  return string.replace(/[A-Z]/g, (match) => `_${match}`).toUpperCase();
-}
-
 export const useTourConfiguration = () => {
   const intl = useIntl();
   const dispatch = useDispatch();

--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -43,6 +43,7 @@ import {
   selectNonCoursewareTopics as inContextNonCourseware,
 } from '../../in-context-topics/data/selectors';
 import { selectCoursewareTopics, selectNonCoursewareIds, selectNonCoursewareTopics } from '../../topics/data/selectors';
+import { updateUserDiscussionsTourByName } from '../../tours/data';
 import {
   discussionsPath, formikCompatibleHandler, isFormikFieldInvalid, useCommentsPagePath,
 } from '../../utils';
@@ -90,6 +91,21 @@ const PostEditor = ({
   const editReasonCodeValidation = canDisplayEditReason && {
     editReasonCode: Yup.string().required(intl.formatMessage(messages.editReasonCodeError)),
   };
+
+  const enableNotifyAllLearnersTour = useCallback((enabled) => {
+    const data = {
+      enabled,
+      tourName: 'notify_all_learners',
+    };
+    dispatch(updateUserDiscussionsTourByName(data));
+  }, []);
+
+  useEffect(() => {
+    enableNotifyAllLearnersTour(true);
+    return () => {
+      enableNotifyAllLearnersTour(false);
+    };
+  }, []);
 
   const canSelectCohort = useCallback((tId) => {
     // If the user isn't privileged, they can't edit the cohort.
@@ -427,6 +443,7 @@ const PostEditor = ({
             <Form.Group>
               <Form.Checkbox
                 name="notifyAllLearners"
+                id="notify-learners"
                 checked={values.notifyAllLearners}
                 onChange={handleChange}
                 onBlur={handleBlur}

--- a/src/discussions/tours/constants.js
+++ b/src/discussions/tours/constants.js
@@ -7,11 +7,11 @@ import messages from './messages';
  */
 export default function tourCheckpoints(intl) {
   return {
-    EXAMPLE_TOUR: [
+    notify_all_learners: [
       {
-        title: intl.formatMessage(messages.exampleTourTitle),
-        body: intl.formatMessage(messages.exampleTourBody),
-        target: '#example-tour-target',
+        title: intl.formatMessage(messages.notifyAllLearnersTourTitle),
+        body: intl.formatMessage(messages.notifyAllLearnersTourBody),
+        target: '#notify-learners',
         placement: 'bottom',
       },
     ],

--- a/src/discussions/tours/messages.js
+++ b/src/discussions/tours/messages.js
@@ -16,15 +16,15 @@ const messages = defineMessages({
     defaultMessage: 'Okay',
     description: 'Action to end current tour',
   },
-  exampleTourTitle: {
-    id: 'tour.example.title',
-    defaultMessage: 'Example Tour',
-    description: 'Title for example tour',
+  notifyAllLearnersTourTitle: {
+    id: 'tour.title.notifyAllLearners',
+    defaultMessage: 'Let your learners know.',
+    description: 'Title of the tour to notify all learners',
   },
-  exampleTourBody: {
-    id: 'tour.example.body',
-    defaultMessage: 'This is an example tour',
-    description: 'Body for example tour',
+  notifyAllLearnersTourBody: {
+    id: 'tour.body.notifyAllLearners',
+    defaultMessage: 'Check this box to notify all learners.',
+    description: 'Body of the tour to notify all learners',
   },
 });
 


### PR DESCRIPTION
[INF-1930](https://2u-internal.atlassian.net/browse/INF-1930)

### Description

This PR introduces a product tour for the newly added “Notify all learners” checkbox in both the Discussions MFE and the Discussion Sidebar.

The product tour is designed to highlight and explain the new checkbox feature.

**Eligibility:** The tour will only be shown to users with roles that have permission to view the checkbox.

**Dismissal:** Once the user acknowledges the tour, it will not appear again.

**Content:**

**Title**: "Let your learners know."

**Body**: "Check this box to notify all learners."

**Feature Flag:**
The tour is gated behind the same waffle flag "notifications.enable_post_notify_all_learners" that controls the checkbox. 


#### Screenshots/sandbox (optional):
<img width="1091" alt="Screenshot 2025-07-02 at 6 10 06 PM" src="https://github.com/user-attachments/assets/d30527c1-46cc-43d3-8f34-4423ea0797a0" />


#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.