### PR TITLE
fix: Update frontend-platform to version 8.3.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
         "@edx/frontend-component-footer": "^14.6.0",
         "@edx/frontend-component-header": "^6.2.0",
-        "@edx/frontend-platform": "^8.3.3",
+        "@edx/frontend-platform": "^8.3.8",
         "@edx/openedx-atlas": "^0.6.0",
         "@openedx/paragon": "^23.4.5",
         "@reduxjs/toolkit": "1.9.7",
@@ -2385,16 +2385,16 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-8.3.3.tgz",
-      "integrity": "sha512-xj8uKY4k9DgScYWsBFx8B1cngZ6HTPHvmd7W+NpBB4Kqw9yCT1OUii4p8/8khF68vb7hcTQuu13A9hM0lkE5bw==",
+      "version": "8.3.8",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-8.3.8.tgz",
+      "integrity": "sha512-wr3HKzDcYGNuHcM7HuZ/mqBdqnY/A7eYa3JDVZEsceyjy0PJyVKHWFu3yneGpD1zufguQCvS0q53C8gJbVzIgw==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",
         "@formatjs/intl-relativetimeformat": "10.0.1",
-        "axios": "1.8.4",
-        "axios-cache-interceptor": "1.6.2",
+        "axios": "1.9.0",
+        "axios-cache-interceptor": "1.8.0",
         "form-urlencoded": "4.1.4",
         "glob": "7.2.3",
         "history": "4.10.1",
@@ -2426,9 +2426,9 @@
       }
     },
     "node_modules/@edx/frontend-platform/node_modules/axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -2437,9 +2437,9 @@
       }
     },
     "node_modules/@edx/frontend-platform/node_modules/axios-cache-interceptor": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios-cache-interceptor/-/axios-cache-interceptor-1.6.2.tgz",
-      "integrity": "sha512-YLbAODIHZZIcD4b3WYFVQOa5W2TY/WnJ6sBHqAg6Z+hx+RVj8/OcjQyRopO6awn7/kOkGL5X9TP16AucnlJ/lw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/axios-cache-interceptor/-/axios-cache-interceptor-1.8.0.tgz",
+      "integrity": "sha512-cTNnPGJyQkxnWp0EWvE3NRvgURU5cWw/Qx3dIhXyHSM4Ip0c7EEe0I3an0Jwa549m1CAOg57ibj27YRNLmQCcg==",
       "license": "MIT",
       "dependencies": {
         "cache-parser": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/frontend-component-footer": "^14.6.0",
     "@edx/frontend-component-header": "^6.2.0",
-    "@edx/frontend-platform": "^8.3.3",
+    "@edx/frontend-platform": "^8.3.8",
     "@edx/openedx-atlas": "^0.6.0",
     "@openedx/paragon": "^23.4.5",
     "@reduxjs/toolkit": "1.9.7",


### PR DESCRIPTION
### Description

Update frontend-platform to version 8.3.8 in the `teak-design-tokens` branch to incorporate the following two fixes that affect theming:

[8.3.7]: Simplify the logic for Paragon `fallbackThemeUrl` to always rely on `window.location?.origin`;
[8.3.8]: Allow the creation of URLs with only `brandOverride` definition.

[8.3.7]: https://github.com/openedx/frontend-platform/releases/tag/v8.3.7
[8.3.8]: https://github.com/openedx/frontend-platform/releases/tag/v8.3.8

#### How Has This Been Tested?

Theme the MFE with the following config:

```
MFE_CONFIG["PARAGON_THEME_URLS"] = {
    "core": {
        "urls": {
            "brandOverride": "http://local.edly.io:3000/core.min.css"
        },
    },
    "variants": {
        "light": {
            "urls": {
                "brandOverride": "http://local.edly.io:3000/light.min.css"
            },
        },
    },
}
```

Prior to the fix, it doesn’t load the CSS.

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.

FYI: @brian-smith-tcril