### PR TITLE
fix: prevent generatePath error when author is invalid in AuthorLabel

### DIFF
--- a/src/discussions/common/AuthorLabel.jsx
+++ b/src/discussions/common/AuthorLabel.jsx
@@ -101,17 +101,22 @@ const AuthorLabel = ({
     </>
   ), [author, authorLabelMessage, authorToolTip, icon, isRetiredUser, postCreatedAt, showTextPrimary, alert]);
 
-  const learnerPostsLink = (
-    <Link
-      data-testid="learner-posts-link"
-      id="learner-posts-link"
-      to={generatePath(Routes.LEARNERS.POSTS, { learnerUsername: author, courseId })}
-      className="text-decoration-none text-reset"
-      style={{ width: 'fit-content' }}
-    >
-      {!alert && authorName}
-    </Link>
-  );
+  const learnerPostsLink = useMemo(() => {
+    if (!showUserNameAsLink) {
+      return null;
+    }
+    return (
+      <Link
+        data-testid="learner-posts-link"
+        id="learner-posts-link"
+        to={generatePath(Routes.LEARNERS.POSTS, { learnerUsername: author, courseId })}
+        className="text-decoration-none text-reset"
+        style={{ width: 'fit-content' }}
+      >
+        {!alert && authorName}
+      </Link>
+    );
+  }, [showUserNameAsLink, author, courseId, alert, authorName]);
 
   return showUserNameAsLink
     ? (


### PR DESCRIPTION
## Description
This PR fixes the 'Missing :learnerUsername param' error that occurs in the AuthorLabel component when the author field is null, undefined, or the 'anonymous' string.

## Problem
The `learnerPostsLink` component was being created unconditionally during render, which meant `generatePath()` was called with an invalid `author` value even when the link wasn't going to be displayed. This caused the router to throw an error.

## Solution
Wrapped the `learnerPostsLink` creation in a `useMemo` hook that:
- Checks `showUserNameAsLink` before calling `generatePath()`
- Returns `null` if the link shouldn't be shown
- Only creates the Link component when all validation conditions are met

## Testing
- Linting passes
- The fix ensures `generatePath` is only called when `author` is a valid username and all other conditions (`linkToProfile`, not anonymous, not in-context sidebar) are met