### PR TITLE
fix: matching styles for report/delete post buttons

### DIFF
--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -142,6 +142,7 @@ const Post = ({ handleAddResponseButton, openEmailConfirmation }) => {
         onClose={hideDeleteConfirmation}
         confirmAction={handleDeleteConfirmation}
         closeButtonVariant="tertiary"
+        confirmButtonVariant="danger"
         confirmButtonText={intl.formatMessage(messages.deleteConfirmationDelete)}
       />
       {!abuseFlagged && (
@@ -151,7 +152,7 @@ const Post = ({ handleAddResponseButton, openEmailConfirmation }) => {
           description={intl.formatMessage(messages.reportPostDescription)}
           onClose={hideReportConfirmation}
           confirmAction={handleReportConfirmation}
-          confirmButtonVariant="danger"
+          confirmButtonVariant="primary"
         />
       )}
       <HoverCard


### PR DESCRIPTION
When choose report or delete post, looks like confirm and delete buttons have mismatched style:
<img width="1728" height="906" alt="Screenshot 2025-07-28 at 12 18 06" src="https://github.com/user-attachments/assets/987b1de9-1895-4330-a0fd-94dd31658815" />
<img width="1728" height="908" alt="Screenshot 2025-07-28 at 12 18 44" src="https://github.com/user-attachments/assets/5867e00c-e16d-41ac-91b5-5bc25b109197" />

It seems that Confirm must have `primary` variant, and Delete `danger` variant, not vice versa, fixed variants:
<img width="575" height="233" alt="Screenshot 2025-07-28 at 12 22 16" src="https://github.com/user-attachments/assets/36638691-d31f-424a-9f32-49444ad9ff2d" />
<img width="715" height="352" alt="Screenshot 2025-07-28 at 12 22 38" src="https://github.com/user-attachments/assets/43f52e9b-a064-44a5-b174-70940b0af3ff" />



