### PR TITLE
feat: added cohort update option in post edit

### DIFF
--- a/src/discussions/posts/data/api.js
+++ b/src/discussions/posts/data/api.js
@@ -97,7 +97,7 @@ export const postThread = async (
   content,
   {
     following,
-    cohort,
+    groupId,
     anonymous,
     anonymousToPeers,
     notifyAllLearners,
@@ -114,7 +114,7 @@ export const postThread = async (
     following,
     anonymous,
     anonymousToPeers,
-    groupId: cohort,
+    groupId,
     enableInContextSidebar,
     notifyAllLearners,
     captchaToken: recaptchaToken,
@@ -154,6 +154,7 @@ export const updateThread = async (threadId, {
   pinned,
   editReasonCode,
   closeReasonCode,
+  groupId,
 } = {}) => {
   const url = `${getThreadsApiUrl()}${threadId}/`;
   const patchData = snakeCaseObject({
@@ -169,6 +170,7 @@ export const updateThread = async (threadId, {
     pinned,
     editReasonCode,
     closeReasonCode,
+    groupId,
   });
   const { data } = await getAuthenticatedHttpClient()
     .patch(url, patchData, { headers: { 'Content-Type': 'application/merge-patch+json' } });

--- a/src/discussions/posts/data/thunks.js
+++ b/src/discussions/posts/data/thunks.js
@@ -208,7 +208,7 @@ export function createNewThread({
   following,
   anonymous,
   anonymousToPeers,
-  cohort,
+  groupId,
   enableInContextSidebar,
   notifyAllLearners,
   recaptchaToken,
@@ -224,12 +224,12 @@ export function createNewThread({
         following,
         anonymous,
         anonymousToPeers,
-        cohort,
+        groupId,
         notifyAllLearners,
         recaptchaToken,
       }));
       const data = await postThread(courseId, topicId, type, title, content, {
-        cohort,
+        groupId,
         following,
         anonymous,
         anonymousToPeers,
@@ -252,7 +252,8 @@ export function createNewThread({
 }
 
 export function updateExistingThread(threadId, {
-  flagged, voted, read, topicId, type, title, content, following, closed, pinned, closeReasonCode, editReasonCode,
+  flagged, voted, read, topicId, type, title, content, following,
+  closed, pinned, closeReasonCode, editReasonCode, groupId,
 }) {
   return async (dispatch) => {
     try {
@@ -270,6 +271,7 @@ export function updateExistingThread(threadId, {
         pinned,
         editReasonCode,
         closeReasonCode,
+        groupId,
       }));
       const data = await updateThread(threadId, {
         flagged,
@@ -284,6 +286,7 @@ export function updateExistingThread(threadId, {
         pinned,
         editReasonCode,
         closeReasonCode,
+        groupId,
       });
       dispatch(updateThreadSuccess(camelCaseObject(data)));
     } catch (error) {

--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -140,7 +140,7 @@ const PostEditor = ({
     notifyAllLearners: false,
     anonymous: allowAnonymous ? false : undefined,
     anonymousToPeers: allowAnonymousToPeers ? false : undefined,
-    cohort: post?.cohort || 'default',
+    cohort: post?.groupId || 'default',
     editReasonCode: post?.lastEdit?.reasonCode || (
       userIsStaff && canDisplayEditReason ? 'violates-guidelines' : undefined
     ),
@@ -175,6 +175,8 @@ const PostEditor = ({
 
   const submitForm = useCallback(async (values, { resetForm }) => {
     let recaptchaToken;
+    const groupId = canSelectCohort(values.topic) ? selectedCohort(values.cohort) : undefined;
+
     if (shouldRequireCaptcha && executeRecaptcha) {
       try {
         recaptchaToken = await executeRecaptcha('submit_post');
@@ -196,10 +198,9 @@ const PostEditor = ({
         title: values.title,
         content: values.comment,
         editReasonCode: values.editReasonCode || undefined,
+        groupId,
       }));
     } else {
-      const cohort = canSelectCohort(values.topic) ? selectedCohort(values.cohort) : undefined;
-
       await dispatchSubmit(createNewThread({
         courseId,
         topicId: values.topic,
@@ -209,7 +210,7 @@ const PostEditor = ({
         following: values.follow,
         anonymous: allowAnonymous ? values.anonymous : undefined,
         anonymousToPeers: allowAnonymousToPeers ? values.anonymousToPeers : undefined,
-        cohort,
+        groupId,
         enableInContextSidebar,
         notifyAllLearners: values.notifyAllLearners,
         ...(shouldRequireCaptcha && recaptchaToken ? { recaptchaToken } : {}),


### PR DESCRIPTION
This issue was addressed in [this](https://github.com/openedx/frontend-app-discussions/issues/826) discussion.

### Issue Description
In a course forum organized by cohorts, a moderator can create posts specific to each cohort. However, they should also have the ability to edit the cohort selection when modifying a post. The problem arises when the post is submitted after changing the cohort in edit mode—the changes do not take effect.

### Steps to Reproduce
1. Use the Instructor Dashboard to divide a course by cohorts.
2. In Studio, navigate to Page & Resources > Discussions > edX (new) and select "Divide discussions by cohorts."
3. Use a Discussion Admin or Moderator account to create a post specific to one cohort.
4. Attempt to change the cohort by editing the post.

### Resolution
- The current backend and frontend API implementations do not allow editing the cohort while the cohort dropdown is visible.
- A frontend implementation has been added to support the API for sending the cohort parameter. 

### Note
However, backend implementation is also required for this to be fully functional.