### PR TITLE
fix: fixed rate limit dialogue for edit contents

### DIFF
--- a/src/discussions/post-comments/comments/comment/CommentEditor.jsx
+++ b/src/discussions/post-comments/comments/comment/CommentEditor.jsx
@@ -94,10 +94,10 @@ const CommentEditor = ({
   };
 
   useEffect(() => {
-    if (contentCreationRateLimited) {
+    if (contentCreationRateLimited && !id) {
       openRestrictionDialogue();
     }
-  }, [contentCreationRateLimited]);
+  }, [contentCreationRateLimited, id]);
 
   const handleCaptchaChange = useCallback((token, setFieldValue) => {
     setFieldValue('recaptchaToken', token || '');

--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -177,10 +177,10 @@ const PostEditor = ({
   }, [postId, topicId, post?.author, category, editExisting, commentsPagePath, location]);
 
   useEffect(() => {
-    if (contentCreationRateLimited) {
+    if (contentCreationRateLimited && !postId) {
       openRestrictionDialogue();
     }
-  }, [contentCreationRateLimited]);
+  }, [contentCreationRateLimited, postId]);
 
   // null stands for no cohort restriction ("All learners" option)
   const selectedCohort = useCallback(


### PR DESCRIPTION
### Description

The rate limit dialogue should not be visible when editing content.

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.