### PR TITLE
fix: space gap between modals buttons and text color fixes

### DIFF
--- a/src/discussions/common/HoverCard.jsx
+++ b/src/discussions/common/HoverCard.jsx
@@ -75,7 +75,7 @@ const HoverCard = ({
                 const actionFunction = actionHandlers[endorseIcons.action];
                 actionFunction();
               }}
-              className={['endorse', 'unendorse'].includes(endorseIcons.id) ? 'text-dark-500' : 'text-success-500'}
+              className={['endorse', 'unendorse'].includes(endorseIcons.id) ? 'text-primary' : 'text-primary'}
               size="sm"
               alt="Endorse"
             />

--- a/src/discussions/post-comments/comments/comment/Comment.jsx
+++ b/src/discussions/post-comments/comments/comment/Comment.jsx
@@ -225,7 +225,7 @@ const Comment = ({
             />
           ) : (
             <HTMLLoader
-              cssClassName="comment-body html-loader text-break mt-14px font-style text-primary-500"
+              cssClassName="comment-body html-loader text-break mt-14px font-style text-gray-700"
               componentId="comment"
               htmlNode={renderedBody}
               testId={id}

--- a/src/discussions/post-comments/comments/comment/Reply.jsx
+++ b/src/discussions/post-comments/comments/comment/Reply.jsx
@@ -168,7 +168,7 @@ const Reply = ({ responseId }) => {
             <HTMLLoader
               componentId="reply"
               htmlNode={renderedBody}
-              cssClassName="html-loader text-break font-style text-primary-500"
+              cssClassName="html-loader text-break font-style text-gray-700"
               testId={id}
             />
           )}

--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -188,7 +188,7 @@ const Post = ({ handleAddResponseButton, openRestrictionDialogue }) => {
         postType={postType}
         title={title}
       />
-      <div className="d-flex mt-14px text-break font-style text-primary-500">
+      <div className="d-flex mt-14px text-break font-style text-gray-700">
         <HTMLLoader htmlNode={renderedBody} componentId="post" cssClassName="html-loader w-100" testId={postId} />
       </div>
       {(topicContext || topic) && (

--- a/src/index.scss
+++ b/src/index.scss
@@ -376,6 +376,10 @@ header {
 
 #paragon-portal-root .pgn__modal-layer {
   z-index: 5000 !important;
+
+  .pgn__modal-footer .pgn__action-row {
+    gap: 8px;
+  }
 }
 
 #iconbutton-tooltip-top {


### PR DESCRIPTION
There is an issue, if open discussions in the sidebar when in course. And then choose dropdown with the actions, then report or delete, in the appeared modal focus on buttons will be overlaped on each other:

<img width="1725" height="907" alt="Screenshot 2025-07-28 at 12 03 48" src="https://github.com/user-attachments/assets/24440ea0-ed6f-4518-a861-6a3877619fe6" />

This fix add some gap, to prevent this style issue:
<img width="1728" height="907" alt="Screenshot 2025-07-28 at 12 08 05" src="https://github.com/user-attachments/assets/ff20a4b5-b4ec-441d-a005-40c6e3ddf7cb" />

Additionally fixed styles for the reply/post sections, currently it has wrong classes for the text-color:
<img width="403" height="272" alt="Screenshot 2025-08-04 at 11 34 26" src="https://github.com/user-attachments/assets/721d1bcc-477a-469e-b7e5-8fd4bcb230ff" />

After fix:
<img width="378" height="262" alt="Screenshot 2025-08-04 at 11 43 08" src="https://github.com/user-attachments/assets/0067b7be-4304-40d8-92f9-d4b62813b67a" />

