### PR TITLE
fix: fixed disappering modal description while deleting

### DIFF
--- a/src/discussions/learners/LearnerPostsView.jsx
+++ b/src/discussions/learners/LearnerPostsView.jsx
@@ -157,11 +157,10 @@ const LearnerPostsView = () => {
       <Confirmation
         isOpen={isDeleting}
         title={intl.formatMessage(messages.deletePostsTitle)}
-        description={learnerLoadingStatus === RequestStatus.SUCCESSFUL
-          ? intl.formatMessage(messages.deletePostsDescription, {
-            count: bulkDeleteStats.threadCount + bulkDeleteStats.commentCount,
-            bulkType: isDeletingCourseOrOrg,
-          }) : ''}
+        description={intl.formatMessage(messages.deletePostsDescription, {
+          count: bulkDeleteStats.threadCount + bulkDeleteStats.commentCount,
+          bulkType: isDeletingCourseOrOrg,
+        })}
         boldDescription={intl.formatMessage(messages.deletePostsBoldDescription)}
         onClose={hideDeleteConfirmation}
         confirmAction={() => handleDeletePosts(isDeletingCourseOrOrg)}


### PR DESCRIPTION
Ticket: [INF-2029](https://2u-internal.atlassian.net/browse/INF-2029)

Fixed an issue with the description of the confirmation modal disappearing while the delete command is being executed and awaiting response from the backend.