### PR TITLE
feat: added tooltips for like and follow button

### DIFF
--- a/src/discussions/common/HoverCard.jsx
+++ b/src/discussions/common/HoverCard.jsx
@@ -14,6 +14,7 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import { ThreadType } from '../../data/constants';
 import { useHasLikePermission, useUserPostingEnabled } from '../data/hooks';
 import PostCommentsContext from '../post-comments/postCommentsContext';
+import messages from '../posts/post/messages';
 import ActionsDropdown from './ActionsDropdown';
 import DiscussionContext from './context';
 
@@ -82,32 +83,48 @@ const HoverCard = ({
         </div>
       )}
       <div className="hover-button">
-        <IconButton
-          src={voted ? ThumbUpFilled : ThumbUpOutline}
-          iconAs={Icon}
-          size="sm"
-          alt="Like"
-          disabled={!userHasLikePermission}
-          iconClassNames="like-icon-dimensions"
-          onClick={(e) => {
-            e.preventDefault();
-            onLike();
-          }}
-        />
+        <OverlayTrigger
+          overlay={(
+            <Tooltip>
+              {intl.formatMessage(voted ? messages.removeLike : messages.like)}
+            </Tooltip>
+        )}
+        >
+          <IconButton
+            src={voted ? ThumbUpFilled : ThumbUpOutline}
+            iconAs={Icon}
+            size="sm"
+            alt="Like"
+            disabled={!userHasLikePermission}
+            iconClassNames="like-icon-dimensions"
+            onClick={(e) => {
+              e.preventDefault();
+              onLike();
+            }}
+          />
+        </OverlayTrigger>
       </div>
       {following !== undefined && (
         <div className="hover-button">
-          <IconButton
-            src={following ? StarFilled : StarOutline}
-            iconAs={Icon}
-            size="sm"
-            alt="Follow"
-            iconClassNames="follow-icon-dimensions"
-            onClick={(e) => {
-              e.preventDefault();
-              onFollow();
-            }}
-          />
+          <OverlayTrigger
+            overlay={(
+              <Tooltip>
+                {intl.formatMessage(following ? messages.unFollow : messages.follow)}
+              </Tooltip>
+          )}
+          >
+            <IconButton
+              src={following ? StarFilled : StarOutline}
+              iconAs={Icon}
+              size="sm"
+              alt="Follow"
+              iconClassNames="follow-icon-dimensions"
+              onClick={(e) => {
+                e.preventDefault();
+                onFollow();
+              }}
+            />
+          </OverlayTrigger>
         </div>
       )}
       <div className="hover-button ml-auto">

--- a/src/discussions/common/HoverCard.test.jsx
+++ b/src/discussions/common/HoverCard.test.jsx
@@ -1,5 +1,5 @@
 import {
-  render, screen, waitFor, within,
+  fireEvent, render, screen, waitFor, within,
 } from '@testing-library/react';
 import MockAdapter from 'axios-mock-adapter';
 import { IntlProvider } from 'react-intl';
@@ -137,5 +137,28 @@ describe('HoverCard', () => {
     expect(within(hoverCard).getByRole('button', { name: /Endorse/i })).toBeInTheDocument();
     expect(within(hoverCard).queryByRole('button', { name: /like/i })).toBeInTheDocument();
     expect(within(hoverCard).queryByRole('button', { name: /actions menu/i })).toBeInTheDocument();
+  });
+
+  test('it should call onFollow when follow button is clicked', async () => {
+    await waitFor(() => renderComponent(discussionPostId));
+    const post = screen.getByTestId('post-thread-1');
+    const hoverCard = within(post).getByTestId('hover-card-thread-1');
+
+    const followBtn = within(hoverCard).getByRole('button', { name: /follow/i });
+    fireEvent.click(followBtn);
+
+    expect(followBtn).toBeEnabled();
+  });
+
+  test('it should call onLike when Like button is clicked', async () => {
+    await waitFor(() => renderComponent(discussionPostId));
+
+    const post = screen.getByTestId('post-thread-1');
+    const hoverCard = within(post).getByTestId('hover-card-thread-1');
+
+    const likeBtn = within(hoverCard).getByRole('button', { name: /like/i });
+    fireEvent.click(likeBtn);
+
+    expect(likeBtn).toBeEnabled();
   });
 });


### PR DESCRIPTION
[INF-2096](https://2u-internal.atlassian.net/browse/INF-2096)

### Description

This PR enhances the forum menu by adding tooltips to the Like and Follow buttons. The tooltips provide quick contextual information for users, improving usability and accessibility.

#### Screenshots/sandbox (optional):
<img width="284" height="134" alt="Screenshot 2025-08-12 at 4 33 43 PM" src="https://github.com/user-attachments/assets/a8863208-4a71-4a0f-8c2e-9f4bc492ee8a" />
<img width="290" height="148" alt="Screenshot 2025-08-12 at 4 33 38 PM" src="https://github.com/user-attachments/assets/ecc5731d-d27b-4cf0-b1a5-aca23a70db56" />
<img width="279" height="114" alt="Screenshot 2025-08-12 at 4 33 30 PM" src="https://github.com/user-attachments/assets/53344d35-6c24-4768-b84c-397a43322aee" />
<img width="285" height="133" alt="Screenshot 2025-08-12 at 4 33 25 PM" src="https://github.com/user-attachments/assets/ee437ed5-98cc-46df-a3df-55662723fe2c" />


#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.