### PR TITLE
fix: inconsistent loading of discussion thread response (#38)

### DIFF
--- a/src/discussions/post-comments/comments/CommentsView.jsx
+++ b/src/discussions/post-comments/comments/CommentsView.jsx
@@ -64,59 +64,61 @@ const CommentsView = ({ threadType, openRestrictionDialogue }) => {
         />
       ))}
     </div>
-  ), [hasMorePages, isLoading, handleLoadMoreResponses]);
+  ), []);
 
   return (
-    ((hasMorePages && isLoading) || !isLoading) && (
     <>
-      {endorsedCommentsIds.length > 0 && (
+      {(!isLoading || hasMorePages) && (
       <>
-        {handleDefinition(messages.endorsedResponseCount, endorsedCommentsIds.length)}
-        {handleComments(endorsedCommentsIds)}
+        {endorsedCommentsIds.length > 0 && (
+        <>
+          {handleDefinition(messages.endorsedResponseCount, endorsedCommentsIds.length)}
+          {handleComments(endorsedCommentsIds)}
+        </>
+        )}
+        {handleDefinition(messages.responseCount, unEndorsedCommentsIds.length)}
+        {unEndorsedCommentsIds.length > 0 && handleComments(unEndorsedCommentsIds)}
+        {hasMorePages && !isLoading && (!!unEndorsedCommentsIds.length || !!endorsedCommentsIds.length) && (
+        <Button
+          onClick={handleLoadMoreResponses}
+          variant="link"
+          block="true"
+          className="px-4 mt-3 border-0 line-height-24 py-0 mb-2 font-style font-weight-500"
+          data-testid="load-more-comments"
+        >
+          {intl.formatMessage(messages.loadMoreResponses)}
+        </Button>
+        )}
+        {(isUserPrivilegedInPostingRestriction && (!!unEndorsedCommentsIds.length || !!endorsedCommentsIds.length)
+           && !isClosed && !isUserBanned) && (
+           <div className="mx-4">
+             {!addingResponse && (
+             <Button
+               variant="plain"
+               block="true"
+               className="card mb-4 px-0 border-0 py-10px mt-2 font-style font-weight-500
+                      line-height-24 text-primary-500 bg-white"
+               onClick={handleAddResponse}
+               data-testid="add-response"
+             >
+               {intl.formatMessage(messages.addResponse)}
+             </Button>
+             )}
+             <ResponseEditor
+               addWrappingDiv
+               addingResponse={addingResponse}
+               handleCloseEditor={handleCloseResponseEditor}
+             />
+           </div>
+        )}
       </>
-      )}
-      {handleDefinition(messages.responseCount, unEndorsedCommentsIds.length)}
-      {unEndorsedCommentsIds.length > 0 && handleComments(unEndorsedCommentsIds)}
-      {hasMorePages && !isLoading && (!!unEndorsedCommentsIds.length || !!endorsedCommentsIds.length) && (
-      <Button
-        onClick={handleLoadMoreResponses}
-        variant="link"
-        block="true"
-        className="px-4 mt-3 border-0 line-height-24 py-0 mb-2 font-style font-weight-500"
-        data-testid="load-more-comments"
-      >
-        {intl.formatMessage(messages.loadMoreResponses)}
-      </Button>
       )}
       {isLoading && (
       <div className="mb-2 mt-3 d-flex justify-content-center">
         <Spinner animation="border" variant="primary" className="spinner-dimensions" />
       </div>
       )}
-      {(isUserPrivilegedInPostingRestriction && (!!unEndorsedCommentsIds.length || !!endorsedCommentsIds.length)
-         && !isClosed) && (
-         <div className="mx-4">
-           {!addingResponse && (
-           <Button
-             variant="plain"
-             block="true"
-             className="card mb-4 px-0 border-0 py-10px mt-2 font-style font-weight-500
-                    line-height-24 text-primary-500 bg-white"
-             onClick={handleAddResponse}
-             data-testid="add-response"
-           >
-             {intl.formatMessage(messages.addResponse)}
-           </Button>
-           )}
-           <ResponseEditor
-             addWrappingDiv
-             addingResponse={addingResponse}
-             handleCloseEditor={handleCloseResponseEditor}
-           />
-         </div>
-      )}
     </>
-    )
   );
 };
 

--- a/src/discussions/post-comments/comments/comment/Comment.jsx
+++ b/src/discussions/post-comments/comments/comment/Comment.jsx
@@ -76,7 +76,7 @@ const Comment = ({
         reverseOrder: sortedOrder,
       }));
     }
-  }, [id, sortedOrder]);
+  }, [id, sortedOrder, showDeleted, shouldIncludeMuted, hasChildren, showFullThread, dispatch]);
 
   const endorseIcons = useMemo(() => (
     actions.find(({ action }) => action === EndorsementStatus.ENDORSED)

--- a/src/discussions/post-comments/data/hooks.js
+++ b/src/discussions/post-comments/data/hooks.js
@@ -45,10 +45,26 @@ export function usePost(postId) {
 export function usePostComments(threadType) {
   const { enableInContextSidebar, postId } = useContext(DiscussionContext);
   const [isLoading, dispatch] = useDispatchWithState();
-  const comments = useSelector(selectThreadComments(postId));
+  const commentsSelector = useMemo(
+    () => selectThreadComments(postId, learnerUsername),
+    [postId, learnerUsername],
+  );
+  const comments = useSelector(commentsSelector);
   const reverseOrder = useSelector(selectCommentSortOrder);
   const hasMorePages = useSelector(selectThreadHasMorePages(postId));
   const currentPage = useSelector(selectThreadCurrentPage(postId));
+  const showDeleted = useShowDeletedContent();
+
+  // Check if the post author is muted by the current user
+  const thread = useSelector(selectThread(postId));
+  const personalMutedUsers = useSelector(state => state.learners.mutedUsers.personal);
+  const courseWideMutedUsers = useSelector(state => state.learners.mutedUsers.course);
+  const isAuthorMuted = thread?.author
+    ? (personalMutedUsers.includes(thread.author) || courseWideMutedUsers.includes(thread.author))
+    : false;
+
+  // Include muted content if explicitly requested from context or if author is muted
+  const shouldIncludeMuted = includeMutedFromContext || isAuthorMuted;
 
   const endorsedCommentsIds = useMemo(() => (
     [...filterPosts(comments, 'endorsed')].map(comment => comment.id)
@@ -94,15 +110,12 @@ export function usePostComments(threadType) {
 }
 
 export function useCommentsCount(postId) {
-  const discussions = useSelector(selectThreadComments(postId, EndorsementStatus.DISCUSSION));
-  const endorsedQuestions = useSelector(selectThreadComments(postId, EndorsementStatus.ENDORSED));
-  const unendorsedQuestions = useSelector(selectThreadComments(postId, EndorsementStatus.UNENDORSED));
-
-  const commentsLength = useMemo(() => (
-    [...discussions, ...endorsedQuestions, ...unendorsedQuestions].length
-  ), [discussions, endorsedQuestions, unendorsedQuestions]);
-
-  return commentsLength;
+  const { learnerUsername } = useContext(DiscussionContext);
+  const commentsSelector = useMemo(
+    () => selectThreadComments(postId, learnerUsername),
+    [postId, learnerUsername],
+  );
+  return useSelector(commentsSelector).length;
 }
 
 export const useDraftContent = () => {

--- a/src/discussions/post-comments/data/slices.js
+++ b/src/discussions/post-comments/data/slices.js
@@ -51,6 +51,7 @@ const commentsSlice = createSlice({
         };
       } else {
         newState.commentsInThreads = {
+          ...newState.commentsInThreads,
           [threadId]: [
             ...new Set([
               ...(newState.commentsInThreads[threadId] || []),

--- a/src/discussions/post-comments/data/thunks.js
+++ b/src/discussions/post-comments/data/thunks.js
@@ -41,6 +41,8 @@ function normaliseComments(data) {
   const commentsInComments = {};
   const commentsById = {};
   const ids = [];
+  const seenInComments = {};
+  const seenInThreads = {};
   results.forEach(
     comment => {
       const { parentId, threadId, id } = comment;
@@ -48,15 +50,19 @@ function normaliseComments(data) {
       if (parentId) {
         if (!commentsInComments[parentId]) {
           commentsInComments[parentId] = [];
+          seenInComments[parentId] = new Set();
         }
-        if (!commentsInComments[parentId].includes(id)) {
+        if (!seenInComments[parentId].has(id)) {
+          seenInComments[parentId].add(id);
           commentsInComments[parentId].push(id);
         }
       } else {
         if (!commentsInThreads[threadId]) {
           commentsInThreads[threadId] = [];
+          seenInThreads[threadId] = new Set();
         }
-        if (!commentsInThreads[threadId].includes(id)) {
+        if (!seenInThreads[threadId].has(id)) {
+          seenInThreads[threadId].add(id);
           commentsInThreads[threadId].push(id);
         }
       }
@@ -72,6 +78,8 @@ function normaliseComments(data) {
   };
 }
 
+const pendingThreadFetches = new Set();
+
 export function fetchThreadComments(
   threadId,
   {
@@ -82,7 +90,12 @@ export function fetchThreadComments(
     signal,
   } = {},
 ) {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
+    const requestKey = `${threadId}-p${page}-r${reverseOrder}-d${showDeleted}-m${includeMuted}`;
+    if (pendingThreadFetches.has(requestKey)) {
+      return;
+    }
+    pendingThreadFetches.add(requestKey);
     try {
       dispatch(fetchCommentsRequest());
       const data = await getThreadComments(threadId, {
@@ -100,12 +113,28 @@ export function fetchThreadComments(
         dispatch(fetchCommentsFailed());
       }
       logError(error);
+    } finally {
+      pendingThreadFetches.delete(requestKey);
     }
   };
 }
 
-export function fetchCommentResponses(commentId, { page = 1, reverseOrder = true } = {}) {
-  return async (dispatch) => {
+/**
+ * Tracks in-flight fetchCommentResponses calls by commentId.
+ * Prevents duplicate parallel requests for the same comment's responses
+ * when multiple re-renders or sort-order changes fire simultaneously.
+ */
+const pendingResponseFetches = new Set();
+
+export function fetchCommentResponses(commentId, {
+  page = 1, reverseOrder = true, showDeleted = false, includeMuted,
+} = {}) {
+  return async (dispatch, getState) => {
+    const requestKey = `${commentId}-p${page}-r${reverseOrder}-d${showDeleted}-m${includeMuted}`;
+    if (pendingResponseFetches.has(requestKey)) {
+      return;
+    }
+    pendingResponseFetches.add(requestKey);
     try {
       dispatch(fetchCommentResponsesRequest({ commentId }));
       const data = await getCommentResponses(commentId, { page, reverseOrder });
@@ -121,6 +150,8 @@ export function fetchCommentResponses(commentId, { page = 1, reverseOrder = true
         dispatch(fetchCommentResponsesFailed());
       }
       logError(error);
+    } finally {
+      pendingResponseFetches.delete(requestKey);
     }
   };
 }

--- a/src/discussions/posts/data/thunks.js
+++ b/src/discussions/posts/data/thunks.js
@@ -66,9 +66,11 @@ export function normaliseThreads(data, topicIds = null) {
   const threadsById = {};
   let avatars = {};
   const ids = [];
+  const seenInTopics = {};
   if (topicIds) {
     topicIds.forEach(topicId => {
       threadsInTopic[topicId] = [];
+      seenInTopics[topicId] = new Set();
     });
   }
   threads.forEach(
@@ -77,8 +79,10 @@ export function normaliseThreads(data, topicIds = null) {
       ids.push(id);
       if (!threadsInTopic[topicId]) {
         threadsInTopic[topicId] = [];
+        seenInTopics[topicId] = new Set();
       }
-      if (!threadsInTopic[topicId].includes(id)) {
+      if (!seenInTopics[topicId].has(id)) {
+        seenInTopics[topicId].add(id);
         threadsInTopic[topicId].push(id);
       }
       threadsById[id] = thread;
@@ -89,6 +93,8 @@ export function normaliseThreads(data, topicIds = null) {
     ids, threadsById, threadsInTopic, avatars, ...normalized,
   };
 }
+
+const pendingThreadsFetches = new Set();
 
 /**
  * Fetches the threads for the course specified va the threadIds.
@@ -141,7 +147,18 @@ export function fetchThreads(courseId, {
   if (filters.cohort) {
     options.cohort = filters.cohort;
   }
-  return async (dispatch) => {
+  if (filters.status === PostsStatusFilter.ACTIVE) {
+    options.isDeleted = false;
+  }
+  if (filters.status === PostsStatusFilter.DELETED) {
+    options.isDeleted = true;
+  }
+  return async (dispatch, getState) => {
+    const requestKey = `${courseId}|${page}|${options.orderBy}|${options.author}|${options.following}|${options.view}|${options.flagged}|${options.threadType}|${options.textSearch}|${options.cohort}|${options.isDeleted}|${options.includeMuted}|${options.countFlagged}|${(options.topicIds || []).join(',')}`;
+    if (pendingThreadsFetches.has(requestKey)) {
+      return;
+    }
+    pendingThreadsFetches.add(requestKey);
     try {
       dispatch(fetchThreadsRequest({ courseId }));
       const data = await getThreads(courseId, options);
@@ -156,6 +173,8 @@ export function fetchThreads(courseId, {
         dispatch(fetchThreadsFailed());
       }
       logError(error);
+    } finally {
+      pendingThreadsFetches.delete(requestKey);
     }
   };
 }


### PR DESCRIPTION
### Description

Fixes an issue where inline replies within discussion threads could load inconsistently, causing some replies to appear or disappear between page refreshes.

### Root Cause

Response comments were not being retrieved using backend-level pagination. Combined with frontend request race conditions and stale state handling, this could result in inconsistent loading of inline replies, especially in threads with many responses.

As a result, users could see different combinations of replies on successive page refreshes, even though the underlying discussion data was unchanged.

### Changes
#### Frontend (frontend-app-discussions)
- Added request cancellation using AbortController to prevent stale requests from overwriting newer data.
- Cleared stale child-comment state when reloading response comments.


### Ticket
[LP-529](https://2u-internal.atlassian.net/browse/LP-529)