### PR TITLE
feat: captcha only for learners

### DIFF
--- a/src/discussions/post-comments/comments/comment/CommentEditor.jsx
+++ b/src/discussions/post-comments/comments/comment/CommentEditor.jsx
@@ -19,6 +19,7 @@ import useDispatchWithState from '../../../../data/hooks';
 import DiscussionContext from '../../../common/context';
 import {
   selectCaptchaSettings,
+  selectIsUserLearner,
   selectModerationSettings,
   selectUserHasModerationPrivileges,
   selectUserIsGroupTa,
@@ -53,8 +54,9 @@ const CommentEditor = ({
   const [editorContent, setEditorContent] = useState();
   const { addDraftContent, getDraftContent, removeDraftContent } = useDraftContent();
   const captchaSettings = useSelector(selectCaptchaSettings);
+  const isUserLearner = useSelector(selectIsUserLearner);
 
-  const shouldRequireCaptcha = !id && captchaSettings.enabled;
+  const shouldRequireCaptcha = !id && captchaSettings.enabled && isUserLearner;
 
   const captchaValidation = {
     recaptchaToken: Yup.string().required(intl.formatMessage(messages.captchaVerificationLabel)),

--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -32,6 +32,7 @@ import {
   selectDivisionSettings,
   selectEnableInContext,
   selectIsNotifyAllLearnersEnabled,
+  selectIsUserLearner,
   selectModerationSettings,
   selectUserHasModerationPrivileges,
   selectUserIsGroupTa,
@@ -86,6 +87,7 @@ const PostEditor = ({
   const postEditorId = `post-editor-${editExisting ? postId : 'new'}`;
   const isNotifyAllLearnersEnabled = useSelector(selectIsNotifyAllLearnersEnabled);
   const captchaSettings = useSelector(selectCaptchaSettings);
+  const isUserLearner = useSelector(selectIsUserLearner);
 
   const canDisplayEditReason = (editExisting
     && (userHasModerationPrivileges || userIsGroupTa || userIsStaff)
@@ -96,7 +98,7 @@ const PostEditor = ({
     editReasonCode: Yup.string().required(intl.formatMessage(messages.editReasonCodeError)),
   };
 
-  const shouldRequireCaptcha = !postId && captchaSettings.enabled;
+  const shouldRequireCaptcha = !postId && captchaSettings.enabled && isUserLearner;
   const captchaValidation = {
     recaptchaToken: Yup.string().required(intl.formatMessage(messages.captchaVerificationLabel)),
   };


### PR DESCRIPTION
[INF-2043](https://2u-internal.atlassian.net/browse/INF-2043)

### Description

To prevent inconvenience for instructors, we should skip displaying the CAPTCHA for users who hold at least one course role (i.e., they are not just learners).

This PR includes the frontend changes required to support this behavior.

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.