### PR TITLE
feat: added tooltip for author role

### DIFF
--- a/src/discussions/common/AuthorLabel.jsx
+++ b/src/discussions/common/AuthorLabel.jsx
@@ -55,7 +55,11 @@ const AuthorLabel = ({
         placement={authorToolTip ? 'top' : 'right'}
         overlay={(
           <Tooltip id={authorToolTip ? `endorsed-by-${author}-tooltip` : `${authorLabel}-label-tooltip`}>
-            {authorToolTip ? author : authorLabel}
+            <>
+              {authorToolTip ? author : authorLabel}
+              <br />
+              {intl.formatMessage(messages.authorAdminDescription)}
+            </>
           </Tooltip>
         )}
         trigger={['hover', 'focus']}
@@ -97,18 +101,38 @@ const AuthorLabel = ({
     </>
   ), [author, authorLabelMessage, authorToolTip, icon, isRetiredUser, postCreatedAt, showTextPrimary, alert]);
 
+  const learnerPostsLink = (
+    <Link
+      data-testid="learner-posts-link"
+      id="learner-posts-link"
+      to={generatePath(Routes.LEARNERS.POSTS, { learnerUsername: author, courseId })}
+      className="text-decoration-none text-reset"
+      style={{ width: 'fit-content' }}
+    >
+      {!alert && authorName}
+    </Link>
+  );
+
   return showUserNameAsLink
     ? (
       <div className={`${className} flex-wrap`}>
-        <Link
-          data-testid="learner-posts-link"
-          id="learner-posts-link"
-          to={generatePath(Routes.LEARNERS.POSTS, { learnerUsername: author, courseId })}
-          className="text-decoration-none text-reset"
-          style={{ width: 'fit-content' }}
-        >
-          {!alert && authorName}
-        </Link>
+        {!authorLabel ? (
+          <OverlayTrigger
+            placement={authorToolTip ? 'top' : 'right'}
+            overlay={(
+              <Tooltip id={authorToolTip ? `endorsed-by-${author}-tooltip` : `${authorLabel}-label-tooltip`}>
+                <>
+                  {intl.formatMessage(messages.authorLearnerTitle)}
+                  <br />
+                  {intl.formatMessage(messages.authorLearnerDescription)}
+                </>
+              </Tooltip>
+        )}
+            trigger={['hover', 'focus']}
+          >
+            {learnerPostsLink}
+          </OverlayTrigger>
+        ) : learnerPostsLink }
         {labelContents}
       </div>
     )

--- a/src/discussions/messages.js
+++ b/src/discussions/messages.js
@@ -208,6 +208,21 @@ const messages = defineMessages({
     defaultMessage: 'Enroll',
     description: 'Action button on content page when the user has not logged into the MFE or not enrolled in the course.',
   },
+  authorAdminDescription: {
+    id: 'discussions.author.admin.description',
+    defaultMessage: 'Part of the team that runs this course',
+    description: 'tooltip for course admins',
+  },
+  authorLearnerTitle: {
+    id: 'discussions.author.learner.title',
+    defaultMessage: 'Learner',
+    description: 'tooltip for course learners title',
+  },
+  authorLearnerDescription: {
+    id: 'discussions.author.learner.description',
+    defaultMessage: 'Taking the course just like you',
+    description: 'tooltip for course learners',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
[INF-2069](https://2u-internal.atlassian.net/browse/INF-2069)

### Description

This PR adds a tooltip to display the logged-in user's course role (e.g., Instructor, Staff, Moderator) on posts, responses, and comments within the discussion forum.

The tooltip appears when hovering over the user’s name and provides additional context about their role in the course.


#### Screenshots/sandbox (optional):
<img width="345" height="114" alt="Screenshot 2025-07-30 at 12 05 30 PM" src="https://github.com/user-attachments/assets/f4a4de19-5e9a-4894-bb22-e53f3f11c185" />


<img width="404" height="99" alt="Screenshot 2025-07-30 at 12 05 22 PM" src="https://github.com/user-attachments/assets/3ebeaf35-ccef-4034-80fa-b157bdc0c4b8" />


<img width="369" height="97" alt="Screenshot 2025-07-30 at 12 05 05 PM" src="https://github.com/user-attachments/assets/1cdf4417-7c44-4c80-bc02-473b6eb556af" />



#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.