### PR TITLE
fix: cohort name difference in filter and post view

### DIFF
--- a/src/components/FilterBar.jsx
+++ b/src/components/FilterBar.jsx
@@ -175,7 +175,7 @@ const FilterBar = ({
                       <ActionItem
                         key={toString(cohort.id)}
                         id={toString(cohort.id)}
-                        label={capitalize(cohort.name)}
+                        label={cohort.name}
                         value={toString(cohort.id)}
                         selected={selectedFilters.cohort}
                       />

--- a/src/discussions/posts/PostsView.test.jsx
+++ b/src/discussions/posts/PostsView.test.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { fireEvent, render, screen } from '@testing-library/react';
 import MockAdapter from 'axios-mock-adapter';
 import { act } from 'react-dom/test-utils';
@@ -232,7 +230,7 @@ describe('PostsView', () => {
 
     test('test that the cohorts filter works', async () => {
       await act(async () => {
-        fireEvent.click(screen.getByLabelText('Cohort 1'));
+        fireEvent.click(screen.getByLabelText('cohort 1'));
       });
 
       dropDownButton = screen.getByRole('button', {
@@ -280,7 +278,7 @@ describe('PostsView', () => {
         queryParam: { group_id: undefined },
       },
       {
-        label: 'Cohort 1',
+        label: 'cohort 1',
         queryParam: { group_id: 'cohort-1' },
       },
     ])(

--- a/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
+++ b/src/discussions/posts/post-filter-bar/PostFilterBar.jsx
@@ -165,7 +165,7 @@ const PostFilterBar = () => {
                 <ActionItem
                   key={cohort.id}
                   id={toString(cohort.id)}
-                  label={capitalize(cohort.name)}
+                  label={cohort.name}
                   value={toString(cohort.id)}
                   selected={currentFilters.cohort}
                 />


### PR DESCRIPTION
This resolved the issue mentioned in [this](https://github.com/openedx/frontend-app-discussions/issues/827) discussion.

- Cohort name is different in the post filter and the post view

### After the cohort name is the same in the filter and post view
<img width="496" height="518" alt="Screenshot 2025-12-16 at 6 08 50 PM" src="https://github.com/user-attachments/assets/abebe46a-fccc-4d45-9f68-b6f074c9f5e8" />
<img width="476" height="565" alt="Screenshot 2025-12-16 at 6 09 54 PM" src="https://github.com/user-attachments/assets/a9ce917c-f621-45d4-b3ad-31587e6bbe33" />
