### PR TITLE
fix: remove primary color from discussion post and messages text

### DIFF
--- a/src/discussions/post-comments/comments/comment/Comment.jsx
+++ b/src/discussions/post-comments/comments/comment/Comment.jsx
@@ -226,7 +226,7 @@ const Comment = ({
             />
           ) : (
             <HTMLLoader
-              cssClassName="comment-body html-loader text-break mt-14px font-style text-primary-500"
+              cssClassName="comment-body html-loader text-break mt-14px font-style"
               componentId="comment"
               htmlNode={renderedBody}
               testId={id}

--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -189,7 +189,7 @@ const Post = ({ handleAddResponseButton, openRestrictionDialogue }) => {
         title={title}
         postUsers={postUsers}
       />
-      <div className="d-flex mt-14px text-break font-style text-primary-500">
+      <div className="d-flex mt-14px text-break font-style">
         <HTMLLoader htmlNode={renderedBody} componentId="post" cssClassName="html-loader w-100" testId={postId} />
       </div>
       {(topicContext || topic) && (

--- a/src/discussions/posts/post/PostHeader.jsx
+++ b/src/discussions/posts/post/PostHeader.jsx
@@ -126,7 +126,7 @@ const PostHeader = ({
             </div>
           ) : (
             <h5
-              className="mb-0 font-style text-primary-500"
+              className="mb-0 font-style"
               style={{ lineHeight: '21px' }}
               aria-level="1"
               tabIndex="-1"


### PR DESCRIPTION
# Description

There is an issue where on discussion pages, comment text and username have `text-primary-500` class which is usually used for links, buttons, etc. instead of general text colors of the platform:

<img width="1722" height="936" alt="Screenshot 2025-07-25 at 19 43 18" src="https://github.com/user-attachments/assets/128bf387-0351-4fcc-b970-7e7c0fbb6865" />

It's looks strange and not consistent with other platform styles, and can also confuse users by making it appear as if they are clickable elements.

## Testing Instructions

1. Open course
2. Go to the Discussion tab
3. Choose some post and look on it's text
4. It will look like general text with corresponding color

After the fix:

<img width="1723" height="928" alt="Screenshot 2025-07-25 at 19 50 35" src="https://github.com/user-attachments/assets/190715d8-6ab5-4409-af1f-8ef741732bdf" />

### Changelog

- Removed wrong text color classes


